### PR TITLE
retry of pwm.set_pwm on first exception due to I2C timing errors

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -33,7 +33,10 @@ class PCA9685:
         time.sleep(init_delay) # "Tamiya TBLE-02" makes a little leap otherwise
 
     def set_pulse(self, pulse):
-        self.pwm.set_pwm(self.channel, 0, int(pulse * self.pwm_scale))
+        try:
+            self.pwm.set_pwm(self.channel, 0, int(pulse * self.pwm_scale))
+        except:
+            self.pwm.set_pwm(self.channel, 0, int(pulse * self.pwm_scale))
 
     def run(self, pulse):
         self.set_pulse(pulse)


### PR DESCRIPTION
Using the Teensy PCA9685 emulation I ran across a few I/O errors when donkey tried to set a new pwm value. It was explained by the original author of the emulation that the rPi I2C library doesn't "doesn't allow slaves to clock extend" which seems to be something lots of I2C slave devices do. I found that a simple retry of the message was enough to cover the sporadic I/O errors I'd seen.