### PR TITLE
XBox controller has throttle reversed, so added throttle_dir config

### DIFF
--- a/docs/parts/controllers.md
+++ b/docs/parts/controllers.md
@@ -164,10 +164,10 @@ The XBox One controller requires that the bluetooth disable_ertm parameter be se
 - add the line: `options bluetooth disable_ertm=1`
 - reboot so that this takes affect.
 - after reboot you can verify that disable_ertm is set to true entering this
-  command oin a terminal: `cat /sys/module/bluetooth/parameters/disable_ertm`
+  command in a terminal: `cat /sys/module/bluetooth/parameters/disable_ertm`
 - the result should print 'Y'.  If not, make sure the above steps have been done correctly.
 
-Once that is done, you can pair your controller to your Raspberry Pi using the blue tooth tool.  Enter the following command into a bash shell prompt:  
+Once that is done, you can pair your controller to your Raspberry Pi using the bluetooth tool.  Enter the following command into a bash shell prompt:  
 
 ```bash
 sudo bluetoothctl

--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -1242,7 +1242,8 @@ def get_js_controller(cfg):
     else:
         raise("Unknown controller type: " + cfg.CONTROLLER_TYPE)
     
-    ctr = cont_class(throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
+    ctr = cont_class(throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
+                                throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
                                 steering_scale=cfg.JOYSTICK_STEERING_SCALE,
                                 auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
     

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -1,8 +1,8 @@
-""" 
-CAR CONFIG 
+"""
+CAR CONFIG
 
 This file is read by your car application's manage.py script to change the car
-performance. 
+performance.
 
 EXMAPLE
 -----------
@@ -110,6 +110,7 @@ CONTROLLER_TYPE='ps3'           #(ps3|ps4|xbox|nimbus|wiiu|F710)
 USE_NETWORKED_JS = False
 NETWORK_JS_SERVER_IP = "192.168.0.1"
 JOYSTICK_DEADZONE = 0.0         # when non zero, this is the smallest throttle before recording triggered.
+JOYSTICK_THROTTLE_DIR = -1.0    # use -1.0 to flip forward/backward, use 1.0 to use joystick's natural forward/backward
 
 #For the categorical model, this limits the upper bound of the learned throttle
 #it's very IMPORTANT that this value is matched from the training PC config.py and the robot.py


### PR DESCRIPTION
Fix for issue where the xbox controller throttle input is backwards; so pulling joystick down goes forward, pushing up goes backward.  

- added JOYSTICK_THROTTLE_DIR to config; maintained -1.0 default.
- updated controller.py get_js_controller() to pass throttle_dir using cfg.JOYSTICK_THROTTLE_DIR

So now the user can add JOYSTICK_THROTTLE_DIR = 1.0  to their myconfig.py in order to flip the throttle input on their on their controller.