### PR TITLE
Fix USE_FPV

### DIFF
--- a/donkeycar/parts/web_controller/templates/base_fpv.html
+++ b/donkeycar/parts/web_controller/templates/base_fpv.html
@@ -69,7 +69,7 @@
 
 <div class="gap"></div>
 <div>    
-    <img id='mpeg-image', class='img-responsive' src="/video"/> </img>
+    <img id='mpeg-image' class='img-responsive' src="/video"/> </img>
 </div>
 
 </body>

--- a/donkeycar/parts/web_controller/templates/base_fpv.html
+++ b/donkeycar/parts/web_controller/templates/base_fpv.html
@@ -9,7 +9,6 @@
             display: block;
             margin-left: auto;
             margin-right: auto;
-            width: 100%;
             height: 100%;
             border: 2px solid rgb(226, 110, 57);
             border-radius: 8px;
@@ -45,23 +44,33 @@
           padding: 0px;
           height: 61px;
         }
+        
+        .logo {
+            height: 70px
+        }
+        
+        body {
+            margin: 0px
+        }
+        
+        #mpeg-image {
+            width: auto;
+            height: calc(100vh - 80px);
+        }
 
     </style>
 </head>
 
 <div class="row" style="background-color:rgb(226, 110, 57);">
-    <div class="column">
-        <img src="/static/donkeycar-logo-sideways.png" alt="Donkeycar Logo">
-    </div>
-    <div class="column">
-        <h1>Donkey FPV</h1>
-    </div>
+    <img class="logo" src="/static/donkeycar-logo-sideways.png" alt="Donkeycar Logo">
 </div>
 
 <body style="background-color:rgb(48, 49, 51);">
 
 <div class="gap"></div>
-<img id='mpeg-image', class='img-responsive' src="/video"/> </img>
+<div>    
+    <img id='mpeg-image', class='img-responsive' src="/video"/> </img>
+</div>
 
 </body>
 </html>

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -301,7 +301,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
 
     # Use the FPV preview, which will show the cropped image output, or the full frame.
     if cfg.USE_FPV:
-        V.add(WebFpv(), inputs=[inf_input], threaded=True)
+        V.add(WebFpv(), inputs=['cam/image_array'], threaded=True)
 
     #Behavioral state
     if cfg.TRAIN_BEHAVIORS:


### PR DESCRIPTION
1. Fallback USE_FPV to use 'cam/image_array' as inf_input is normalized.
2. The video stream should fit the screen by height instead of width

Note: By using 'cam/image_array' , crop (if set) is not shown in the FPV. Just aim to fix the FPV at the moment as it is a bit tricky to incorporate the crop in the current codebase. Welcome any feedback. Thanks.