### PR TITLE
Enable throttle scaling while controlling manual throttle

### DIFF
--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -35,7 +35,7 @@ class Joystick(object):
             self.num_buttons = 0
             print("no support for fnctl module. joystick not enabled.")
             return False
-            
+
         if not os.path.exists(self.dev_fn):
             print(self.dev_fn, "is missing")
             return False
@@ -46,7 +46,7 @@ class Joystick(object):
         # Open the joystick device.
         print('Opening %s...' % self.dev_fn)
         self.jsdev = open(self.dev_fn, 'rb')
-    
+
         # Get the device name.
         buf = array.array('B', [0] * 64)
         ioctl(self.jsdev, 0x80006a13 + (0x10000 * len(buf)), buf) # JSIOCGNAME(len)
@@ -95,8 +95,8 @@ class Joystick(object):
     def poll(self):
         '''
         query the state of the joystick, returns button which was pressed, if any,
-        and axis which was moved, if any. button_state will be None, 1, or 0 if no changes, 
-        pressed, or released. axis_val will be a float from -1 to +1. button and axis will 
+        and axis which was moved, if any. button_state will be None, 1, or 0 if no changes,
+        pressed, or released. axis_val will be a float from -1 to +1. button and axis will
         be the string label determined by the axis map in init.
         '''
         button = None
@@ -135,10 +135,11 @@ class Joystick(object):
 
         return button, button_state, axis, axis_val
 
+
 class PyGameJoystick(object):
     def __init__(self, which_js=0):
         import pygame
-        
+
         # Initialize the joysticks
         pygame.joystick.init()
 
@@ -169,7 +170,7 @@ class PyGameJoystick(object):
                 self.axis_states[i] = val
                 logging.debug("axis: %s val: %f" % (axis, val))
 
-        
+
         for i in range( self.joystick.get_numbuttons() ):
             state = self.joystick.get_button( i )
             if self.button_states[i] != state:
@@ -192,6 +193,7 @@ class PyGameJoystick(object):
                 iBtn += 1
 
         return button, button_state, axis, axis_val
+
 
 class JoystickCreator(Joystick):
     '''
@@ -243,7 +245,6 @@ class PS3JoystickOld(Joystick):
             0x2e : 'dpad_d_pressure',
             0x2c : 'dpad_u_pressure',
         }
-        
 
         self.button_names = {
             0x120 : 'select',
@@ -256,7 +257,7 @@ class PS3JoystickOld(Joystick):
             0x129 : 'R2',
             0x121 : 'L3',
             0x122 : 'R3',
-	   
+
             0x12c : "triangle", 
             0x12d : "circle",
             0x12e : "cross",
@@ -267,6 +268,7 @@ class PS3JoystickOld(Joystick):
             0x127 : 'dpad_left',
             0x125 : 'dpad_right',
         }
+
 
 class PS3Joystick(Joystick):
     '''
@@ -322,17 +324,17 @@ class PS4Joystick(Joystick):
             0x01 : 'left_stick_vert',
             0x02 : 'right_stick_horz',
             0x05 : 'right_stick_vert',
-            
+
             0x03 : 'left_trigger_axis',
             0x04 : 'right_trigger_axis',
-            
+
             0x10 : 'dpad_leftright',
             0x11 : 'dpad_updown',
 
             0x19 : 'tilt_a',
             0x1a : 'tilt_b',
             0x1b : 'tilt_c',
-            
+
             0x06 : 'motion_a',
             0x07 : 'motion_b',
             0x08 : 'motion_c',
@@ -357,6 +359,7 @@ class PS4Joystick(Joystick):
             0x139 : 'options',
             0x13c : 'PS',
         }
+
 
 class PS3JoystickPC(Joystick):
     '''
@@ -394,7 +397,6 @@ class PS3JoystickPC(Joystick):
             0x2e : 'dpad_d_pressure',
             0x2c : 'dpad_u_pressure',
         }
-        
 
         self.button_names = {
             0x13a : 'select',
@@ -407,8 +409,8 @@ class PS3JoystickPC(Joystick):
             0x139 : 'R2',
             0x13d : 'L3',
             0x13e : 'R3',
-	   
-            0x133 : "triangle", 
+
+            0x133 : "triangle",
             0x131 : "circle",
             0x130 : "cross",
             0x134 : 'square',
@@ -418,6 +420,7 @@ class PS3JoystickPC(Joystick):
             0x222 : 'dpad_left',
             0x223 : 'dpad_right',
         }
+
 
 class PyGamePS3Joystick(PyGameJoystick):
     '''
@@ -439,7 +442,7 @@ class PyGamePS3Joystick(PyGameJoystick):
             0 : "cross",
             1 : "circle",
             2 : 'square',
