### PR TITLE
Performance improvement of PWMThrottle and PWMSteering 

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -23,7 +23,7 @@ class PCA9685:
         # Initialise the PCA9685 using the default address (0x40).
         if busnum is not None:
             from Adafruit_GPIO import I2C
-            #replace the get_bus function with our own
+            # replace the get_bus function with our own
             def get_bus():
                 return busnum
             I2C.get_default_bus = get_bus
@@ -81,11 +81,11 @@ class JHat:
     def __init__(self, channel, address=0x40, frequency=60, busnum=None):
         print("Firing up the Hat")
         import Adafruit_PCA9685
-        LED0_OFF_L         = 0x08
+        LED0_OFF_L = 0x08
         # Initialise the PCA9685 using the default address (0x40).
         if busnum is not None:
             from Adafruit_GPIO import I2C
-            #replace the get_bus function with our own
+            # replace the get_bus function with our own
             def get_bus():
                 return busnum
             I2C.get_default_bus = get_bus
@@ -94,15 +94,14 @@ class JHat:
         self.channel = channel
         self.register = LED0_OFF_L+4*channel
 
-        #we install our own write that is more efficient use of interrupts
+        # we install our own write that is more efficient use of interrupts
         self.pwm.set_pwm = self.set_pwm
         
     def set_pulse(self, pulse):
         self.set_pwm(self.channel, 0, pulse) 
 
     def set_pwm(self, channel, on, off):
-        #print("pulse", off)
-        """Sets a single PWM channel."""
+        # sets a single PWM channel
         self.pwm._device.writeList(self.register, [off & 0xFF, off >> 8])
         
     def run(self, pulse):
@@ -129,14 +128,14 @@ class JHatReader:
         pwm control values from last RC input  
         '''
         h1 = self.pwm._device.readU8(self.register)
-        #first byte of header must be 100, otherwize we might be reading
-        #in the wrong byte offset
+        # first byte of header must be 100, otherwize we might be reading
+        # in the wrong byte offset
         while h1 != 100:
             print("skipping to start of header")
             h1 = self.pwm._device.readU8(self.register)
         
         h2 = self.pwm._device.readU8(self.register)
-        #h2 ignored now
+        # h2 ignored now
 
         val_a = self.pwm._device.readU8(self.register)
         val_b = self.pwm._device.readU8(self.register)
@@ -146,11 +145,9 @@ class JHatReader:
         val_d = self.pwm._device.readU8(self.register)
         self.throttle = (val_d << 8) + val_c
 
-        #scale the values from -1 to 1
+        # scale the values from -1 to 1
         self.steering = (((float)(self.steering)) - 1500.0) / 500.0  + 0.158
         self.throttle = (((float)(self.throttle)) - 1500.0) / 500.0  + 0.136
-        
-        #print(self.steering, self.throttle)
 
     def update(self):
         while(self.running):
@@ -167,52 +164,66 @@ class JHatReader:
 
 class PWMSteering:
     """
-    Wrapper over a PWM motor cotnroller to convert angles to PWM pulses.
+    Wrapper over a PWM motor controller to convert angles to PWM pulses.
     """
-    LEFT_ANGLE = -1 
+    LEFT_ANGLE = -1
     RIGHT_ANGLE = 1
 
-    def __init__(self, controller=None,
-                       left_pulse=290,
-                       right_pulse=490):
+    def __init__(self,
+                 controller=None,
+                 left_pulse=290,
+                 right_pulse=490):
 
         self.controller = controller
         self.left_pulse = left_pulse
         self.right_pulse = right_pulse
+        self.pulse = dk.utils.map_range(0, self.LEFT_ANGLE, self.RIGHT_ANGLE,
+                                        self.left_pulse, self.right_pulse)
+        self.running = True
+        print('PWM Steering created')
 
+    def update(self):
+        while self.running:
+            self.controller.set_pulse(self.pulse)
+
+    def run_threaded(self, angle):
+        # map absolute angle to angle that vehicle can implement.
+        self.pulse = dk.utils.map_range(angle,
+                                        self.LEFT_ANGLE, self.RIGHT_ANGLE,
+                                        self.left_pulse, self.right_pulse)
 
     def run(self, angle):
-        #map absolute angle to angle that vehicle can implement.
-        pulse = dk.utils.map_range(angle,
-                                self.LEFT_ANGLE, self.RIGHT_ANGLE,
-                                self.left_pulse, self.right_pulse)
-
-        self.controller.set_pulse(pulse)
+        self.run_threaded(angle)
+        self.controller.set_pulse(self.pulse)
 
     def shutdown(self):
-        self.run(0) #set steering straight
-
+        # set steering straight
+        self.pulse = 0
+        time.sleep(0.3)
+        self.running = False
 
 
 class PWMThrottle:
     """
-    Wrapper over a PWM motor cotnroller to convert -1 to 1 throttle
+    Wrapper over a PWM motor controller to convert -1 to 1 throttle
     values to PWM pulses.
     """
     MIN_THROTTLE = -1
-    MAX_THROTTLE =  1
+    MAX_THROTTLE = 1
 
-    def __init__(self, controller=None,
-                       max_pulse=300,
-                       min_pulse=490,
-                       zero_pulse=350):
+    def __init__(self,
+                 controller=None,
+                 max_pulse=300,
+                 min_pulse=490,
+                 zero_pulse=350):
 
         self.controller = controller
         self.max_pulse = max_pulse
         self.min_pulse = min_pulse
         self.zero_pulse = zero_pulse
-        
-        #send zero pulse to calibrate ESC
+        self.pulse = zero_pulse
+
+        # send zero pulse to calibrate ESC
         print("Init ESC")
         self.controller.set_pulse(self.max_pulse)
         time.sleep(0.01)
@@ -220,23 +231,29 @@ class PWMThrottle:
         time.sleep(0.01)
         self.controller.set_pulse(self.zero_pulse)
         time.sleep(1)
+        self.running = True
+        print('PWM Throttle created')
 
+    def update(self):
+        while self.running:
+            self.controller.set_pulse(self.pulse)
+
+    def run_threaded(self, throttle):
+        if throttle > 0:
+            self.pulse = dk.utils.map_range(throttle, 0, self.MAX_THROTTLE,
+                                            self.zero_pulse, self.max_pulse)
+        else:
+            self.pulse = dk.utils.map_range(throttle, self.MIN_THROTTLE, 0,
+                                            self.min_pulse, self.zero_pulse)
 
     def run(self, throttle):
-        if throttle > 0:
-            pulse = dk.utils.map_range(throttle,
-                                    0, self.MAX_THROTTLE, 
-                                    self.zero_pulse, self.max_pulse)
-        else:
-            pulse = dk.utils.map_range(throttle,
-                                    self.MIN_THROTTLE, 0, 
-                                    self.min_pulse, self.zero_pulse)
+        self.run_threaded(throttle)
+        self.controller.set_pulse(self.pulse)
 
-        self.controller.set_pulse(pulse)
-        
     def shutdown(self):
-        self.run(0) #stop vehicle
-
+        # stop vehicle
+        self.run(0)
+        self.running = False
 
 
 class Adafruit_DCMotor_Hat:
@@ -281,6 +298,7 @@ class Adafruit_DCMotor_Hat:
 
     def shutdown(self):
         self.mh.getMotor(self.motor_num).run(Adafruit_MotorHAT.RELEASE)
+
 
 class Maestro:
     '''
