### PR TITLE
Change the Throttle back to right analog stick on PS3 controller

### DIFF
--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -199,7 +199,7 @@ class JoystickController(object):
     def __init__(self, poll_delay=0.0,
                  max_throttle=1.0,
                  steering_axis='x',
-                 throttle_axis='rz',
+                 throttle_axis='ry',
                  steering_scale=1.0,
                  throttle_scale=-1.0,
                  dev_fn='/dev/input/js0',


### PR DESCRIPTION
I used `jstest` to check the axes number for the vertical movement of the right analog stick on PS3 controller. Seems the button mapping has changed in Raspbian Stretch.

Reference: https://retropie.org.uk/forum/topic/17400/changed-button-numbers-on-ps3-controller-on-stretch-4-4-image