-            3 : "triangle", 
+            3 : "triangle",
 
             6 : 'select',
             7 : 'start',
@@ -454,6 +457,7 @@ class PyGamePS3Joystick(PyGameJoystick):
             12 : 'dpad_down',
             13 : 'dpad_up',
         }
+
 
 class XboxOneJoystick(Joystick):
     '''
@@ -470,11 +474,10 @@ class XboxOneJoystick(Joystick):
       - after reboot you can vertify that disable_ertm is set to true entering this
         command oin a terminal: cat /sys/module/bluetooth/parameters/disable_ertm
       - the result should print 'Y'.  If not, make sure the above steps have been done corretly.
-    
+
     credit:
     https://github.com/Ezward/donkeypart_ps3_controller/blob/master/donkeypart_ps3_controller/part.py
     '''
-
     def __init__(self, *args, **kwargs):
         super(XboxOneJoystick, self).__init__(*args, **kwargs)
 
@@ -499,6 +502,7 @@ class XboxOneJoystick(Joystick):
             0x13b: 'options',
         }
 
+
 class LogitechJoystick(Joystick):
     '''
     An interface to a physical Logitech joystick available at /dev/input/js0
@@ -508,7 +512,6 @@ class LogitechJoystick(Joystick):
     credit:
     https://github.com/kevkruemp/donkeypart_logitech_controller/blob/master/donkeypart_logitech_controller/part.py
     '''
-
     def __init__(self, *args, **kwargs):
         super(LogitechJoystick, self).__init__(*args, **kwargs)
 
@@ -523,7 +526,6 @@ class LogitechJoystick(Joystick):
 
             0x10: 'dpad_leftright', # 1 is right, -1 is left
             0x11: 'dpad_up_down', # 1 is down, -1 is up
-
         }
 
         self.button_names = {
@@ -542,6 +544,7 @@ class LogitechJoystick(Joystick):
             0x13d: 'Left_stick_press',
             0x13e: 'right_stick_press',
         }
+
 
 class Nimbus(Joystick):
     #An interface to a physical joystick available at /dev/input/js0
@@ -570,10 +573,11 @@ class Nimbus(Joystick):
             0x10 : 'what',
         }
 
+
 class WiiU(Joystick):
     #An interface to a physical joystick available at /dev/input/js0
     #contains mappings may work for the WiiUPro joystick
-    #This was taken from 
+    #This was taken from
     #https://github.com/autorope/donkeypart_bluetooth_game_controller/blob/master/donkeypart_bluetooth_game_controller/wiiu_config.yml
     #and need testing!
     def __init__(self, *args, **kwargs):
@@ -595,7 +599,7 @@ class WiiU(Joystick):
             547: 'PAD_RIGHT',
             546: 'PAD_LEFT',
             544: 'PAD_UP',
