### PR TITLE
Fix issues with xboxswapped controller

### DIFF
--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -810,6 +810,13 @@ class JoystickController(object):
 
             time.sleep(self.poll_delay)
 
+    def do_nothing(self, param):
+        '''assign no action to the given axis
+        this is useful to unmap certain axes, for example when swapping sticks
+        '''
+        pass
+
+
 
     def set_steering(self, axis_val):
         self.angle = self.steering_scale * axis_val
@@ -1148,9 +1155,14 @@ class XboxOneSwappedJoystickController(XboxOneJoystickController):
         '''
         super(XboxOneSwappedJoystickController, self).init_trigger_maps()
 
+        # make the actual swap of the sticks
         self.set_axis_trigger('right_stick_horz', self.set_steering)
         self.set_axis_trigger('left_stick_vert', self.set_throttle)
-        
+
+        # unmap default assinments to the axes
+        self.set_axis_trigger('left_stick_horz', self.do_nothing)
+        self.set_axis_trigger('right_stick_vert', self.do_nothing)
+
 
 class LogitechJoystickController(JoystickController):
     '''


### PR DESCRIPTION
XboxOneSwappedJoystickController calls the init method from XboxOneJoystickController which initializes controller with steering on left and throttle on right. Then it just adds additional mapping to make steering on right and throttle on left, without clearing prior mapping.

This ends in both joysticks to react to steering **and** throttle in the same time, which renders the whole control process unusable - unless you focus on steering with single joystick or you are super precise with your fingers ;-).

This PR adds required additional mapping to the old axes so that they do nothing - so that they do not react any longer to the input, which effectively makes joystick swap as intended.