### PR TITLE
Support for TensorRTLinear model.

### DIFF
--- a/donkeycar/parts/keras.py
+++ b/donkeycar/parts/keras.py
@@ -325,8 +325,8 @@ def default_n_linear(num_outputs, input_shape=(120, 160, 3), roi_crop=(0, 0)):
     
     img_in = Input(shape=input_shape, name='img_in')
     x = img_in
-    x = Cropping2D(cropping=(roi_crop, (0,0)))(x) #trim pixels off top and bottom
-    #x = Lambda(lambda x: x/127.5 - 1.)(x) # normalize and re-center
+    # Remove Cropping2D here as TensorRT does not seem to support a strided_slice operation.
+    # TODO: Add this to the pre-processing step.
     x = BatchNormalization()(x)
     x = Convolution2D(24, (5,5), strides=(2,2), activation='relu', name="conv2d_1")(x)
     x = Dropout(drop)(x)

--- a/donkeycar/parts/tensorrt.py
+++ b/donkeycar/parts/tensorrt.py
@@ -1,0 +1,91 @@
+from collections import namedtuple
+from donkeycar.parts.keras import KerasPilot
+import json
+import numpy as np
+import pycuda.driver as cuda
+import pycuda.autoinit
+from pathlib import Path
+import tensorflow as tf
+import tensorrt as trt
+
+HostDeviceMemory = namedtuple('HostDeviceMemory', 'host_memory device_memory')
+
+class TensorRTLinear(KerasPilot):
+    '''
+    Uses TensorRT to do the inference.
+    '''
+    def __init__(self, cfg, *args, **kwargs):
+        super(TensorRTLinear, self).__init__(*args, **kwargs)
+        self.logger = trt.Logger(trt.Logger.WARNING)
+        self.cfg = cfg
+        self.engine = None
+        self.inputs = None
+        self.outputs = None
+        self.bindings = None
+        self.stream = None
+
+    def compile(self):
+        print('Nothing to compile')
+
+    def load(self, model_path):
+        uff_model = Path(model_path)
+        metadata_path = Path('%s/%s.metadata' % (uff_model.parent.as_posix(), uff_model.stem))
+        with open(metadata_path.as_posix(), 'r') as metadata, trt.Builder(self.logger) as builder, builder.create_network() as network, trt.UffParser() as parser:
+            metadata = json.loads(metadata.read())
+            # Configure inputs and outputs
+            print('Configuring I/O')
+            input_names = metadata['input_names']
+            output_names = metadata['output_names']
+            for name in input_names:
+                parser.register_input(name, (self.cfg.IMAGE_DEPTH, self.cfg.IMAGE_W, self.cfg.IMAGE_H))
+
+            for name in output_names:
+                parser.register_output(name)
+            # Parse network
+            print('Parsing TensorRT Network')
+            parser.parse(uff_model.as_posix(), network)
+            print('Building CUDA Engine')
+            self.engine = builder.build_cuda_engine(network)
+            # Allocate buffers
+            print('Allocating Buffers')
+            self.inputs, self.outputs, self.bindings, self.stream = TensorRTLinear.allocate_buffers(self.engine)
+            print('Ready')
+
+    def run(self, image):
+        image = image.reshape((1,) + image.shape)
+        with self.engine.create_execution_context() as context:
+            [steering, throttle] = TensorRTLinear.infer(context=context, bindings=self.bindings, inputs=self.inputs, outputs=self.outputs, stream=self.stream)
+            return steering[0], throttle[0]
+
+    @classmethod
+    def allocate_buffers(cls, engine):
+        inputs = []
+        outputs = []
+        bindings = []
+        stream = cuda.Stream()
+        for binding in engine:
+            size = trt.volume(engine.get_binding_shape(binding)) * engine.max_batch_size
+            dtype = trt.nptype(engine.get_binding_dtype(binding))
+            # Allocate host and device buffers
+            host_memory = cuda.pagelocked_empty(size, dtype)
+            device_memory = cuda.mem_alloc(host_memory.nbytes)
+            bindings.append(int(device_memory))
+            if engine.binding_is_input(binding):
+                inputs.append(HostDeviceMemory(host_memory, device_memory))
+            else:
+                outputs.append(HostDeviceMemory(host_memory, device_memory))
+
+        return inputs, outputs, bindings, stream
+
+    @classmethod
+    def infer(cls, context, bindings, inputs, outputs, stream, batch_size=1):
+        # Transfer input data to the GPU.
+        [cuda.memcpy_htod_async(inp.device_memory, inp.host_memory, stream) for inp in inputs]
+        # Run inference.
+        context.execute_async(batch_size=batch_size, bindings=bindings, stream_handle=stream.handle)
+        # Transfer predictions back from the GPU.
+        [cuda.memcpy_dtoh_async(out.host_memory, out.device_memory, stream) for out in outputs]
+        # Synchronize the stream
+        stream.synchronize()
+        # Return only the host outputs.
+        return [out.host_memory for out in outputs]

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -318,7 +318,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
         model_reload_cb = None
 
