### PR TITLE
Small change - added 90, 99, 99.9 percentiles to performance statistics.

### DIFF
--- a/donkeycar/vehicle.py
+++ b/donkeycar/vehicle.py
@@ -7,7 +7,7 @@ Created on Sun Jun 25 10:44:24 2017
 """
 
 import time
-from statistics import median
+import numpy as np
 from threading import Thread
 from .memory import Memory
 from prettytable import PrettyTable
@@ -35,7 +35,9 @@ class PartProfiler:
     def report(self):
         print("Part Profile Summary: (times in ms)")
         pt = PrettyTable()
-        pt.field_names = ["part", "max", "min", "avg", "median"]
+        field_names = ["part", "max", "min", "avg"]
+        pctile = [50, 90, 99, 99.9]
+        pt.field_names = field_names + [str(p) + '%' for p in pctile]
         for p, val in self.records.items():
             # remove first and last entry because you there could be one-off
             # time spent in initialisations, and the latest diff could be
@@ -43,11 +45,12 @@ class PartProfiler:
             arr = val['times'][1:-1]
             if len(arr) == 0:
                 continue
-            pt.add_row([p.__class__.__name__,
-                        "%.2f" % (max(arr) * 1000),
-                        "%.2f" % (min(arr) * 1000),
-                        "%.2f" % (sum(arr) / len(arr) * 1000),
-                        "%.2f" % (median(arr) * 1000)])
+            row = [p.__class__.__name__,
+                   "%.2f" % (max(arr) * 1000),
+                   "%.2f" % (min(arr) * 1000),
+                   "%.2f" % (sum(arr) / len(arr) * 1000)]
+            row += ["%.2f" % (np.percentile(arr, p) * 1000) for p in pctile]
+            pt.add_row(row)
         print(pt)
 
 
@@ -69,6 +72,8 @@ class Vehicle:
 
         Parameters
         ----------
+            part: class
+                donkey vehicle part has run() attribute
             inputs : list
                 Channel names to get from memory.
             outputs : list
@@ -121,6 +126,8 @@ class Vehicle:
         max_loop_count : int
             Maximum number of loops the drive loop should execute. This is
             used for testing that all the parts of the vehicle work.
+        verbose: bool
+            If debug output should be printed into shell
         """
 
         try:
@@ -133,7 +140,7 @@ class Vehicle:
                     entry.get('thread').start()
 
             # wait until the parts warm up.
-            print('Starting vehicle...')
+            print('Starting vehicle at {} Hz'.format(rate_hz))
 
             loop_count = 0
             while self.on:


### PR DESCRIPTION
# Extending the performance metrics of the part profiler to contain more percentiles
Adding more percentiles to help investigating if slower parts are frequently slow or only in rare occurrences.

## Current state
- Part profiler shows min, max, average and 50% percentile (= median)

## Change
- Add 90%, 99% and 99.9% 

