### PR TITLE
Remove deprecated message argument from pytest.raises().

### DIFF
--- a/donkeycar/tests/test_vehicle.py
+++ b/donkeycar/tests/test_vehicle.py
@@ -2,17 +2,20 @@ import pytest
 import donkeycar as dk
 from donkeycar.parts.transform import Lambda
 
+
 def _get_sample_lambda():
     def f():
         return 1
     f.update = f
     return Lambda(f)
 
+
 @pytest.fixture()
 def vehicle():
     v = dk.Vehicle()
     v.add(_get_sample_lambda(), outputs=['test_out'])
     return v
+
 
 def test_create_vehicle():
     v = dk.Vehicle()
@@ -33,19 +36,22 @@ def test_vehicle_run(vehicle):
 def test_should_raise_assertion_on_non_list_inputs_for_add_part():
     vehicle = dk.Vehicle()
     inputs = 'any'
-    with pytest.raises(AssertionError, message="inputs is not a list: %r" % inputs):
+    with pytest.raises(AssertionError):
         vehicle.add(_get_sample_lambda(), inputs=inputs)
+        pytest.fail("inputs is not a list: %r" % inputs)
 
 
 def test_should_raise_assertion_on_non_list_outputs_for_add_part():
     vehicle = dk.Vehicle()
     outputs = 'any'
-    with pytest.raises(AssertionError, message="outputs is not a list: %r" % outputs):
+    with pytest.raises(AssertionError):
         vehicle.add(_get_sample_lambda(), outputs=outputs)
+        pytest.fail("outputs is not a list: %r" % outputs)
 
 
 def test_should_raise_assertion_on_non_boolean_threaded_for_add_part():
     vehicle = dk.Vehicle()
     threaded = 'non_boolean'
-    with pytest.raises(AssertionError, message="threaded is not a boolean: %r" % threaded):
+    with pytest.raises(AssertionError):
         vehicle.add(_get_sample_lambda(), threaded=threaded)
+        pytest.fail("threaded is not a boolean: %r" % threaded)


### PR DESCRIPTION
Newer versions of pytest require replacing the `message` parameter in pytest.raises() with a pytest.fail() at the end of the `with` statement:

    def test_should_raise_assertion_on_non_list_inputs_for_add_part():
        vehicle = dk.Vehicle()
        inputs = 'any'
>       with pytest.raises(AssertionError, message="inputs is not a list: %r" % inputs):
E       pytest.PytestDeprecationWarning: The 'message' parameter is deprecated.
E       (did you mean to use `match='some regex'` to check the exception message?)
E       Please see:
E         https://docs.pytest.org/en/4.6-maintenance/deprecations.html#message-parameter-of-pytest-raises
