### PR TITLE
Return vehicle from drive function with an option to not start it, so…

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -31,7 +31,7 @@ from donkeycar.parts.file_watcher import FileWatcher
 from donkeycar.parts.launch import AiLaunch
 from donkeycar.utils import *
 
-def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type='single', meta=[] ):
+def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type='single', meta=[], start_vehicle=True ):
     '''
     Construct a working robotic vehicle from many parts.
     Each part runs as a job in the Vehicle loop, calling either
@@ -556,10 +556,12 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
             ctr.set_button_down_trigger('cross', new_tub_dir)
         ctr.print_controls()
 
-    #run the vehicle for 20 seconds
-    V.start(rate_hz=cfg.DRIVE_LOOP_HZ, 
-            max_loop_count=cfg.MAX_LOOPS)
+    if start_vehicle:
+        #run the vehicle for 20 seconds
+        V.start(rate_hz=cfg.DRIVE_LOOP_HZ,
+                max_loop_count=cfg.MAX_LOOPS)
 
+    return V
 
 if __name__ == '__main__':
     args = docopt(__doc__)


### PR DESCRIPTION
… the caller can modify the vehicle before running.

Example code of how this can be used without having to modify manage.py. This way future repo changes to manage.py don't have to be merged with local changes. I've only been able to do minimal testing on this because my PS3 controller is dead.

```python
from manage import drive

vehicle = drive(cfg, start_v=False)

vehicle.add( ImageResize( (cfg.IMAGE_MODEL_W, cfg.IMAGE_MODEL_H) ),
                   inputs=['cam/image_array'],
                   outputs=['cam/resized_image'] )

for part in vehicle.parts:
    if isinstance(part["part"], KerasPilot):
        inputs = part["inputs"]
        if 'cam/image_array' in inputs:
            inputs[inputs.index('cam/image_array')] = 'cam/resized_image'
        else:
            inputs[inputs.index('cam/normalized/cropped')] = 'cam/resized_image'
        part["inputs"] = inputs

vehicle.start(rate_hz=cfg.DRIVE_LOOP_HZ, max_loop_count=cfg.MAX_LOOPS)
```
