### PR TITLE
Allow PWM freq. of PCA9685 to be specified

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -160,6 +160,7 @@ class CalibrateCar(BaseCommand):
         parser.add_argument('--channel', help="The channel you'd like to calibrate [0-15]")
         parser.add_argument('--address', default='0x40', help="The i2c address you'd like to calibrate [default 0x40]")
         parser.add_argument('--bus', default=None, help="The i2c bus you'd like to calibrate [default autodetect]")
+        parser.add_argument('--pwmFreq', default=60, help="The frequency to use for the PWM")
         parsed_args = parser.parse_args(args)
         return parsed_args
 
@@ -176,8 +177,10 @@ class CalibrateCar(BaseCommand):
             busnum = int(args.bus)
         address = int(args.address, 16)
         print('init PCA9685 on channel %d address %s bus %s' %(channel, str(hex(address)), str(busnum)))
-        c = PCA9685(channel, address=address, busnum=busnum)
-        
+        freq = int(args.pwmFreq)
+        print("Using PWM freq: {}".format(freq))
+        c = PCA9685(channel, address=address, busnum=busnum, frequency=freq)
+        print()
         while True:
             try:
                 val = input("""Enter a PWM setting to test ('q' for quit) (0-1500): """)

--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -15,6 +15,10 @@ class PCA9685:
     This is used for most RC Cars
     '''
     def __init__(self, channel, address=0x40, frequency=60, busnum=None, init_delay=0.1):
+
+        self.default_freq = 60
+        self.pwm_scale = frequency / self.default_freq
+
         import Adafruit_PCA9685
         # Initialise the PCA9685 using the default address (0x40).
         if busnum is not None:
@@ -29,7 +33,7 @@ class PCA9685:
         time.sleep(init_delay) # "Tamiya TBLE-02" makes a little leap otherwise
 
     def set_pulse(self, pulse):
-        self.pwm.set_pwm(self.channel, 0, pulse) 
+        self.pwm.set_pwm(self.channel, 0, int(pulse * self.pwm_scale))
 
     def run(self, pulse):
         self.set_pulse(pulse)


### PR DESCRIPTION
Allow PWM freq. of PCA9685 to be specified (default value remains as before)
Also includes code to scale PWM values appropriately based on the freq. specified.