### PR TITLE
removed self arg from map_frange and moved map_frange to utils

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -7,6 +7,7 @@ are wrapped in a mixer class before being used in the drive loop.
 import time
 
 import donkeycar as dk
+from utils import map_frange
 
         
 class PCA9685:
@@ -617,17 +618,6 @@ class Mini_HBridge_DC_Motor_PWM(object):
         self.pwm_b.stop()
         GPIO.cleanup()
 
-def map_frange(self, x, X_min, X_max, Y_min, Y_max):
-    ''' 
-    Linear mapping between two ranges of values 
-    '''
-    X_range = X_max - X_min
-    Y_range = Y_max - Y_min
-    XY_ratio = X_range/Y_range
-
-    y = ((x-X_min) / XY_ratio + Y_min)
-
-    return y
     
 class RPi_GPIO_Servo(object):
     '''

--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -7,7 +7,6 @@ are wrapped in a mixer class before being used in the drive loop.
 import time
 
 import donkeycar as dk
-from utils import map_frange
 
         
 class PCA9685:
@@ -641,7 +640,7 @@ class RPi_GPIO_Servo(object):
         -1 is full backwards.
         '''
         #I've read 90 is a good max
-        self.throttle = map_frange(pulse, -1.0, 1.0, self.min, self.max)
+        self.throttle = dk.map_frange(pulse, -1.0, 1.0, self.min, self.max)
         #print(pulse, self.throttle)
         self.pwm.ChangeDutyCycle(self.throttle)
 

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -294,6 +294,18 @@ def my_ip():
 OTHER
 '''
 
+def map_frange(x, X_min, X_max, Y_min, Y_max):
+    ''' 
+    Linear mapping between two ranges of values 
+    '''
+    X_range = X_max - X_min
+    Y_range = Y_max - Y_min
+    XY_ratio = X_range/Y_range
+
+    y = ((x-X_min) / XY_ratio + Y_min)
+
+    return y
+
 
 def merge_two_dicts(x, y):
     """Given two dicts, merge them into a new dict as a shallow copy."""


### PR DESCRIPTION
map_frange() was defined in actuator.py and called in actuator.py by RPi_GPIO_Servo class.  It was defined with a 'self' argument, as if it was a class method, but it was defined in the module scope.  It's a useful function, so I moved it to utils.py and changed actuator.py to import it.

