### PR TITLE
448 protected DriveMode from None throttle or steering

### DIFF
--- a/donkeycar/templates/basic_web.py
+++ b/donkeycar/templates/basic_web.py
@@ -153,10 +153,10 @@ def drive(cfg, model_path=None, model_type=None):
                 return user_angle, user_throttle
             
             elif mode == 'local_angle':
-                return pilot_angle, user_throttle
+                return pilot_angle if pilot_angle else 0.0, user_throttle
             
             else: 
-                return pilot_angle, pilot_throttle * cfg.AI_THROTTLE_MULT
+                return pilot_angle if pilot_angle else 0.0, pilot_throttle * cfg.AI_THROTTLE_MULT if pilot_throttle else 0.0
         
     V.add(DriveMode(), 
           inputs=['user/mode', 'user/angle', 'user/throttle',

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -391,10 +391,10 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
                 return user_angle, user_throttle
             
             elif mode == 'local_angle':
-                return pilot_angle, user_throttle
+                return pilot_angle if pilot_angle else 0.0, user_throttle
             
             else: 
-                return pilot_angle, pilot_throttle * cfg.AI_THROTTLE_MULT
+                return pilot_angle if pilot_angle else 0.0, pilot_throttle * cfg.AI_THROTTLE_MULT if pilot_throttle else 0.0
         
     V.add(DriveMode(), 
           inputs=['user/mode', 'user/angle', 'user/throttle',


### PR DESCRIPTION
Addresses issue 448 https://github.com/autorope/donkeycar/issues/448

Sometimes throttle or steering values can become null if the drive mode is changed.  This code protects against None type inside of DriveMode class.  