### PR TITLE
Update setup_jetson_nano.md docs with the correct unversioned directory names

### DIFF
--- a/docs/guide/robot_sbc/setup_jetson_nano.md
+++ b/docs/guide/robot_sbc/setup_jetson_nano.md
@@ -126,11 +126,11 @@ cmake -D CMAKE_BUILD_TYPE=RELEASE \
 	-D INSTALL_C_EXAMPLES=OFF \
 	-D OPENCV_ENABLE_NONFREE=ON \
 	# Contrib path
-	-D OPENCV_EXTRA_MODULES_PATH=~/projects/cv2/opencv_contrib-4.1.0/modules \
+	-D OPENCV_EXTRA_MODULES_PATH=~/projects/cv2/opencv-contrib/modules \
 	# Your virtual environment's Python executable
 	# You need to specify the result of echo $(which python)
 	-D PYTHON_EXECUTABLE=~/env/bin/python \
-	-D BUILD_EXAMPLES=ON ../opencv-4.1.0
+	-D BUILD_EXAMPLES=ON ../opencv
 ```
 
 The `cmake` command should show a summary of the configuration. Make sure that the `Interpreter` is set to the Python executable associated to *your* virtualenv.  Note: there are several paths in the CMake setup, make sure they match where you downloaded and saved the OpenCV source.


### PR DESCRIPTION
At lines 103-104 the mv command removes the version IDs from the directory names for opencv and opencv_contrib.  This change makes the cmake command starting on line 123 consistent with these directory names.