### PR TITLE
Support for Realsense D435 and D435i depth cameras

### DIFF
--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -236,8 +236,8 @@ class Tub(object):
                 img.save(os.path.join(self.path, name))
                 json_data[key]=name
 
-            elif typ == 'depth_array':
-                # save depth as a 16bit png
+            elif typ == 'gray16_array':
+                # save np.uint16 as a 16bit png
                 img = Image.fromarray(np.uint16(val))
                 name = self.make_file_name(key, ext='.png')
                 img.save(os.path.join(self.path, name))

--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -236,6 +236,13 @@ class Tub(object):
                 img.save(os.path.join(self.path, name))
                 json_data[key]=name
 
+            elif typ == 'depth_array':
+                # save depth as a 16bit png
+                img = Image.fromarray(np.uint16(val))
+                name = self.make_file_name(key, ext='.png')
+                img.save(os.path.join(self.path, name))
+                json_data[key]=name
+
             else:
                 msg = 'Tub does not know what to do with this type {}'.format(typ)
                 raise TypeError(msg)

--- a/donkeycar/parts/realsense435i.py
+++ b/donkeycar/parts/realsense435i.py
@@ -10,6 +10,20 @@ import logging
 import numpy as np
 import pyrealsense2 as rs
 
+#
+# NOTE: Jetson Nano users should clone the Jetson Hacks project
+#       https://github.com/JetsonHacksNano/installLibrealsense
+#       and _build librealsense from source_ in order to get the python bindings.
+#       ./buildLibrealsense.sh
+#
+
+#
+# The Realsense D435 will not output images with arbitrarily chosen dimensions.
+# The dimensions must be from the allowed list.  I've chosen a reasonable
+# resolution that I know is supported by the camera.
+# If the part is initialized with different sizes, then opencv
+# will be used to resize the image before it is returned.
+#
 WIDTH = 424
 HEIGHT = 240
 CHANNELS = 3

--- a/donkeycar/parts/realsense435i.py
+++ b/donkeycar/parts/realsense435i.py
@@ -94,6 +94,9 @@ class RealSense435i(object):
         self.start_time = time.time()
         self.frame_time = self.start_time
 
+        self.running = True
+
+
     def _poll(self):
         last_time = self.frame_time
         self.frame_time = time.time() - self.start_time

--- a/donkeycar/parts/realsense435i.py
+++ b/donkeycar/parts/realsense435i.py
@@ -133,7 +133,7 @@ class RealSense435i(object):
 
             # Convert depth to 16bit array, RGB into 8bit planar array
             self.depth_image = np.asanyarray(depth_frame.get_data(), dtype=np.uint16) if self.enable_depth else None
-            self.color_image = np.asanyarray(color_frame.get_data()) if self.enable_rgb else None
+            self.color_image = np.asanyarray(color_frame.get_data(), dtype=np.uint8) if self.enable_rgb else None
 
             if self.resize:
                 import cv2

--- a/donkeycar/parts/realsense435i.py
+++ b/donkeycar/parts/realsense435i.py
@@ -79,7 +79,7 @@ class RealSense435i(object):
                     align_to = rs.stream.color
                     self.align = rs.align(align_to)
 
-        time.sleep(1)   # let camera warm up
+        time.sleep(2)   # let camera warm up
 
         # initialize frame state
         self.color_image = None
@@ -96,6 +96,13 @@ class RealSense435i(object):
 
         self.running = True
 
+    def _stop_pipeline(self):
+        if self.imu_pipeline is not None:
+            self.imu_pipeline.stop()
+            self.imu_pipeline = None
+        if self.pipeline is not None:
+            self.pipeline.stop()
+            self.pipeline = None
 
     def _poll(self):
         last_time = self.frame_time
@@ -182,11 +189,10 @@ class RealSense435i(object):
 
     def shutdown(self):
         self.running = False
-        time.sleep(0.1)
-        if self.imu_pipeline is not None:
-            self.imu_pipeline.stop()
-        if self.pipeline is not None:
-            self.pipeline.stop()
+        time.sleep(2) # give thread enough time to shutdown
+
+        # done running
+        self._stop_pipeline()
 
 
 #

--- a/donkeycar/parts/realsense435i.py
+++ b/donkeycar/parts/realsense435i.py
@@ -131,8 +131,8 @@ class RealSense435i(object):
             depth_frame = aligned_frames.get_depth_frame() if aligned_frames is not None else frames.get_depth_frame()
             color_frame = aligned_frames.get_color_frame() if aligned_frames is not None else frames.get_color_frame()
 
-            # Convert images to numpy arrays
-            self.depth_image = np.asanyarray(depth_frame.get_data()) if self.enable_depth else None
+            # Convert depth to 16bit array, RGB into 8bit planar array
+            self.depth_image = np.asanyarray(depth_frame.get_data(), dtype=np.uint16) if self.enable_depth else None
             self.color_image = np.asanyarray(color_frame.get_data()) if self.enable_rgb else None
 
             if self.resize:

