### PR TITLE
Add support for MPU9250

### DIFF
--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -73,5 +73,5 @@ Valid settings are from 0 to 6:
 - `6` 5Hz
 
 ### Notes on MPU9250
-At startup the MPU9250 driver perform a calibration to zero accel and gyro bias. 
+At startup the MPU9250 driver performs calibration to zero accel and gyro bias. Usually the process takes less than 10 seconds, and in that time avoid moving or touching the car.
 Please place the car on the ground before starting Donkey 

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -61,7 +61,7 @@ IMU_DLP_CONFIG = 3
 ```
 `IMU_SENSOR` can be either `mpu6050` or `mpu9250` based on the sensor you are using.
 
-`IMU_DLP_CONFIG` allows to change the digital lowpass filter settings for your imu. Lower frequency settings can filter high frequency noise at the expense of increased latency in imu sensor data.
+`IMU_DLP_CONFIG` allows to change the digital lowpass filter settings for your IMU. Lower frequency settings (see below) can filter high frequency noise at the expense of increased latency in IMU sensor data.
 Valid settings are from 0 to 6:
 
 - `0` 250Hz

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -51,7 +51,8 @@ pip install mpu9250-jmdev
 ```
 
 ### Configuration
-Enable the following configurations to your `myconfig.py`
+Enable the following configurations to your `myconfig.py`:
+
 ``` python
 #IMU
 HAVE_IMU = True

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -59,7 +59,7 @@ HAVE_IMU = True
 IMU_SENSOR = 'mpu9250'          # (mpu6050|mpu9250)
 IMU_DLP_CONFIG = 3
 ```
-`IMU_SENSOR` can be either `mpu6050` or `mpu9250` based on the sensor you are using
+`IMU_SENSOR` can be either `mpu6050` or `mpu9250` based on the sensor you are using.
 
 `IMU_DLP_CONFIG` allows to change the digital lowpass filter settings for your imu. Lower frequency settings can filter high frequency noise at the expense of increased latency in imu sensor data.
 Valid settings are from 0 to 6:

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -57,7 +57,7 @@ Enable the following configurations to your `myconfig.py`:
 #IMU
 HAVE_IMU = True
 IMU_SENSOR = 'mpu9250'          # (mpu6050|mpu9250)
-IMU_DLP_CONFIG = 6
+IMU_DLP_CONFIG = 3
 ```
 `IMU_SENSOR` can be either `mpu6050` or `mpu9250` based on the sensor you are using
 

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -6,7 +6,7 @@ IMUs or inertial measurement units are parts that sense the inertial forces on a
 
 This is a cheap, small, and moderately precise imu. Commonly available at [Amazon](https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Dindustrial&field-keywords=MPU6050).
 
-MPU9250 offer in addition a integrated magnetometer
+MPU9250 offers additional integrated magnetometer.
 
 * Typically uses the I2C interface and can be chained off the default PWM PCA9685 board. This configuration will also provide power.
 * MPU6050: Outputs acceleration X, Y, Z, Gyroscope X, Y, Z, and temperature.

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -74,4 +74,4 @@ Valid settings are from 0 to 6:
 
 ### Notes on MPU9250
 At startup the MPU9250 driver performs calibration to zero accel and gyro bias. Usually the process takes less than 10 seconds, and in that time avoid moving or touching the car.
-Please place the car on the ground before starting Donkey 
+Please place the car on the ground before starting Donkey.

--- a/docs/parts/imu.md
+++ b/docs/parts/imu.md
@@ -2,13 +2,15 @@
 
 IMUs or inertial measurement units are parts that sense the inertial forces on a robot. They vary depending on sensor, but may commonly include linear and rotational accelleration. They may sometimes include magnetometer to give global compasss facing dir. Frequently temperature is available from these as it affects their sensitivity.
 
-## MPU6050
+## MPU6050/MPU9250
 
 This is a cheap, small, and moderately precise imu. Commonly available at [Amazon](https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Dindustrial&field-keywords=MPU6050).
 
+MPU9250 offer in addition a integrated magnetometer
 
 * Typically uses the I2C interface and can be chained off the default PWM PCA9685 board. This configuration will also provide power.
-* Outputs acceleration X, Y, Z, Gyroscope X, Y, Z, and temperature.
+* MPU6050: Outputs acceleration X, Y, Z, Gyroscope X, Y, Z, and temperature.
+* MPU6250: Outputs acceleration X, Y, Z, Gyroscope X, Y, Z, Magnetometer X, Y, Z and temperature.
 * Chip built-in 16bit AD converter, 16bit data output
 * Gyroscopes range: +/- 250 500 1000 2000 degree/sec
 * Acceleration range: ±2 ±4 ±8 ±16g
@@ -32,6 +34,7 @@ cd py-smbus/library
 python setup.py build
 sudo python setup.py install
 ```
