### PR TITLE
[DOC] explanation about others Linux distributions installation 

### DIFF
--- a/docs/guide/simulator.md
+++ b/docs/guide/simulator.md
@@ -12,6 +12,7 @@ You will need a specific build per platform:
 
 Extract this compressed file. It will create a folder containing an executable. Double click that executable to launch the simulator.
 
+[Note]: The official version to linux is the ubuntu release, but this version work on most debian & arch linux distributions, it's a binary.
 
 #### Extra Mac Steps
 


### PR DESCRIPTION
Why I write it on the simulator docs?
 - 2 month ago I wanted to install the donkey car on my machine, but I use Manjaro (arch) distribution Linux and when I saw the only Ubuntu(Debian) option, I decided don't try install it by doc download link, i search by the source code and try build it on my arch Linux, but it spent so much time, so I tried download it to verify what's the simulator extension, and it was a binary! Because the docs said that release is built to Ubuntu(Debian) I thought it was a .deb file, but it isn't, its was a binary file! if I knew it was a binary file I already tried run it on my machine before, and it doesn't was written on docs.