### PR TITLE
add support for tf version 2

### DIFF
--- a/donkeycar/parts/tflite.py
+++ b/donkeycar/parts/tflite.py
@@ -1,7 +1,12 @@
 import tensorflow as tf
 
 def keras_model_to_tflite(in_filename, out_filename, data_gen=None):
-    converter = tf.lite.TFLiteConverter.from_keras_model_file(in_filename)
+    verStr = tf.__version__
+    if verStr.find('1.1')  == 0: # found MAJOR.MINOR match for version 1.1x.x
+        converter = tf.lite.TFLiteConverter.from_keras_model_file(in_filename)
+    if verStr.find('2.')  == 0: # found MAJOR.MINOR match for version 2.x.x
+        new_model= tf.keras.models.load_model(in_filename) #filepath="keras_model.h5")
+        converter = tf.lite.TFLiteConverter.from_keras_model(new_model)
     if data_gen is not None:
         #when we have a data_gen that is the trigger to use it to 
         #create integer weights and calibrate them. Warning: this model will


### PR DESCRIPTION
tf version 2 does not have the from_keras_model_file function so it must be explicitly loaded and the converter object created.