### PR TITLE
removed incorrect hashes as per issue 23 in gym-donkeycar

### DIFF
--- a/donkeycar/parts/web_controller/templates/base.html
+++ b/donkeycar/parts/web_controller/templates/base.html
@@ -6,19 +6,19 @@
 
   <script
     src="/static/jquery-3.1.1.min.js"
-    integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
+    integrity=""
     crossorigin="anonymous"></script>
 
   <script
     src="/static/ui/1.12.1/jquery-ui.min.js"
-    integrity="sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU="
+    integrity=""
     crossorigin="anonymous"></script>
 
   <script type="text/javascript" src="/static/nipple.js"></script>
 
 
   <link href="/static/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
-  <script src="/static/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+  <script src="/static/bootstrap/3.3.7/js/bootstrap.min.js" integrity="" crossorigin="anonymous"></script>
 
 
   <script type="text/javascript" src="/static/main.js"></script>


### PR DESCRIPTION
As per this issue: https://github.com/tawnkramer/gym-donkeycar/issues/23

Fixes the UI controller for Windows when running the car in 'traditional' mode.   Google Chrome rejects the files due to this parameter.  Setting it to blank fixes the error.