### PR TITLE
Update Ip-Adress change to Hostname

### DIFF
--- a/docs/guide/calibrate.md
+++ b/docs/guide/calibrate.md
@@ -73,7 +73,7 @@ Now that you have your car roughly calibrated you can try driving it to
 verify that it drives as expected. Here's how to fine tune your car's calibration.
 
 1. Start your car by running `python manage.py drive`.
-2. Go to `<your_cars_ip_address>:8887` in a browser.
+2. Go to `<your_cars_hostname.local>:8887` in a browser.
 3. Press `j` until the cars steering is all the way right.
 4. Press `i` a couple times to get the car to go forward.
 5. Measure the diameter of the turn and record it on a spreadsheet.

--- a/donkeycar/templates/basic_web.py
+++ b/donkeycar/templates/basic_web.py
@@ -195,7 +195,7 @@ def drive(cfg, model_path=None, model_type=None):
     tub = th.new_tub_writer(inputs=inputs, types=types)
     V.add(tub, inputs=inputs, outputs=["tub/num_records"], run_condition='recording')
 
-    print("You can now go to <your pi ip address>:8887 to drive your car.")
+    print("You can now go to <your pis hostname.local>:8887 to drive your car.")
 
     #run the vehicle for 20 seconds
     V.start(rate_hz=cfg.DRIVE_LOOP_HZ, 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -539,7 +539,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
         V.add(pub, inputs=['jpg/bin'])
 
     if type(ctr) is LocalWebController:
-        print("You can now go to <your pi ip address>:8887 to drive your car.")
+        print("You can now go to <your pis hostname.local>:8887 to drive your car.")
     elif isinstance(ctr, JoystickController):
         print("You can now move your joystick to drive your car.")
         #tell the controller about the tub        


### PR DESCRIPTION
When you put in the Browser the ip-Adress with :8887 its not running.
You must put the hostname.local:8887
Test it with Ubuntu 18 and Firefox