### PR TITLE
check TensorFlow version before overriding keras session

### DIFF
--- a/donkeycar/parts/keras.py
+++ b/donkeycar/parts/keras.py
@@ -15,7 +15,7 @@ models to help direct the vehicles motion.
 import os
 import numpy as np
 
-from tensorflow import ConfigProto, Session
+import tensorflow as tf
 from tensorflow.python import keras
 from tensorflow.python.keras.layers import Input, Dense
 from tensorflow.python.keras.models import Model, Sequential
@@ -28,12 +28,16 @@ from tensorflow.python.keras.layers import Conv3D, MaxPooling3D, Cropping3D, Con
 
 import donkeycar as dk
 
-# Override keras session to work around a bug in TF 1.13.1
-# Remove after we upgrade to TF 1.14 / TF 2.x.
-config = ConfigProto()
-config.gpu_options.allow_growth = True
-session = Session(config=config)
-keras.backend.set_session(session)
+if tf.__version__ == '1.13.1':
+    from tensorflow import ConfigProto, Session
+
+    # Override keras session to work around a bug in TF 1.13.1
+    # Remove after we upgrade to TF 1.14 / TF 2.x.
+    config = ConfigProto()
+    config.gpu_options.allow_growth = True
+    session = Session(config=config)
+    keras.backend.set_session(session)
+
 
 class KerasPilot(object):
     '''


### PR DESCRIPTION
The fix for TensorFlow 1.3.1 introduced in https://github.com/autorope/donkeycar/commit/d1448d8e1cf5148a51853fe282978664db0deacb does not work for TensorFlow 1.4 and higher. Rather than having to remove these lines when trying out a new TensorFlow version, these lines are only executed if TensorFlow 1.3.1 is being used.