-        if '.h5' in model_path:
+        if '.h5' in model_path or '.uff' in model_path:
             #when we have a .h5 extension
             #load everything from the model file
             load_model(kl, model_path)

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -392,7 +392,7 @@ def get_model_by_type(model_type, cfg):
     create a Keras model and return it.
     '''
     from donkeycar.parts.keras import KerasRNN_LSTM, KerasBehavioral, KerasCategorical, KerasIMU, KerasLinear, Keras3D_CNN, KerasLocalizer, KerasLatent
- 
+    
     if model_type is None:
         model_type = cfg.DEFAULT_MODEL_TYPE
     print("\"get_model_by_type\" model Type is: {}".format(model_type))
@@ -408,6 +408,11 @@ def get_model_by_type(model_type, cfg):
         kl = KerasIMU(num_outputs=2, num_imu_inputs=6, input_shape=input_shape)        
     elif model_type == "linear":
         kl = KerasLinear(input_shape=input_shape, roi_crop=roi_crop)
+    elif model_type == "tensorrt_linear":
+        # Aggressively lazy load this. This module imports pycuda.autoinit which causes a lot of unexpected things
+        # to happen when using TF-GPU for training.
+        from donkeycar.parts.tensorrt import TensorRTLinear
+        kl = TensorRTLinear(cfg=cfg)
     elif model_type == "3d":
         kl = Keras3D_CNN(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, seq_length=cfg.SEQUENCE_LENGTH)
     elif model_type == "rnn":

--- a/scripts/freeze_model.py
+++ b/scripts/freeze_model.py
@@ -9,11 +9,16 @@ Note:
 import os
 
 from docopt import docopt
+import json
+from pathlib import Path
 import tensorflow as tf
 
 args = docopt(__doc__)
 in_model = os.path.expanduser(args['--model'])
 output = os.path.expanduser(args['--output'])
+output_path = Path(output)
+output_meta = Path('%s/%s.metadata' % (output_path.parent.as_posix(), output_path.stem))
+
 
 # Reset session
 tf.keras.backend.clear_session()
@@ -24,6 +29,10 @@ session = tf.keras.backend.get_session()
 
 input_names = [layer.op.name for layer in model.inputs]
 output_names = [layer.op.name for layer in model.outputs]
+
+# Store additional information in metadata, useful for infrencing
+meta = {'input_names': input_names, 'output_names': output_names}
+
 graph = session.graph
 
 # Freeze Graph
@@ -32,9 +41,11 @@ with graph.as_default():
     graph_frozen = tf.compat.v1.graph_util.remove_training_nodes(graph.as_graph_def())
     # Convert variables to constants
     graph_frozen = tf.compat.v1.graph_util.convert_variables_to_constants(session, graph_frozen, output_names)
-    with open(output, 'wb') as output_file:
+    with open(output, 'wb') as output_file, open(output_meta.as_posix(), 'w') as meta_file:
         output_file.write(graph_frozen.SerializeToString())
+        meta_file.write(json.dumps(meta))
 
     print ('Inputs = [%s], Outputs = [%s]' % (input_names, output_names))
+    print ('Writing metadata to %s' % output_meta.as_posix())
     print ('To convert use: \n   `convert-to-uff %s`' % (output))
 


### PR DESCRIPTION
* This PR adds support for Tensor RT.
* There are probably more minor improvements I can make to `tensorrt.py`, but I think this is a good starting point.
* `freeze_model.py` exports metadata about the model which helps us reconstruct the TensorRT model.
* Make sure `pycuda.autoinit` is never loaded during training, as it interferes with `tensorflow-gpu`.

Test: Tested this on my Jetson Nano.

----

* **Note** - This PR removes a `Cropping2D` layer from the linear model as its unsupported by the TensorRT runtime. If you are using Cropping2D use `opencv` to do the cropping as a pre-processing step.

----

### Using TensorRT

#### Setup TensorRT on your Ubuntu Machine
Follow the instructions [here](https://docs.nvidia.com/deeplearning/sdk/tensorrt-install-guide/index.html#installing-tar). Make sure you use the `tar` file instructions unless you have previously installed CUDA using `.deb` files.

#### Convert Model to `uff` on your Ubuntu Machine

* Use the script in `donkeycar/scripts/freeze_model.py` to freeze your linear model. This will convert the linear model to a protobuf file, and use the `convert-to-uff` utility to convert it to a `uff` file.

```bash
python freeze_model.py --model=../../Training/Race/models/Linear.h5 --output=../../Training/Race/models/Linear.pb
convert-to-uff ../../Training/Race/models/Linear.pb
# Produces Linear.uff
```
* Copy (`scp`) the `Linear.uff` file to the Jetson Nano.

#### Jetson Nano

* Setup some environment variables so `nvcc` is on `$PATH`. Add the following lines to your `~/.bashrc` file.

```bash
export CUDA_HOME=/usr/local/cuda
export PATH=$CUDA_HOME/bin:$PATH
export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
```

```bash
source ~/.bashrc
nvcc --version
```

You should see something like:
```bash
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2018 NVIDIA Corporation
Built on ...
Cuda compilation tools, release 10.0, Vxxxxx
```
* Switch to your `virtualenv` and install `pycuda`.

```
workon donkeycar
pip install pycuda
```

* After this you will also need to setup `PYTHONPATH` such that your `dist-packages` are included as part of your `virtualenv`. Add this to your `.bashrc`. This needs to be done because the python bindings to `tensorrt` are available in `dist-packages` and this folder is usually not visible to your virtualenv. To make them visible we add it to `PYTHONPATH`.

```bash
export PYTHONPATH=/usr/lib/python3.6/dist-packages:$PYTHONPATH
```

#### Running the model on the Jetson Nano.

* In `config.py` make sure you pick `tensorrt_linear` as the model type. 

```
DEFAULT_MODEL_TYPE = `tensorrt_linear`
```

* Finally you can do

```bash
# After you scp your `uff` model to the Nano
python manage.py drive --model=./models/Linear.uff
```