### PR TITLE
CSI camera: Config option to flip the cam frame orientation

### DIFF
--- a/docs/guide/create_application.md
+++ b/docs/guide/create_application.md
@@ -87,7 +87,7 @@ If you plan to use a joystick, take a side track over to [here](/parts/controlle
 If you are on a raspberry pi and using the recommended pi camera, then no changes are needed to your __myconfg.py__. 
 
 > Jetson Nano: when using a Sony IMX219 based camera, and you are using the default car template, then you will want edit your __myconfg.py__ to have:
-`CAMERA_TYPE = "CSIC"`. 
+`CAMERA_TYPE = "CSIC"`. For flipping the image vertically set `CSIC_CAM_GSTREAMER_FLIP_PARM = 6`. This is helpful if you have to mount the camera in a rotated position.
 
 CVCAM is a camera type that has worked for USB cameras when OpenCV is setup. This requires additional setup for [OpenCV for Nano](/guide/robot_sbc/setup_jetson_nano/#step-4-install-opencv) or [OpenCV for Raspberry Pi](https://www.learnopencv.com/install-opencv-4-on-raspberry-pi/).
 

--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -139,11 +139,12 @@ class CSICamera(BaseCamera):
         'videoconvert ! '
         'video/x-raw, format=(string)BGR ! appsink'  % (capture_width,capture_height,framerate,flip_method,display_width,display_height))
     
-    def __init__(self, image_w=160, image_h=120, image_d=3, framerate=60):
+    def __init__(self, image_w=160, image_h=120, image_d=3, framerate=60, gstreamer_flip=0):
         self.w = image_w
         self.h = image_h
         self.running = True
         self.frame = None
+        self.flip_method = gstreamer_flip
 
     def init_camera(self):
         import cv2
@@ -152,8 +153,8 @@ class CSICamera(BaseCamera):
         self.camera = cv2.VideoCapture(\
             self.gstreamer_pipeline(\
                 display_width=self.w,\
-                    display_height=self.h,
-                    flip_method=0),
+                    display_height=self.h,\
+                    flip_method=self.flip_method),
                     cv2.CAP_GSTREAMER)
 
         self.poll_camera()

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -30,6 +30,8 @@ IMAGE_W = 160
 IMAGE_H = 120
 IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
 CAMERA_FRAMERATE = DRIVE_LOOP_HZ
+# For CSIC camera - If the camera is mounted in a rotated position, changing the below parameter will correct the output frame orientation
+CSIC_CAM_GSTREAMER_FLIP_PARM = 0 # (0 => none , 4 => Flip horizontally, 6 => Flip vertically)
 
 #9865, over rides only if needed, ie. TX2..
 PCA9685_I2C_ADDR = 0x40     #I2C address, use i2cdetect to validate this number

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -102,7 +102,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
             cam = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
         elif cfg.CAMERA_TYPE == "CSIC":
             from donkeycar.parts.camera import CSICamera
-            cam = CSICamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE)
+            cam = CSICamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE, gstreamer_flip=cfg.CSIC_CAM_GSTREAMER_FLIP_PARM)
         elif cfg.CAMERA_TYPE == "V4L":
             from donkeycar.parts.camera import V4LCamera
             cam = V4LCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE)


### PR DESCRIPTION
If the Jetson Nano's camera is mounted in a rotated position, provide an option
to flip the camera frame.

CSICamera nano part is implemented using gstreamer. Passing
the flip parameter to the gstreamer pipeline will do this.

Signed-off-by: Jithu Joseph <jithu83@gmail.com>