-            548: 'PAD_DOWN,'
+            548: 'PAD_DOWN,',
         }
 
         self.axis_names = {
@@ -622,6 +626,7 @@ class JoystickController(object):
     ES_THROTTLE_POS_ONE = 2
     ES_THROTTLE_NEG_TWO = 3
 
+
     def __init__(self, poll_delay=0.0,
                  throttle_scale=1.0,
                  steering_scale=1.0,
@@ -634,6 +639,7 @@ class JoystickController(object):
         self.mode = 'user'
         self.poll_delay = poll_delay
         self.running = True
+        self.last_throttle_axis_val = 0
         self.throttle_scale = throttle_scale
         self.steering_scale = steering_scale
         self.throttle_dir = throttle_dir
@@ -647,11 +653,12 @@ class JoystickController(object):
         self.estop_state = self.ES_IDLE
         self.chaos_monkey_steering = None
         self.dead_zone = 0.0
-        
+
         self.button_down_trigger_map = {}
         self.button_up_trigger_map = {}
         self.axis_trigger_map = {}
         self.init_trigger_maps()
+
 
     def init_js(self):
         '''
@@ -660,6 +667,7 @@ class JoystickController(object):
         '''
         raise(Exception("Subclass needs to define init_js"))
 
+
     def init_trigger_maps(self):
         '''
         Creating mapping of buttons to functions.
@@ -667,11 +675,13 @@ class JoystickController(object):
         '''
         raise(Exception("init_trigger_maps"))
 
+
     def set_deadzone(self, val):
         '''
         sets the minimim throttle for recording
         '''
         self.dead_zone = val
+
 
     def print_controls(self):
         '''
@@ -694,11 +704,13 @@ class JoystickController(object):
         # print("On Axis Move:")
         # print(self.axis_trigger_map)
 
+
     def set_button_down_trigger(self, button, func):
         '''
         assign a string button descriptor to a given function call
         '''
         self.button_down_trigger_map[button] = func
+
 
     def set_button_up_trigger(self, button, func):
         '''
@@ -706,29 +718,34 @@ class JoystickController(object):
         '''
         self.button_up_trigger_map[button] = func
 
+
     def set_axis_trigger(self, axis, func):
         '''
         assign a string axis descriptor to a given function call
         '''
         self.axis_trigger_map[axis] = func
 
+
     def set_tub(self, tub):
         self.tub = tub
+
 
     def erase_last_N_records(self):
         if self.tub is not None:
             try:
                 self.tub.erase_last_n_records(self.num_records_to_erase)
-                print('erased last %d records.' % self.num_records_to_erase)                
+                print('erased last %d records.' % self.num_records_to_erase)
             except:
                 print('failed to erase')
-        
+
+
     def on_throttle_changes(self):
         '''
         turn on recording when non zero throttle in the user mode.
         '''
         if self.auto_record_on_throttle:
             self.recording = (abs(self.throttle) > self.dead_zone and self.mode == 'user')
+
 
     def emergency_stop(self):
         '''
@@ -740,6 +757,7 @@ class JoystickController(object):
         self.constant_throttle = False
         self.estop_state = self.ES_START
         self.throttle = 0.0
+
 
     def update(self):
         '''
@@ -773,15 +791,19 @@ class JoystickController(object):
 
             time.sleep(self.poll_delay)
 
+
     def set_steering(self, axis_val):
         self.angle = self.steering_scale * axis_val
         #print("angle", self.angle)
 
+
     def set_throttle(self, axis_val):
         #this value is often reversed, with positive value when pulling down
+        self.last_throttle_axis_val = axis_val
         self.throttle = (self.throttle_dir * axis_val * self.throttle_scale)
         #print("throttle", self.throttle)
         self.on_throttle_changes()
+
 
     def toggle_manual_recording(self):
         '''
@@ -796,6 +818,7 @@ class JoystickController(object):
 
         print('recording:', self.recording)
 
+
     def increase_max_throttle(self):
         '''
         increase throttle scale setting
@@ -804,8 +827,11 @@ class JoystickController(object):
         if self.constant_throttle:
             self.throttle = self.throttle_scale
             self.on_throttle_changes()
+        else:
+            self.throttle = (self.throttle_dir * self.last_throttle_axis_val * self.throttle_scale)
 
         print('throttle_scale:', self.throttle_scale)
+
 
     def decrease_max_throttle(self):
         '''
@@ -815,8 +841,11 @@ class JoystickController(object):
         if self.constant_throttle:
             self.throttle = self.throttle_scale
             self.on_throttle_changes()
+        else:
+            self.throttle = (self.throttle_dir * self.last_throttle_axis_val * self.throttle_scale)
 
         print('throttle_scale:', self.throttle_scale)
+
 
     def toggle_constant_throttle(self):
         '''
@@ -830,7 +859,8 @@ class JoystickController(object):
             self.constant_throttle = True
             self.throttle = self.throttle_scale
             self.on_throttle_changes()
-        print('constant_throttle:', self.constant_throttle)           
+        print('constant_throttle:', self.constant_throttle)
+
 
     def toggle_mode(self):
         '''
@@ -847,14 +877,18 @@ class JoystickController(object):
             self.mode = 'user'
         print('new mode:', self.mode)
 
+
     def chaos_monkey_on_left(self):
         self.chaos_monkey_steering = -0.2
+
 
     def chaos_monkey_on_right(self):
         self.chaos_monkey_steering = 0.2
 
+
     def chaos_monkey_off(self):
         self.chaos_monkey_steering = None
+
 
     def run_threaded(self, img_arr=None):
         self.img_arr = img_arr
@@ -885,9 +919,11 @@ class JoystickController(object):
 
         return self.angle, self.throttle, self.mode, self.recording
 
+
     def run(self, img_arr=None):
         raise Exception("We expect for this part to be run with the threaded=True argument.")
         return None, None, None, None
+
 
     def shutdown(self):
         #set flag to exit polling thread, then wait a sec for it to leave
@@ -902,6 +938,7 @@ class JoystickCreatorController(JoystickController):
     def __init__(self, *args, **kwargs):
         super(JoystickCreatorController, self).__init__(*args, **kwargs)
 
+
     def init_js(self):
         '''
         attempt to init joystick
@@ -915,6 +952,7 @@ class JoystickCreatorController(JoystickController):
             self.js = None
 
         return self.js is not None
+
 
     def init_trigger_maps(self):
         '''
@@ -973,7 +1011,6 @@ class PS3JoystickController(JoystickController):
         }
 
 
-
 class PS4JoystickController(JoystickController):
     '''
     A Controller object that maps inputs to actions
@@ -1016,15 +1053,16 @@ class PS4JoystickController(JoystickController):
             'right_stick_vert' : self.set_throttle,
         }
 
+
 class XboxOneJoystickController(JoystickController):
     '''
     A Controller object that maps inputs to actions
     credit:
     https://github.com/Ezward/donkeypart_ps3_controller/blob/master/donkeypart_ps3_controller/part.py
     '''
-
     def __init__(self, *args, **kwargs):
         super(XboxOneJoystickController, self).__init__(*args, **kwargs)
+
 
     def init_js(self):
         '''
@@ -1037,7 +1075,8 @@ class XboxOneJoystickController(JoystickController):
             print(self.dev_fn, "not found.")
             self.js = None
         return self.js is not None
-    
+
+
     def magnitude(self, reversed = False):
         def set_magnitude(axis_val):
             '''
@@ -1052,6 +1091,7 @@ class XboxOneJoystickController(JoystickController):
                 magnitude *= -1
             self.set_throttle(magnitude)
         return set_magnitude
+
 
     def init_trigger_maps(self):
         '''
@@ -1083,9 +1123,9 @@ class LogitechJoystickController(JoystickController):
     credit:
     https://github.com/kevkruemp/donkeypart_logitech_controller/blob/master/donkeypart_logitech_controller/part.py
     '''
-
     def __init__(self, *args, **kwargs):
         super(LogitechJoystickController, self).__init__(*args, **kwargs)
+
 
     def init_js(self):
         '''
@@ -1098,6 +1138,7 @@ class LogitechJoystickController(JoystickController):
             print(self.dev_fn, "not found.")
             self.js = None
         return self.js is not None
+
 
     def init_trigger_maps(self):
         '''
@@ -1130,6 +1171,7 @@ class NimbusController(JoystickController):
     def __init__(self, *args, **kwargs):
         super(NimbusController, self).__init__(*args, **kwargs)
 
+
     def init_js(self):
         #attempt to init joystick
         try:
@@ -1139,6 +1181,7 @@ class NimbusController(JoystickController):
             print(self.dev_fn, "not found.")
             self.js = None
         return self.js is not None
+
 
     def init_trigger_maps(self):
         #init set of mapping from buttons to function calls
@@ -1160,6 +1203,7 @@ class WiiUController(JoystickController):
     def __init__(self, *args, **kwargs):
         super(WiiUController, self).__init__(*args, **kwargs)
 
+
     def init_js(self):
         #attempt to init joystick
         try:
@@ -1169,6 +1213,7 @@ class WiiUController(JoystickController):
             print(self.dev_fn, "not found.")
             self.js = None
         return self.js is not None
+
 
     def init_trigger_maps(self):
         #init set of mapping from buttons to function calls
@@ -1197,7 +1242,8 @@ class JoyStickPub(object):
         context = zmq.Context()
         self.socket = context.socket(zmq.PUB)
         self.socket.bind("tcp://*:%d" % port)
-    
+
+
     def run(self):
         while True:
             button, button_state, axis, axis_val = self.js.poll()
@@ -1211,7 +1257,6 @@ class JoyStickPub(object):
                 message_data = (button, button_state, axis, axis_val)
                 self.socket.send_string( "%s %d %s %f" % message_data)
                 print("SENT", message_data)
-
 
 
 class JoyStickSub(object):
@@ -1230,9 +1275,11 @@ class JoyStickSub(object):
         self.axis_val = 0.0
         self.running = True
 
+
     def shutdown(self):
         self.running = False
         time.sleep(0.1)
+
 
     def update(self):
         while self.running:
@@ -1248,14 +1295,17 @@ class JoyStickSub(object):
             if self.axis == "0":
                 self.axis = None
 
+
     def run_threaded(self):
         pass
+
 
     def poll(self):
         ret = (self.button, self.button_state, self.axis, self.axis_val)
         self.button = None
         self.axis = None
         return ret
+
 
 def get_js_controller(cfg):
     cont_class = None
@@ -1273,12 +1323,12 @@ def get_js_controller(cfg):
         cont_class = LogitechJoystickController
     else:
         raise("Unknown controller type: " + cfg.CONTROLLER_TYPE)
-    
+
     ctr = cont_class(throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
                                 throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
                                 steering_scale=cfg.JOYSTICK_STEERING_SCALE,
                                 auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
-    
+
     ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)
     return ctr
 


### PR DESCRIPTION
Previously while driving, if the throttle scaling was changed, the throttle would need to be released, then applied again in order for the new scaling to be used.  This small modification allows scaling to be changed while driving so maximum speed can be slightly increased/decreased on the fly.

Removed some extra spaces in the code and made the layout of the spacing a bit more consistent.