### PR TITLE
Added SHIFT function to controller to allow button combinations

### DIFF
--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -714,6 +714,11 @@ class JoystickController(object):
         # print("On Axis Move:")
         # print(self.axis_trigger_map)
 
+    def set_button_up_trigger(self, button, func):
+         set_button_trigger(self, button, func)
+
+    def set_button_down_trigger(self, button, func):
+         set_button_trigger(self, button, func)
 
     def set_button_trigger(self, button, func):
         '''

--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -632,7 +632,7 @@ class JoystickController(object):
                  steering_scale=1.0,
                  throttle_dir=-1.0,
                  dev_fn='/dev/input/js0',
-                 auto_record_on_throttle=True):
+                 auto_record_on_throttle=True,memobject=None):
 
         self.angle = 0.0
         self.throttle = 0.0
@@ -653,11 +653,13 @@ class JoystickController(object):
         self.estop_state = self.ES_IDLE
         self.chaos_monkey_steering = None
         self.dead_zone = 0.0
-
         self.button_down_trigger_map = {}
-        self.button_up_trigger_map = {}
         self.axis_trigger_map = {}
         self.init_trigger_maps()
+        self.shiftkey=""
+        self.mem=memobject
+        if self.mem is None : print("Warning : to get all features from the Controller, the mamage.py file should be modified using line : ctr = get_js_controller(cfg,memobject=V.mem)")
+
 
 
     def init_js(self):
@@ -689,34 +691,39 @@ class JoystickController(object):
         '''
         pt = PrettyTable()
         pt.field_names = ["control", "action"]
-        for button, control in self.button_down_trigger_map.items():
-            pt.add_row([button, control.__name__])
+        for button, control in self.button_trigger_map.items():
+            if button[-2:] == "_1" :
+              if type(control) is str :
+                 pt.add_row([button[:-2], control])
+              else:
+                 pt.add_row([button[:-2], control.__name__])
+
         for axis, control in self.axis_trigger_map.items():
-            pt.add_row([axis, control.__name__])
+            if type(control) is str :
+
+                  pt.add_row([axis, control])
+            else:
+                  pt.add_row([axis, control.__name__])
+
         print("Joystick Controls:")
         print(pt)
 
         # print("Joystick Controls:")
         # print("On Button Down:")
-        # print(self.button_down_trigger_map)
-        # print("On Button Up:")
-        # print(self.button_up_trigger_map)
+        # print(self.button_trigger_map)
         # print("On Axis Move:")
         # print(self.axis_trigger_map)
 
 
-    def set_button_down_trigger(self, button, func):
+    def set_button_trigger(self, button, func):
         '''
         assign a string button descriptor to a given function call
         '''
-        self.button_down_trigger_map[button] = func
-
-
-    def set_button_up_trigger(self, button, func):
-        '''
-        assign a string button descriptor to a given function call
-        '''
-        self.button_up_trigger_map[button] = func
+        if button[-2:] == "_1" or button[-2:] == "_0": 
+            self.button_trigger_map[button] = func
+        else:
+            ## if not defined, we consider that the function is assigned when button is pressed.
+            self.button_trigger_map[button+"_1"] = func
 
 
     def set_axis_trigger(self, axis, func):
@@ -763,32 +770,41 @@ class JoystickController(object):
         '''
         poll a joystick for input events
         '''
-
+        self.shiftkey=""
         #wait for joystick to be online
         while self.running and self.js is None and not self.init_js():
             time.sleep(3)
 
         while self.running:
             button, button_state, axis, axis_val = self.js.poll()
-
-            if axis is not None and axis in self.axis_trigger_map:
+               
+            if axis is not None :
                 '''
                 then invoke the function attached to that axis
                 '''
-                self.axis_trigger_map[axis](axis_val)
+                axis=self.shiftkey+axis
+                if   axis is not None  and axis in self.axis_trigger_map:
+                
+                   if type(self.axis_trigger_map[axis]) is str :
+                       funcstr=self.axis_trigger_map[axis]
+                       funcstr2=funcstr.replace("%val%",str(axis_val))
+                       exec(funcstr2)
+                       #exec(self.axis_trigger_map[axis])
+                   else:
+                      self.axis_trigger_map[axis](axis_val)
 