--- a/donkeycar/parts/realsense435i.py
+++ b/donkeycar/parts/realsense435i.py
@@ -1,0 +1,169 @@
+"""
+Author: Ed Murphy
+File: realsense435i.py
+Date: April 14 2019
+Notes: Donkeycar part for the Intel Realsense depth cameras D435 and D435i.
+"""
+import time
+import logging
+
+import numpy as np
+import pyrealsense2 as rs
+
+
+class RealSense435i(object):
+    """
+    Donkeycar part for the Intel Realsense depth cameras D435 and D435i.
+    The Intel Realsense D435i camera is a device which uses an imu, twin fisheye cameras,
+    and an Movidius chip to stream a depth map along with an rgb image and optionally,
+    accelerometer and gyro data (the 'i' variant has an IMU, the non-i variant does not)
+    """
+
+    def __init__(self, enable_rgb=True, enable_depth=True, enable_imu=False, device_id = None):
+        self.device_id = device_id  # "923322071108" # serial number of device to use or None to use default
+        self.enable_imu = enable_imu
+        self.enable_rgb = enable_rgb
+        self.enable_depth = enable_depth
+
+        # Configure streams
+        if self.enable_imu:
+            self.imu_pipeline = rs.pipeline()
+            imu_config = rs.config()
+            if None != self.device_id:
+                imu_config.enable_device(self.device_id)
+            imu_config.enable_stream(rs.stream.accel, rs.format.motion_xyz32f, 63)  # acceleration
+            imu_config.enable_stream(rs.stream.gyro, rs.format.motion_xyz32f, 200)  # gyroscope
+            imu_profile = self.imu_pipeline.start(imu_config)
+
+        if self.enable_depth or self.enable_rgb:
+            self.pipeline = rs.pipeline()
+            config = rs.config()
+
+            # if we are provided with a specific device, then enable it
+            if None != self.device_id:
+                config.enable_device(self.device_id)
+
+            if self.enable_depth:
+                config.enable_stream(rs.stream.depth, 848, 480, rs.format.z16, 60)  # depth
+
+            if self.enable_rgb:
+                config.enable_stream(rs.stream.color, 424, 240, rs.format.bgr8, 60)  # rgb
+
+            # Start streaming
+            profile = self.pipeline.start(config)
+
+            # Getting the depth sensor's depth scale (see rs-align example for explanation)
+            if self.enable_depth:
+                depth_sensor = profile.get_device().first_depth_sensor()
+                depth_scale = depth_sensor.get_depth_scale()
+                print("Depth Scale is: ", depth_scale)
+                if self.enable_rgb:
+                    # Create an align object
+                    # rs.align allows us to perform alignment of depth frames to others frames
+                    # The "align_to" is the stream type to which we plan to align depth frames.
+                    align_to = rs.stream.color
+                    self.align = rs.align(align_to)
+
+        time.sleep(1)   # let camera warm up
+
+        # initialize frame state
+        self.color_image = None
+        self.depth_image = None
+        self.acceleration = None
+        self.gyroscope = None
+        self.frame_count = 0
+        self.start_time = time.time()
+        self.frame_time = self.start_time
+
+    def _poll(self):
+        last_time = self.frame_time
+        self.frame_time = time.time() - self.start_time
+        self.frame_count += 1
+
+        #
+        # get the frames
+        #
+        try:
+            if self.enable_rgb or self.enable_depth:
+                frames = self.pipeline.wait_for_frames(200 if (self.frame_count > 1) else 10000) # wait 10 seconds for first frame
+
+            if self.enable_imu:
+                imu_frames = self.imu_pipeline.wait_for_frames(200 if (self.frame_count > 1) else 10000)
+        except Exception as e:
+            logging.error(e)
+            return
+
+        #
+        # convert camera frames to images
+        #
+        if self.enable_rgb or self.enable_depth:
+            # Align the depth frame to color frame
+            aligned_frames = self.align.process(frames) if self.enable_depth and self.enable_rgb else None
+            depth_frame = aligned_frames.get_depth_frame() if aligned_frames is not None else frames.get_depth_frame()
+            color_frame = aligned_frames.get_color_frame() if aligned_frames is not None else frames.get_color_frame()
+
+            # Convert images to numpy arrays
+            self.depth_image = np.asanyarray(depth_frame.get_data()) if self.enable_depth else None
+            self.color_image = np.asanyarray(color_frame.get_data()) if self.enable_rgb else None
+
+        if self.enable_imu:
+            self.acceleration = imu_frames.first_or_default(rs.stream.accel, rs.format.motion_xyz32f).as_motion_frame().get_motion_data()
+            self.gyroscope = imu_frames.first_or_default(rs.stream.gyro, rs.format.motion_xyz32f).as_motion_frame().get_motion_data()
+            logging.debug("imu frame {} in {} seconds: \n\taccel = {}, \n\tgyro = {}".format(str(self.frame_count), str(self.frame_time - last_time), str(self.acceleration), str(self.gyroscope)))
+
+    def update(self):
+        """
+        When running threaded, update() is called from the background thread
+        to update the state.  run_threaded() is called to return the latest state.
+        """
+        while self.running:
+            self._poll()
+
+    def run_threaded(self):
+        """
+        Return the lastest state read by update().  This will not block.
+        All 4 states are returned, but may be None if the feature is not enabled when the camera part is constructed.
+        For gyroscope, x is pitch, y is yaw and z is roll.
+        :return: (rbg_image: nparray, depth_image: nparray, acceleration: (x:float, y:float, z:float), gyroscope: (x:float, y:float, z:float))
+        """
+        return self.color_image, self.depth_image, self.acceleration, self.gyroscope
+
+    def run(self):
+        """
+        Read and return frame from camera.  This will block while reading the frame.
+        see run_threaded() for return types.
+        """
+        self._poll()
+        return self.run_threaded()
+
+    def shutdown(self):
+        self.running = False
+        time.sleep(0.1)
+        if self.imu_pipeline is not None:
+            self.imu_pipeline.stop()
+        if self.pipeline is not None:
+            self.pipeline.stop()
+
+
+#
+# self test
+#
+if __name__ == "__main__":
+    frame_count = 0
+    start_time = time.time()
+    frame_time = start_time
+
+    try:
+        #
+        # for D435i, enable_imu can be True, for D435 enable_imu should be false
+        #
+        camera = RealSense435i(enable_rgb=True, enable_depth=True, enable_imu=True)
+        while True:
+            rgb, depth, acceleration, gyroscope = camera.run()
+            last_time = frame_time
+            frame_time = time.time()
+            print("imu frame {} in {} seconds: \n\taccel = {}, \n\tgyro = {}".format(str(frame_count), str(
+                frame_time - last_time), str(acceleration), str(gyroscope)))
+            time.sleep(0.05)
+    finally:
+        camera.shutdown()

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -25,7 +25,7 @@ DRIVE_LOOP_HZ = 20      # the vehicle loop will pause if faster than this speed.
 MAX_LOOPS = None        # the vehicle loop can abort after this many iterations, when given a positive integer.
 
 #CAMERA
-CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|MOCK)
+CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|MOCK)
 IMAGE_W = 160
 IMAGE_H = 120
 IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
@@ -240,4 +240,11 @@ PID_D = -0.2                        # differential mult for PID path follower
 PID_THROTTLE = 0.2                  # constant throttle value during path following
 SAVE_PATH_BTN = "cross"             # joystick button to save path
 RESET_ORIGIN_BTN = "triangle"       # joystick button to press to move car back to origin
+
+# Intel Realsense D435 and D435i depth sensing camera
+REALSENSE_D435_RGB = True       # True to capture RGB image
+REALSENSE_D435_DEPTH = True     # True to capture depth as image array
+REALSENSE_D435i_IMU = False     # True to capture IMU data (D435i only)
+REALSENSE_D435_ID = None        # serial number of camera or None if you only have one camera (it will autodetect)
+
 

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -244,7 +244,7 @@ RESET_ORIGIN_BTN = "triangle"       # joystick button to press to move car back 
 # Intel Realsense D435 and D435i depth sensing camera
 REALSENSE_D435_RGB = True       # True to capture RGB image
 REALSENSE_D435_DEPTH = True     # True to capture depth as image array
-REALSENSE_D435i_IMU = False     # True to capture IMU data (D435i only)
+REALSENSE_D435_IMU = False      # True to capture IMU data (D435i only)
 REALSENSE_D435_ID = None        # serial number of camera or None if you only have one camera (it will autodetect)
 
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -554,7 +554,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
     if cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435_DEPTH:
         inputs += ['cam/depth_array']
