### PR TITLE
Travis update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build
 .pytest_cache
 .coverage
 .vscode
+
+# codecov
+htmlcov/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,9 @@
+---
+MD004:
+  style: sublist
+MD007:
+  indent: 2
+MD013:
+  line_length: 120
+  code_blocks: false
+default: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - conda create -q -n test-environment-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment-$TRAVIS_PYTHON_VERSION
   - pip install --upgrade pip
   - hash -r
@@ -45,6 +45,7 @@ jobs:
   allow_failures:
     - name: markdownlint
     - name: yamllint
+    - name: black
 
   include:
 
@@ -56,6 +57,19 @@ jobs:
         - pip install mkdocs
       script:
         - mkdocs build
+
+    # black - The uncompromising Python code formatter - https://github.com/psf/black
+    # it requires python 3.6
+    - stage: lint
+      name: black
+      language: python
+      python: 3.6
+      install:
+        - pip install --upgrade pip
+        - hash -r
+        - pip install black
+      script:
+        - "black --check ."
 
     # yamllint https://github.com/adrienverge/yamllint
     - stage: lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,83 @@
+---
 language: python
 
 # This list should match the versions listed in setup.py
 python:
-- 3.5
-- 3.6
+  - 3.5
+  - 3.6
 
 os:
   - linux
 
-before_install:
-- sudo apt-get update -qq
-
 install:
-- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-- source activate test-environment
-- pip install -e .[tf]
-- pip install -e .[pc]
-- pip install -e .[dev]
-- pip install -e .[ci]
+  - sudo apt-get update -qq
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - source activate test-environment
+  - pip install -e .[tf]
+  - pip install -e .[pc]
+  - pip install -e .[dev]
+  - pip install -e .[ci]
 
 script:
-- pytest -v donkeycar/tests
+  - pytest -v donkeycar/tests
 
 stages:
-    - name: deploy
-      if: branch = master
+  - name: docs
+  - name: lint
+  - name: deploy
+    if: branch = master
 
 jobs:
+  fast_finish: false
+  allow_failures:
+    - name: markdownlint
+    - name: yamllint
+
   include:
+
+    # mkdocs
+    - stage: docs
+      name: mkdocs
+      language: python
+      install:
+        - pip install mkdocs
+      script:
+        - mkdocs build
+
+    # yamllint https://github.com/adrienverge/yamllint
+    - stage: lint
+      name: yamllint
+      language: shell
+      install: skip
+      script:
+        - "docker run --rm -v $PWD:/yaml:ro sdesbure/yamllint yamllint ."
+
+    # markdownlint CLI https://github.com/06kellyjac/docker_markdownlint-cli
+    - stage: lint
+      name: markdownlint
+      language: shell
+      install: skip
+      script:
+        - "docker run -v $PWD:/markdown:ro 06kellyjac/markdownlint-cli ."
+
     - stage: deploy
       python: 3.6
       script: skip
       deploy:
         provider: pypi
-        user: wroscoe
+        username: wroscoe
         password:
+          # yamllint disable-line rule:line-length
           secure: Y64NS2etlOIjKMTLQex+5H/QrKdBzwGjhZ9VVp1NXyx76oqg0ygn5lOPcMAvQbuJbGzT0E/5q/EDhJAh6YjyjVYAS2UgBUehpY5Nu0oYFTfWCTC9fbQRn0XRLXPeZR3BKZ1cAxDCMm4a6iZ4M8CqatN73IexcORCYgkIXZfGRVGcAdLonWzkXPqIwe287e7TiQAx6wM6e7k4DRRUFcrw56lLWTG6FEkauQDNXJFlySwesIgFni+K59tHcxP1U00NTV5utTaNzkkFwro4bp6EsVHEYr8Hgz2Sv0mxAggWmXaMGwILahTSVoRznFsik4r3DiOwVEAc+aeTHg9NJin5/ic4ShODMPKkBQInUNxgmE8cZy5EpZ+a9Xbp1dNt/+x56Bmz+bKoQq/e0ydIBNXCeaT41VFyJTjz9db01HwUPZHfp0NCyIo5QcknH98G0oLmaqv43qGJzmaQi0h4BkkmgI5HpkE12MSDC8QFsDKmOXlj/I4WEWXuPslhuKTgYNadFGdTkfbhnbMjRDkuNfL8YSXwnNDTcB5qT3hIYWGVKN2qAAljWniWHdQMMosMv7CwfoM7IO6apgBuvoMJOMunHEgyGDX5Hb1Y5YYa+OC/0eCfcIEScoPM0JHtMmznYlIv5vwx8B3yK0qk0W8nIv65bZvP5eYBF1zLgeE2FLsuc1o=
-        on:
+        on:  # yamllint disable-line rule:truthy
           tags: true
 
 after_success:
-- codecov
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,17 @@ install:
   - conda update -q conda
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
+  - source activate test-environment-$TRAVIS_PYTHON_VERSION
+  - pip install --upgrade pip
+  - hash -r
+  - conda info -a
   - pip install -e .[tf]
   - pip install -e .[pc]
   - pip install -e .[dev]
   - pip install -e .[ci]
+  - echo "pip freeze virtualenv=test-environment python=${TRAVIS_PYTHON_VERSION}"
+  - pip freeze > test-environment-${TRAVIS_PYTHON_VERSION}.txt
+  - cat test-environment-${TRAVIS_PYTHON_VERSION}.txt
 
 script:
   - pytest -v donkeycar/tests --cov=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - pip install -e .[ci]
 
 script:
-  - pytest -v donkeycar/tests
+  - pytest -v donkeycar/tests --cov=./
 
 stages:
   - name: docs

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+
+ignore: |
+  .galaxy/
+
+rules:
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
* Add stages for makrdownlint, yamllint, mkdocs
* Update travis config so that it no longer generates warnings if pasted
  into https://config.travis-ci.com/explore
* Speed up linting phase (skip install)
* Move docs build earlier
* Allow yamllint and makrdownlint to fail
* Fix code coverage reports