+For MPU6050: 
 
 Install pip lib for `mpu6050`:
 
@@ -39,3 +42,35 @@ Install pip lib for `mpu6050`:
 pip install mpu6050-raspberrypi
 ```
 
+For MPU9250: 
+
+Install pip lib for `mpu9250-jmdev`:
+
+```bash
+pip install mpu9250-jmdev
+```
+
+### Configuration
+Enable the following configurations to your `myconfig.py`
+``` python
+#IMU
+HAVE_IMU = True
+IMU_SENSOR = 'mpu9250'          # (mpu6050|mpu9250)
+IMU_DLP_CONFIG = 6
+```
+`IMU_SENSOR` can be either `mpu6050` or `mpu9250` based on the sensor you are using
+
+`IMU_DLP_CONFIG` allows to change the digital lowpass filter settings for your imu. Lower frequency settings can filter high frequency noise at the expense of increased latency in imu sensor data.
+Valid settings are from 0 to 6:
+
+- `0` 250Hz
+- `1` 184Hz
+- `2` 92Hz
+- `3` 41Hz
+- `4` 20Hz 
+- `5` 10Hz
+- `6` 5Hz
+
+### Notes on MPU9250
+At startup the MPU9250 driver perform a calibration to zero accel and gyro bias. 
+Please place the car on the ground before starting Donkey 

--- a/donkeycar/parts/imu.py
+++ b/donkeycar/parts/imu.py
@@ -59,8 +59,9 @@ class MpuIMU:
             if self.sensortype == SENSOR_MPU6050:
                 self.accel, self.gyro, self.temp = self.sensor.get_all_data()
             else:
+                from mpu9250_jmdev.registers import GRAVITY
                 ret = self.sensor.getAllData()
-                self.accel = { 'x' : ret[1], 'y' : ret[2], 'z' : ret[3] }
+                self.accel = { 'x' : ret[1] * GRAVITY, 'y' : ret[2] * GRAVITY, 'z' : ret[3] * GRAVITY }
                 self.gyro = { 'x' : ret[4], 'y' : ret[5], 'z' : ret[6] }
                 self.mag = { 'x' : ret[13], 'y' : ret[14], 'z' : ret[15] }
         except:

--- a/donkeycar/parts/imu.py
+++ b/donkeycar/parts/imu.py
@@ -1,7 +1,7 @@
 import time
 SENSOR_MPU6050 = 'mpu6050'
 SENSOR_MPU9250 = 'mpu9250'
-class MpuIMU:
+class IMU:
     '''
     Installation:
     
@@ -24,8 +24,8 @@ class MpuIMU:
     def __init__(self, addr=0x68, poll_delay=0.0166, sensor=SENSOR_MPU6050):
         self.sensortype = sensor
         if self.sensortype == SENSOR_MPU6050:
-            from mpu6050 import mpu6050
-            self.sensor = mpu6050(addr)
+            from mpu6050 import mpu6050 as MPU6050
+            self.sensor = MPU6050(addr)
         else:
             from mpu9250_jmdev.registers import AK8963_ADDRESS, GFS_1000, AFS_4G, AK8963_BIT_16, AK8963_MODE_C100HZ
             from mpu9250_jmdev.mpu_9250 import MPU9250
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         sensor_type = sys.argv[1]
 
-    p = MpuIMU(sensor=sensor_type)
+    p = IMU(sensor=sensor_type)
     while iter < 100:
         data = p.run()
         print(data)

--- a/donkeycar/parts/imu.py
+++ b/donkeycar/parts/imu.py
@@ -1,6 +1,11 @@
+#!/usr/bin/env python3
 import time
 SENSOR_MPU6050 = 'mpu6050'
 SENSOR_MPU9250 = 'mpu9250'
+
+DLP_SETTING_DISABLED = 0
+CONFIG_REGISTER = 0x1A
+
 class IMU:
     '''
     Installation:
@@ -21,11 +26,15 @@ class IMU:
     
     '''
 
-    def __init__(self, addr=0x68, poll_delay=0.0166, sensor=SENSOR_MPU6050):
+    def __init__(self, addr=0x68, poll_delay=0.0166, sensor=SENSOR_MPU6050, dlp_setting=DLP_SETTING_DISABLED):
         self.sensortype = sensor
         if self.sensortype == SENSOR_MPU6050:
             from mpu6050 import mpu6050 as MPU6050
             self.sensor = MPU6050(addr)
+        
+            if(dlp_setting > 0):
+                self.sensor.bus.write_byte_data(self.sensor.address, CONFIG_REGISTER, dlp_setting)
+        
         else:
             from mpu9250_jmdev.registers import AK8963_ADDRESS, GFS_1000, AFS_4G, AK8963_BIT_16, AK8963_MODE_C100HZ
             from mpu9250_jmdev.mpu_9250 import MPU9250
@@ -39,6 +48,9 @@ class IMU:
                 afs=AFS_4G,
                 mfs=AK8963_BIT_16,
                 mode=AK8963_MODE_C100HZ)
+            
+            if(dlp_setting > 0):
+                self.sensor.writeSlave(CONFIG_REGISTER, dlp_setting)
             self.sensor.calibrateMPU6500()
             self.sensor.configure()
 
@@ -65,6 +77,7 @@ class IMU:
                 self.accel = { 'x' : ret[1] * GRAVITY, 'y' : ret[2] * GRAVITY, 'z' : ret[3] * GRAVITY }
                 self.gyro = { 'x' : ret[4], 'y' : ret[5], 'z' : ret[6] }
                 self.mag = { 'x' : ret[13], 'y' : ret[14], 'z' : ret[15] }
+                self.temp = ret[16]
         except:
             print('failed to read imu!!')
             
@@ -83,9 +96,11 @@ if __name__ == "__main__":
     iter = 0
     import sys
     sensor_type = SENSOR_MPU6050 
-    
+    dlp_setting = DLP_SETTING_DISABLED
     if len(sys.argv) > 1:
         sensor_type = sys.argv[1]
+    if len(sys.argv) > 2:
+        dlp_setting = int(sys.argv[2])
 
     p = IMU(sensor=sensor_type)
     while iter < 100:

--- a/donkeycar/parts/imu.py
+++ b/donkeycar/parts/imu.py
@@ -39,6 +39,7 @@ class MpuIMU:
                 afs=AFS_4G,
                 mfs=AK8963_BIT_16,
                 mode=AK8963_MODE_C100HZ)
+            self.sensor.calibrateMPU6500()
             self.sensor.configure()
 
         

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -146,6 +146,8 @@ SEQUENCE_LENGTH = 3             #some models use a number of images over time. T
 #IMU
 HAVE_IMU = False                #when true, this add a Mpu6050 part and records the data. Can be used with a 
 IMU_SENSOR = 'mpu6050'          # (mpu6050|mpu9250)
+IMU_DLP_CONFIG = 0              # Digital Lowpass Filter setting (0:250Hz, 1:184Hz, 2:92Hz, 3:41Hz, 4:20Hz, 5:10Hz, 6:5Hz)
+
 #SOMBRERO
 HAVE_SOMBRERO = False           #set to true when using the sombrero hat from the Donkeycar store. This will enable pwm on the hat.
 

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -145,7 +145,7 @@ SEQUENCE_LENGTH = 3             #some models use a number of images over time. T
 
 #IMU
 HAVE_IMU = False                #when true, this add a Mpu6050 part and records the data. Can be used with a 
-
+IMU_SENSOR = 'mpu6050'          # (mpu6050|mpu9250)
 #SOMBRERO
 HAVE_SOMBRERO = False           #set to true when using the sombrero hat from the Donkeycar store. This will enable pwm on the hat.
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -263,8 +263,8 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
     #IMU
     if cfg.HAVE_IMU:
-        from donkeycar.parts.imu import Mpu6050
-        imu = Mpu6050()
+        from donkeycar.parts.imu import MpuIMU
+        imu = MpuIMU(sensor=cfg.IMU_SENSOR)
         V.add(imu, outputs=['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
             'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'], threaded=True)
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -263,8 +263,8 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
     #IMU
     if cfg.HAVE_IMU:
-        from donkeycar.parts.imu import MpuIMU
-        imu = MpuIMU(sensor=cfg.IMU_SENSOR)
+        from donkeycar.parts.imu import IMU
+        imu = IMU(sensor=cfg.IMU_SENSOR)
         V.add(imu, outputs=['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
             'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'], threaded=True)
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -264,7 +264,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     #IMU
     if cfg.HAVE_IMU:
         from donkeycar.parts.imu import IMU
-        imu = IMU(sensor=cfg.IMU_SENSOR)
+        imu = IMU(sensor=cfg.IMU_SENSOR, dlp_setting=cfg.IMU_DLP_CONFIG)
         V.add(imu, outputs=['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
             'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'], threaded=True)
 


### PR DESCRIPTION
This MR adds support for MPU9250 (#549). 

To configure an mpu9250 just enable 
` HAVE_IMU = True` 
and set 
`IMU_SENSOR = 'mpu9250'`