-            if button and button_state >= 1 and button in self.button_down_trigger_map:
-                '''
-                then invoke the function attached to that button
-                '''
-                self.button_down_trigger_map[button]()
-
-            if button and button_state == 0 and button in self.button_up_trigger_map:
-                '''
-                then invoke the function attached to that button
-                '''
-                self.button_up_trigger_map[button]()
-
+            if button :  
+                button=self.shiftkey+button+"_"+str(button_state)
+ 
+                if button in self.button_trigger_map:
+                   '''
+                   then invoke the function attached to that button
+                   '''
+                   if type(self.button_trigger_map[button]) is str :
+                      funcstr=self.button_trigger_map[button]
+                      exec(funcstr)
+                   else:
+                      self.button_trigger_map[button]
             time.sleep(self.poll_delay)
 
 
@@ -988,21 +1004,20 @@ class PS3JoystickController(JoystickController):
         init set of mapping from buttons to function calls
         '''
 
-        self.button_down_trigger_map = {
-            'select' : self.toggle_mode,
-            'circle' : self.toggle_manual_recording,
-            'triangle' : self.erase_last_N_records,
-            'cross' : self.emergency_stop,
-            'dpad_up' : self.increase_max_throttle,
-            'dpad_down' : self.decrease_max_throttle,
-            'start' : self.toggle_constant_throttle,
-            "R1" : self.chaos_monkey_on_right,
-            "L1" : self.chaos_monkey_on_left,
-        }
-
-        self.button_up_trigger_map = {
-            "R1" : self.chaos_monkey_off,
-            "L1" : self.chaos_monkey_off,
+        self.button_trigger_map = {
+            'select_1' : self.toggle_mode,
+            'circle_1' : self.toggle_manual_recording,
+            'triangle_1' : self.erase_last_N_records,
+            'cross_1' : self.emergency_stop,
+            'dpad_up_1' : self.increase_max_throttle,
+            'dpad_down_1' : self.decrease_max_throttle,
+            'start_1' : self.toggle_constant_throttle,
+            "R1_1" : self.chaos_monkey_on_right,
+            "L1_1" : self.chaos_monkey_on_left,
+            "R1_0" : self.chaos_monkey_off,
+            "L1_0" : self.chaos_monkey_off,
+            "LEFT_TOP_TRIGGER_1" : 'self.shiftkey="CAMERA_MODE+"',
+            "CAMERA_MODE+LEFT_TOP_TRIGGER_0" : 'self.shiftkey=""',  
         }
 
         self.axis_trigger_map = {
@@ -1013,7 +1028,7 @@ class PS3JoystickController(JoystickController):
 
 class PS4JoystickController(JoystickController):
     '''
-    A Controller object that maps inputs to actions
+    Controller object that maps inputs to actions
     '''
     def __init__(self, *args, **kwargs):
         super(PS4JoystickController, self).__init__(*args, **kwargs)
@@ -1038,14 +1053,14 @@ class PS4JoystickController(JoystickController):
         init set of mapping from buttons to function calls for ps4
         '''
 