-        types += ['depth_array']
+        types += ['gray16_array']
     
     if cfg.HAVE_IMU or (cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435_IMU):
         inputs += ['imu/acl_x', 'imu/acl_y', 'imu/acl_z',

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -59,6 +59,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     #Initialize car
     V = dk.vehicle.Vehicle()
 
+    print("cfg.CAMERA_TYPE", cfg.CAMERA_TYPE)
     if camera_type == "stereo":
 
         if cfg.CAMERA_TYPE == "WEBCAM":
@@ -82,15 +83,25 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
         V.add(StereoPair(), inputs=['cam/image_array_a', 'cam/image_array_b'], 
             outputs=['cam/image_array'])
+    elif cfg.CAMERA_TYPE == "D435":
+        from donkeycar.parts.realsense435i import RealSense435i
+        cam = RealSense435i(
+            enable_rgb=cfg.REALSENSE_D435_RGB,
+            enable_depth=cfg.REALSENSE_D435_DEPTH,
+            enable_imu=cfg.REALSENSE_D435i_IMU,
+            device_id=cfg.REALSENSE_D435_ID)
+        V.add(cam, inputs=[],
+              outputs=['cam/image_array', 'cam/depth_array',
+                       'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
+                       'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'],
+              threaded=True)
 
     else:
-        print("cfg.CAMERA_TYPE", cfg.CAMERA_TYPE)
         if cfg.DONKEY_GYM:
             from donkeycar.parts.dgym import DonkeyGymEnv 
         
         inputs = []
         threaded = True
-        print("cfg.CAMERA_TYPE", cfg.CAMERA_TYPE)
         if cfg.DONKEY_GYM:
             from donkeycar.parts.dgym import DonkeyGymEnv 
             cam = DonkeyGymEnv(cfg.DONKEY_SIM_PATH, env_name=cfg.DONKEY_GYM_ENV_NAME)
@@ -540,8 +551,12 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     if cfg.TRAIN_BEHAVIORS:
         inputs += ['behavior/state', 'behavior/label', "behavior/one_hot_state_array"]
         types += ['int', 'str', 'vector']
+
+    if cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435_DEPTH:
+        inputs += ['cam/depth_array']
+        types += ['image_array']
     
-    if cfg.HAVE_IMU:
+    if cfg.HAVE_IMU or (cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435i_IMU):
         inputs += ['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
             'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z']
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -88,7 +88,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
         cam = RealSense435i(
             enable_rgb=cfg.REALSENSE_D435_RGB,
             enable_depth=cfg.REALSENSE_D435_DEPTH,
-            enable_imu=cfg.REALSENSE_D435i_IMU,
+            enable_imu=cfg.REALSENSE_D435_IMU,
             device_id=cfg.REALSENSE_D435_ID)
         V.add(cam, inputs=[],
               outputs=['cam/image_array', 'cam/depth_array',
@@ -556,7 +556,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
         inputs += ['cam/depth_array']
         types += ['image_array']
     
-    if cfg.HAVE_IMU or (cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435i_IMU):
+    if cfg.HAVE_IMU or (cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435_IMU):
         inputs += ['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
             'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z']
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -554,7 +554,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
     if cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435_DEPTH:
         inputs += ['cam/depth_array']
-        types += ['image_array']
+        types += ['depth_array']
     
     if cfg.HAVE_IMU or (cfg.CAMERA_TYPE == "D435" and cfg.REALSENSE_D435_IMU):
         inputs += ['imu/acl_x', 'imu/acl_y', 'imu/acl_z',

--- a/donkeycar/vehicle.py
+++ b/donkeycar/vehicle.py
@@ -167,6 +167,8 @@ class Vehicle:
 
         except KeyboardInterrupt:
             pass
+        except Exception as e:
+            print("Exception in vehicle loop: ", str(e))
         finally:
             self.stop()
 

--- a/donkeycar/vehicle.py
+++ b/donkeycar/vehicle.py
@@ -169,7 +169,6 @@ class Vehicle:
         except KeyboardInterrupt:
             pass
         except Exception as e:
-            print("Exception in vehicle loop: ", str(e))
             traceback.print_exc()
         finally:
             self.stop()

--- a/donkeycar/vehicle.py
+++ b/donkeycar/vehicle.py
@@ -11,6 +11,7 @@ import numpy as np
 from threading import Thread
 from .memory import Memory
 from prettytable import PrettyTable
+import traceback
 
 
 class PartProfiler:
@@ -169,6 +170,7 @@ class Vehicle:
             pass
         except Exception as e:
             print("Exception in vehicle loop: ", str(e))
+            traceback.format_exc()
         finally:
             self.stop()
 

--- a/donkeycar/vehicle.py
+++ b/donkeycar/vehicle.py
@@ -170,7 +170,7 @@ class Vehicle:
             pass
         except Exception as e:
             print("Exception in vehicle loop: ", str(e))
-            traceback.format_exc()
+            traceback.print_exc()
         finally:
             self.stop()
 


### PR DESCRIPTION
- enabled using CAMERA_TYPE = 'D435'
- supports RGB, DEPTH and IMU output; each of which can be individually toggled with configuration REALSENSE_D435_xxxx
- supports addressing a camera with a specific ID in the case of multiple cameras (or in presense of T265)
- IMU output is compatible with MPU6050 and IMU model. (Not tested.)
- depth is output as a separate, aligned image in 16bit grayscale png format.  So pixels in depth image can be queried to find the depth of a pixel in the RGB image.