@@ -359,10 +377,11 @@ class Maestro:
             if Maestro.astar_device.inWaiting() > 8:
                 ret = Maestro.astar_device.readline()
 
-        if ret != None:
+        if ret is not None:
             ret = ret.rstrip()
 
         return ret
+
 
 class Teensy:
     '''

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -204,7 +204,6 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
               outputs=['led/blink_rate'])
 
         V.add(led, inputs=['led/blink_rate'])
-        
 
     def get_record_alert_color(num_records):
         col = (0, 0, 0)
@@ -456,9 +455,9 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
                                         zero_pulse=cfg.THROTTLE_STOPPED_PWM, 
                                         min_pulse=cfg.THROTTLE_REVERSE_PWM)
 
-        V.add(steering, inputs=['angle'])
-        V.add(throttle, inputs=['throttle'])
-    
+        V.add(steering, inputs=['angle'], threaded=True)
+        V.add(throttle, inputs=['throttle'], threaded=True)
+
 
     elif cfg.DRIVE_TRAIN_TYPE == "DC_STEER_THROTTLE":
         from donkeycar.parts.actuator import Mini_HBridge_DC_Motor_PWM
@@ -498,7 +497,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
         from donkeycar.parts.actuator import Mini_HBridge_DC_Motor_PWM
         motor = Mini_HBridge_DC_Motor_PWM(cfg.HBRIDGE_PIN_FWD, cfg.HBRIDGE_PIN_BWD)
 
-        V.add(steering, inputs=['angle'])
+        V.add(steering, inputs=['angle'], threaded=True)
         V.add(motor, inputs=["throttle"])
 
     
@@ -568,9 +567,10 @@ if __name__ == '__main__':
     if args['drive']:
         model_type = args['--type']
         camera_type = args['--camera']
-        drive(cfg, model_path=args['--model'], use_joystick=args['--js'], model_type=model_type, camera_type=camera_type,
-            meta=args['--meta'])
-    
+        drive(cfg, model_path=args['--model'], use_joystick=args['--js'],
+              model_type=model_type, camera_type=camera_type,
+              meta=args['--meta'])
+
     if args['train']:
         from train import multi_train, preprocessFileList
         


### PR DESCRIPTION
# Performance improvement of PWM actuators

## Motivation

- PWM actuators, i.e. PWMThrottle and PWMSteering each are taking up 2-3ms in the vehicle loop, that is 5-6ms in aggregate.
- If we want to run the car at 40 Hz than we only have 25ms per loop for all parts. Keras takes up 13-15ms, so optimising the other parts to a minimum will leave more cpu time for the auto pilot.
- In recording drive mode, TubWriter seems to be taking up most of the time, around 7ms.

## Implementation
- Change of PWMSteering and 'PWMThrottle` into threaded parts. Non-threaded functionality is maintained.
- Minor code changes (pep-8), mostly whitespace

## Impact
- Actuator performance goes down to < 0.1 ms.
