### PR TITLE
Wait 0.1s after initializing the PWM controller.

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -19,6 +19,7 @@ class PCA9685:
         self.pwm = Adafruit_PCA9685.PCA9685()
         self.pwm.set_pwm_freq(frequency)
         self.channel = channel
+        time.sleep(0.1) # "Tamiya TBLE-02" makes a little leap otherwise
 
     def set_pulse(self, pulse):
         try:


### PR DESCRIPTION
The ESC "Tamiya TBLE-02" makes a little leap otherwise.
This leap does not happen at the first time after power on,
but on all subsequent starts of the Donkeycar driving program.