### PR TITLE
tubplot option fix

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -525,9 +525,9 @@ class ShowPredictionPlots(BaseCommand):
 
     def parse_args(self, args):
         parser = argparse.ArgumentParser(prog='tubplot', usage='%(prog)s [options]')
-        parser.add_argument('--tub', nargs='+', help='paths to tubs')
+        parser.add_argument('--tub', nargs='+', help='The tub to make plot from')
         parser.add_argument('--model', default=None, help='name of record to create histogram')
-        parser.add_argument('--limit', default=1000, help='how many records to process')
+        parser.add_argument('--limit', type=int, default=1000, help='how many records to process')
         parser.add_argument('--type', default=None, help='model type')
         parser.add_argument('--config', default='./config.py', help='location of config file to use. default: ./config.py')
         parsed_args = parser.parse_args(args)


### PR DESCRIPTION
I think,  tubplot option in management/base.py is mistaking.
--tub is only one. I changed help message.
--limit is integer. I add type=int.