-        self.button_down_trigger_map = {
-            'share' : self.toggle_mode,
-            'circle' : self.toggle_manual_recording,
-            'triangle' : self.erase_last_N_records,
-            'cross' : self.emergency_stop,
-            'L1' : self.increase_max_throttle,
-            'R1' : self.decrease_max_throttle,
-            'options' : self.toggle_constant_throttle,
+        self.button_trigger_map = {
+            'share_1' : self.toggle_mode,
+            'circle_1' : self.toggle_manual_recording,
+            'triangle_1' : self.erase_last_N_records,
+            'cross_1' : self.emergency_stop,
+            'L1_1' : self.increase_max_throttle,
+            'R1_1' : self.decrease_max_throttle,
+            'options_1' : self.toggle_constant_throttle,
         }
 
         self.axis_trigger_map = {
@@ -1098,14 +1113,14 @@ class XboxOneJoystickController(JoystickController):
         init set of mapping from buttons to function calls
         '''
 
-        self.button_down_trigger_map = {
-            'a_button': self.toggle_mode,
-            'b_button': self.toggle_manual_recording,
-            'x_button': self.erase_last_N_records,
-            'y_button': self.emergency_stop,
-            'right_shoulder': self.increase_max_throttle,
-            'left_shoulder': self.decrease_max_throttle,
-            'options': self.toggle_constant_throttle,
+        self.button_trigger_map = {
+            'a_button_1': self.toggle_mode,
+            'b_button_1': self.toggle_manual_recording,
+            'x_button_1': self.erase_last_N_records,
+            'y_button_1': self.emergency_stop,
+            'right_shoulder_1': self.increase_max_throttle,
+            'left_shoulder_1': self.decrease_max_throttle,
+            'options_1': self.toggle_constant_throttle,
         }
 
         self.axis_trigger_map = {
@@ -1145,19 +1160,16 @@ class LogitechJoystickController(JoystickController):
         init set of mapping from buttons to function calls
         '''
 
-        self.button_down_trigger_map = {
-            'start': self.toggle_mode,
-            'B': self.toggle_manual_recording,
-            'Y': self.erase_last_N_records,
-            'A': self.emergency_stop,
-            'back': self.toggle_constant_throttle,
-            "R1" : self.chaos_monkey_on_right,
-            "L1" : self.chaos_monkey_on_left,
-        }
-
-        self.button_up_trigger_map = {
-            "R1" : self.chaos_monkey_off,
-            "L1" : self.chaos_monkey_off,
+        self.button_trigger_map = {
+            'start_1': self.toggle_mode,
+            'B_1': self.toggle_manual_recording,
+            'Y_1': self.erase_last_N_records,
+            'A_1': self.emergency_stop,
+            'back_1': self.toggle_constant_throttle,
+            "R1_1" : self.chaos_monkey_on_right,
+            "L1_1" : self.chaos_monkey_on_left,
+            "R1_0" : self.chaos_monkey_off,
+            "L1_0" : self.chaos_monkey_off,
         }
 
         self.axis_trigger_map = {
@@ -1212,10 +1224,10 @@ class NimbusController(JoystickController):
     def init_trigger_maps(self):
         #init set of mapping from buttons to function calls
 
-        self.button_down_trigger_map = {
-            'y' : self.erase_last_N_records,
-            'b' : self.toggle_mode,
-            'a' : self.emergency_stop,
+        self.button_trigger_map = {
+            'y_1' : self.erase_last_N_records,
+            'b_1' : self.toggle_mode,
+            'a_1' : self.emergency_stop,
         }
 
         self.axis_trigger_map = {
@@ -1244,15 +1256,27 @@ class WiiUController(JoystickController):
     def init_trigger_maps(self):
         #init set of mapping from buttons to function calls
 
-        self.button_down_trigger_map = {
-            'Y' : self.erase_last_N_records,
-            'B' : self.toggle_mode,
-            'A' : self.emergency_stop,
+        self.button_trigger_map = {
+            'Y_1' : self.erase_last_N_records,
+            'B_1' : self.toggle_mode,
+            'A_1' : self.emergency_stop,
+            'LEFT_TOP_TRIGGER_1' : 'self.shiftkey="CAMERA_MODE+"',
+            'CAMERA_MODE+LEFT_TOP_TRIGGER_0' : 'self.shiftkey=""',
+            'CAMERA_MODE+A_1' : 'self.mem.put (["testval"],30)',
+            'CAMERA_MODE+Y_1' : 'self.mem.put (["testval"],0)',
+
+        
+
+
+
+
         }
 
         self.axis_trigger_map = {
             'LEFT_STICK_X' : self.set_steering,
             'RIGHT_STICK_Y' : self.set_throttle,
+            'CAMERA_MODE+LEFT_STICK_X' : 'self.mem.put (["testval"],%val%)',
+
         }
 
 
@@ -1333,7 +1357,7 @@ class JoyStickSub(object):
         return ret
 
 
-def get_js_controller(cfg):
+def get_js_controller(cfg,memobject=None):
     cont_class = None
     if cfg.CONTROLLER_TYPE == "ps3":
         cont_class = PS3JoystickController
@@ -1353,7 +1377,7 @@ def get_js_controller(cfg):
     ctr = cont_class(throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
                                 throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
                                 steering_scale=cfg.JOYSTICK_STEERING_SCALE,
-                                auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
+                                auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE,memobject=memobject)
 
     ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)
     return ctr


### PR DESCRIPTION
The Shift feature allows to define combinations of buttons in the controller.py file ; this adds more possibilities to control parameters of the car. 

While the shift key is pressed , buttons have a different function. 
usage exemple can be to control the pan/tilt of the camera, increase / decrease loglevel during runtime, adjust camera settings, modify the desirable "location" during runtime etc..
A simple exemple of shift key is provided in the wiiu definitions.

For more readability, the button_up_trigger_map and the button_down_trigger_map have been merged. "_1" means button down and "_0" means button up.

In order to allow the controller part to communicate directly with other parts, the mem object is passed to the controller. this allows to update directly some variables that can be used by other parts.     

i tried to ensure that the new file be compatible with all other existing files without any change. 

