### PR TITLE
Dev

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -226,7 +226,7 @@ class MakeMovieShell(BaseCommand):
         parser.add_argument('--model', default=None, help='the model to use to show control outputs')
         parser.add_argument('--type', default=None, help='the model type to load')
         parser.add_argument('--salient', action="store_true", help='should we overlay salient map showing activations')
-        parser.add_argument('--start', type=int, default=1, help='first frame to process')
+        parser.add_argument('--start', type=int, default=0, help='first frame to process')
         parser.add_argument('--end', type=int, default=-1, help='last frame to process')
         parser.add_argument('--scale', type=int, default=2, help='make image frame output larger by X mult')
         parsed_args = parser.parse_args(args)


### PR DESCRIPTION
## Fixing slowness of salient mask 
Fixing the slowness of the salient mask in `makemovie`. Improves performance by a factor > 100 (and even more when making longer videos with many frames). Seems that repeated calls to `compute_visualization_mask` create tensor flow graphs without disposing them. This seems to be a known issue. On my MacBook I get a frame rate of 45 fps w/ saliency vs 100 fps w/o saliency which seems reasonable.

### These are the changes:
* replacing the method `visualize_saliency` with the corresponding code from Keras-vis
* splitting that code into the loss and optimizer which are initialised only once in `init_salient`
* running the remainder in the function `compute_visualization_mask` which is runs on every frame

### Remark
Unfortunately the file was checked in w/ Ctrl+LF in git (I'm surprised this is possible), so the diff below is hard to read. Changes are essentially in (original) lines 186 - 193. I also changed the default `start` value for `make movie` to 0.


