### PR TITLE
Allow data augmentation on tub outside of training

### DIFF
--- a/docs/utility/donkey.md
+++ b/docs/utility/donkey.md
@@ -102,6 +102,20 @@ donkey tubcheck <tub_path> [--fix]
 * It will print the records that throw an exception while reading
 * The optional `--fix` will delete records that have problems
 
+## Augment Tub
+
+This command allows you to perform the data augmentation on a tub or set of tubs directly. The augmentation is also available in training via the `--aug` flag. Preprocessing the tub can speed up the training as the augmentation can take some time. Also you can train with the unmodified tub and the augmented tub joined together. 
+
+Usage:
+
+```bash
+donkey tubaugment <tub_path> [--inplace]
+```
+
+* Run on the host computer or the robot
+* The optional `--inplace` will replace the original tub images when provided. Otherwise `tub_XY_YY-MM-DD` will be copied to a new tub `tub_XX_aug_YY-MM-DD` and the original data remains unchanged
+
+
 ## Histogram
 
 This command will show a pop-up window showing the histogram of record values in a given tub.

--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -546,10 +546,10 @@ class TubAugment(BaseCommand):
         parser = argparse.ArgumentParser(prog='tubaugment',
                                          usage='%(prog)s [options]')
         parser.add_argument('tubs', nargs='+', help='paths to tubs')
-        parser.add_argument('--inplace',
-                            default=False,
+        parser.add_argument('--inplace', dest='inplace', action='store_true',
                             help='If tub should be changed in place or new '
                                  'tub will be created')
+        parser.set_defaults(inplace=False)
         parsed_args = parser.parse_args(args)
         return parsed_args
 

--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -457,8 +457,7 @@ class TubReader(Tub):
         API function needed to use as a Donkey part.
         Accepts keys to read from the tub and retrieves them sequentially.
         """
-        record_dict = self.get_record(self.read_ix)
-        self.read_ix += 1
+        record_dict = self.get_record()
         record = [record_dict[key] for key in args]
         return record
 

--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -17,6 +17,9 @@ import pandas as pd
 
 from PIL import Image
 
+from donkeycar.parts.augment import augment_pil_image
+from donkeycar.utils import arr_to_img
+
 
 class Tub(object):
     """
@@ -93,7 +96,6 @@ class Tub(object):
 
             raise AttributeError(msg)
 
-
     def get_last_ix(self):
         index = self.get_index()           
         return max(index)
@@ -107,11 +109,10 @@ class Tub(object):
             self.update_df()
         return self.df
 
-
     def get_index(self, shuffled=True):
         files = next(os.walk(self.path))[2]
-        record_files = [f for f in files if f[:6]=='record']
-        
+        record_files = [f for f in files if f[:6] == 'record']
+
         def get_file_ix(file_name):
             try:
                 name = file_name.split('.')[0]
@@ -128,7 +129,6 @@ class Tub(object):
             nums = sorted(nums)
             
         return nums 
-
 
     @property
     def inputs(self):
@@ -147,7 +147,7 @@ class Tub(object):
         try:
             with open(path, 'w') as fp:
                 json.dump(json_data, fp)
-                #print('wrote record:', json_data)
+
         except TypeError:
             print('troubles with record:', json_data)
         except FileNotFoundError:
@@ -161,11 +161,8 @@ class Tub(object):
         files = glob.glob(os.path.join(self.path, 'record_*.json'))
         return len(files)
 
-
-
-
     def make_record_paths_absolute(self, record_dict):
-        #make paths absolute
+        # make paths absolute
         d = {}
         for k, v in record_dict.items():
             if type(v) == str: #filename
@@ -175,14 +172,11 @@ class Tub(object):
 
         return d
 
-
-
-
     def check(self, fix=False):
-        '''
+        """
         Iterate over all records and make sure we can load them.
         Optionally remove records that cause a problem.
-        '''
+        """
         print('Checking tub:%s.' % self.path)
         print('Found: %d records.' % self.get_num_records())
         problems = False
@@ -253,9 +247,9 @@ class Tub(object):
         return self.current_ix
 
     def erase_last_n_records(self, num_erase):
-        '''
+        """
         erase N records from the disc and move current back accordingly
-        '''
+        """
         last_erase = self.current_ix
         first_erase = last_erase - num_erase
         self.current_ix = first_erase - 1
@@ -271,13 +265,13 @@ class Tub(object):
         json_path = self.get_json_record_path(i)
         if os.path.exists(json_path):
             os.unlink(json_path)
-        img_filename = '%d_cam-image_array_.jpg' % (i)
+        img_filename = '%d_cam-image_array_.jpg' % i
         img_path = os.path.join(self.path, img_filename)
         if os.path.exists(img_path):
             os.unlink(img_path)
 
     def get_json_record_path(self, ix):
-        return os.path.join(self.path, 'record_'+str(ix)+'.json')
+        return os.path.join(self.path, 'record_' + str(ix) + '.json')
 
     def get_json_record(self, ix):
         path = self.get_json_record_path(ix)
@@ -295,43 +289,36 @@ class Tub(object):
         record_dict = self.make_record_paths_absolute(json_data)
         return record_dict
 
-
     def get_record(self, ix):
-
         json_data = self.get_json_record(ix)
         data = self.read_record(json_data)
         return data
 
-
-
     def read_record(self, record_dict):
-        data={}
+        data = {}
         for key, val in record_dict.items():
             typ = self.get_input_type(key)
-
-            #load objects that were saved as separate files
+            # load objects that were saved as separate files
             if typ == 'image_array':
                 img = Image.open((val))
                 val = np.array(img)
-
             data[key] = val
-
-
         return data
 
-
     def gather_records(self):
-        ri = lambda fnm : int( os.path.basename(fnm).split('_')[1].split('.')[0] )
-
+        ri = lambda fnm: int(os.path.basename(fnm).split('_')[1].split('.')[0])
         record_paths = glob.glob(os.path.join(self.path, 'record_*.json'))
         if len(self.exclude) > 0:
             record_paths = [f for f in record_paths if ri(f) not in self.exclude]
         record_paths.sort(key=ri)
         return record_paths
 
-    def make_file_name(self, key, ext='.png'):
-        name = '_'.join([str(self.current_ix), key, ext])
-        name = name = name.replace('/', '-')
+    def make_file_name(self, key, ext='.png', ix=None):
+        this_ix = ix
+        if this_ix is None:
+            this_ix = self.current_ix
+        name = '_'.join([str(this_ix), key, ext])
+        name = name.replace('/', '-')
         return name
 
     def delete(self):
@@ -341,7 +328,6 @@ class Tub(object):
 
     def shutdown(self):
         pass
-
 
     def excluded(self, index):
         return index in self.exclude
@@ -355,20 +341,41 @@ class Tub(object):
         except:
             pass
 
+    def augment_images(self):
+        # Get all record's index
+        index = self.get_index(shuffled=False)
+        # Go through index
+        count = 0
+        for ix in index:
+            data = self.get_record(ix)
+            for key, val in data.items():
+                typ = self.get_input_type(key)
+                if typ == 'image_array':
+                    # here val is an img_arr
+                    img = arr_to_img(val)
+                    # then augment and denormalise
+                    img_aug = augment_pil_image(img)
+                    name = self.make_file_name(key, ext='.jpg', ix=ix)
+                    try:
+                        img_aug.save(os.path.join(self.path, name))
+                        count += 1
+                    except IOError as err:
+                        print(err)
+        print('Augmenting', count, 'images in', self.path)
+
     def write_exclude(self):
         if 0 == len(self.exclude):
             # If the exclude set is empty don't leave an empty file around.
             if os.path.exists(self.exclude_path):
                 os.unlink(self.exclude_path)
         else:
-            with open(self.exclude_path,'w') as f:
-                json.dump( list(self.exclude), f )
+            with open(self.exclude_path, 'w') as f:
+                json.dump(list(self.exclude), f)
 
     def get_record_gen(self, record_transform=None, shuffle=True, df=None):
 
         if df is None:
             df = self.get_df()
-
 
         while True:
             for _, row in self.df.iterrows():
@@ -381,15 +388,13 @@ class Tub(object):
                     record_dict = record_transform(record_dict)
 
                 record_dict = self.read_record(record_dict)
-
                 yield record_dict
-
 
     def get_batch_gen(self, keys, record_transform=None, batch_size=128, shuffle=True, df=None):
 
         record_gen = self.get_record_gen(record_transform, shuffle=shuffle, df=df)
 
-        if keys == None:
+        if keys is None:
             keys = list(self.df.columns)
 
         while True:
@@ -400,12 +405,9 @@ class Tub(object):
             batch_arrays = {}
             for i, k in enumerate(keys):
                 arr = np.array([r[k] for r in record_list])
-                # if len(arr.shape) == 1:
-                #    arr = arr.reshape(arr.shape + (1,))
                 batch_arrays[k] = arr
 
             yield batch_arrays
-
 
     def get_train_gen(self, X_keys, Y_keys, batch_size=128, record_transform=None, df=None):
 
@@ -417,7 +419,6 @@ class Tub(object):
             X = [batch[k] for k in X_keys]
             Y = [batch[k] for k in Y_keys]
             yield X, Y
-
 
     def get_train_val_gen(self, X_keys, Y_keys, batch_size=128, record_transform=None, train_frac=.8):
         train_df = train=self.df.sample(frac=train_frac,random_state=200)
@@ -432,23 +433,16 @@ class Tub(object):
         return train_gen, val_gen
 
 
-
-
-
 class TubWriter(Tub):
     def __init__(self, *args, **kwargs):
         super(TubWriter, self).__init__(*args, **kwargs)
 
     def run(self, *args):
-        '''
-        API function needed to use as a Donkey part.
-
-        Accepts values, pairs them with their inputs keys and saves them
-        to disk.
-        '''
+        """
+        API function needed to use as a Donkey part. Accepts values,
+        pairs them with their inputs keys and saves them to disk.
+        """
         assert len(self.inputs) == len(args)
-
-        self.record_time = int(time.time() - self.start_time)
         record = dict(zip(self.inputs, args))
         self.put_record(record)
         return self.current_ix
@@ -459,22 +453,21 @@ class TubReader(Tub):
         super(TubReader, self).__init__(*args, **kwargs)
 
     def run(self, *args):
-        '''
+        """
         API function needed to use as a Donkey part.
-
         Accepts keys to read from the tub and retrieves them sequentially.
-        '''
-
-        record = self.get_record()
-        record = [record[key] for key in args ]
+        """
+        record_dict = self.get_record(self.read_ix)
+        self.read_ix += 1
+        record = [record_dict[key] for key in args]
         return record
 
 
-class TubHandler():
+class TubHandler:
     def __init__(self, path):
         self.path = os.path.expanduser(path)
 
-    def get_tub_list(self,path):
+    def get_tub_list(self, path):
         folders = next(os.walk(path))[1]
         return folders
 
@@ -488,14 +481,13 @@ class TubHandler():
 
         folders = self.get_tub_list(path)
         numbers = [get_tub_num(x) for x in folders]
-        #numbers = [i for i in numbers if i is not None]
         next_number = max(numbers+[0]) + 1
         return next_number
 
     def create_tub_path(self):
         tub_num = self.next_tub_number(self.path)
         date = datetime.datetime.now().strftime('%y-%m-%d')
-        name = '_'.join(['tub',str(tub_num),date])
+        name = '_'.join(['tub', str(tub_num), date])
         tub_path = os.path.join(self.path, name)
         return tub_path
 
@@ -503,7 +495,6 @@ class TubHandler():
         tub_path = self.create_tub_path()
         tw = TubWriter(path=tub_path, inputs=inputs, types=types, user_meta=user_meta)
         return tw
-
 
 
 class TubImageStacker(Tub):
@@ -566,7 +557,6 @@ class TubImageStacker(Tub):
         return data
 
 
-
 class TubTimeStacker(TubImageStacker):
     '''
     A Tub for training N with records stacked through time. 
@@ -604,7 +594,7 @@ class TubTimeStacker(TubImageStacker):
             for key, val in json_data.items():
                 typ = self.get_input_type(key)
 
-                #load only the first image saved as separate files
+                # load only the first image saved as separate files
                 if typ == 'image' and i == 0:
                     val = Image.open(os.path.join(self.path, val))
                     data[key] = val                    
@@ -634,16 +624,13 @@ class TubGroup(Tub):
             record_count += len(t.df)
             self.input_types.update(dict(zip(t.inputs, t.types)))
 
-        print('joining the tubs {} records together. This could take {} minutes.'.format(record_count,
-                                                                                         int(record_count / 300000)))
+        print('joining the tubs {} records together. This could take {} minutes.'
+              .format(record_count, int(record_count / 300000)))
 
         self.meta = {'inputs': list(self.input_types.keys()),
                      'types': list(self.input_types.values())}
 
-
         self.df = pd.concat([t.df for t in tubs], axis=0, join='inner')
-
-
 
     def find_tub_paths(self, path):
         matches = []
@@ -652,7 +639,6 @@ class TubGroup(Tub):
             if os.path.isdir(file):
                 matches.append(os.path.join(os.path.abspath(file)))
         return matches
-
 
     def resolve_tub_paths(self, path_list):
         path_list = path_list.split(",")

--- a/donkeycar/tests/test_tub.py
+++ b/donkeycar/tests/test_tub.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
+import os
 import tempfile
 import unittest
-from donkeycar.parts.datastore import TubWriter, Tub
+
 from donkeycar.parts.datastore import TubHandler
-import os
+from donkeycar.parts.datastore import TubWriter, Tub
+from donkeycar.utils import arr_to_img, img_to_arr
+from PIL import ImageChops
 
-import pytest
-
-#fixtures
+# fixtures
 from .setup import tub, tub_path
 
 
@@ -26,10 +27,10 @@ def test_tub_update_df(tub):
 def test_tub_add_record(tub):
     """Tub can save a record and then retrieve it."""
     import numpy as np
-    img_arr = np.zeros((120,160))
-    x=123
-    y=90
-    rec_in  = {'cam/image_array': img_arr, 'user/angle': x, 'user/throttle':y}
+    img_arr = np.zeros((120, 160))
+    x = 123
+    y = 90
+    rec_in = {'cam/image_array': img_arr, 'user/angle': x, 'user/throttle': y}
     rec_index = tub.put_record(rec_in)
     rec_out = tub.get_record(rec_index)
     # Ignore the milliseconds key, which is added when the record is written
@@ -39,11 +40,12 @@ def test_tub_add_record(tub):
 
 
 def test_tub_write_numpy(tub):
-    """Tub can save a record that contains a numpy float, and retrieve it as a python float."""
+    """Tub can save a record that contains a numpy float, and retrieve it as a
+        python float."""
     import numpy as np
-    x=123
-    z=np.float32(11.1)
-    rec_in  = {'user/angle': x, 'user/throttle':z}
+    x = 123
+    z = np.float32(11.1)
+    rec_in = {'user/angle': x, 'user/throttle':z}
     rec_index = tub.put_record(rec_in)
     rec_out = tub.get_record(rec_index)
     assert type(rec_out['user/throttle']) == float
@@ -51,18 +53,50 @@ def test_tub_write_numpy(tub):
 
 def test_tub_exclude(tub):
     """ Make sure the Tub will exclude records in the exclude set """
-    ri = lambda fnm : int( os.path.basename(fnm).split('_')[1].split('.')[0] )
+    ri = lambda fnm: int(os.path.basename(fnm).split('_')[1].split('.')[0])
 
     before = tub.gather_records()
-    assert len(before) == tub.get_num_records() # Make sure we gathered records correctly
+    # Make sure we gathered records correctly
+    assert len(before) == tub.get_num_records()
     tub.exclude.add(1)
     after = tub.gather_records()
-    assert len(after) == (tub.get_num_records() - 1) # Make sure we excluded the correct number of records
+    # Make sure we excluded the correct number of records
+    assert len(after) == (tub.get_num_records() - 1)
     before = set([ri(f) for f in before])
     after = set([ri(f) for f in after])
     diff = before - after
     assert len(diff) == 1
-    assert 1 in diff # Make sure we exclude the correct index
+    # Make sure we exclude the correct index
+    assert 1 in diff
+
+
+def test_tub_augment(tub):
+    """Tub with augmented images which only differ slightly."""
+    import numpy as np
+    index = tub.get_index(shuffled=False)
+    img_arr_before = [tub.get_record(ix)['cam/image_array'] for ix in index]
+    tub.augment_images()
+    img_arr_after = [tub.get_record(ix)['cam/image_array'] for ix in index]
+    total_change = 0
+    for img_arr_b, img_arr_a in zip(img_arr_before, img_arr_after):
+        assert img_arr_a.shape == img_arr_b.shape, 'image size broken'
+        img_a = arr_to_img(img_arr_a)
+        img_b = arr_to_img(img_arr_b)
+        diff = ImageChops.difference(img_a, img_b)
+        diff_arr = img_to_arr(diff)
+        # normalise this number
+        num_pixel_channel = np.prod(diff_arr.shape)
+        avg_change = diff_arr.sum() / num_pixel_channel
+        # check that the augmented image is different
+        assert avg_change != 0, "Augmentation didn't do anything"
+        # change per chanel can be maximally 255 in 8-bit
+        total_change += avg_change
+
+    # An average change of 1 (per 255) would be already too big on the moving
+    # square images. Empirically we see changes in the order of 0.1
+    assert total_change / len(img_arr_before) < 1.0, \
+        'The augmented pictures differ too much.'
+
 
 class TestTubWriter(unittest.TestCase):
     def setUp(self):

--- a/donkeycar/tests/test_tub.py
+++ b/donkeycar/tests/test_tub.py
@@ -87,8 +87,9 @@ def test_tub_augment(tub):
         # normalise this number
         num_pixel_channel = np.prod(diff_arr.shape)
         avg_change = diff_arr.sum() / num_pixel_channel
-        # check that the augmented image is different
-        assert avg_change != 0, "Augmentation didn't do anything"
+        # check that the augmented image is different if not totally black
+        if img_arr_b.max() > 0:
+            assert avg_change != 0, "Augmentation didn't do anything"
         # change per chanel can be maximally 255 in 8-bit
         total_change += avg_change
 


### PR DESCRIPTION
# Stand-alone data augmentation on tubs
The data augmentation can be enabled in training by passing the `--aug` flag. However, this setting slows down training by a bit, in particular if the tub contains > 100k records. This change contains the following:
* Adding a new member function to the `Tub` through which augmentation can be performed on the  images in place
* Adding a new donkey command `donkey tubaugment` to call the above function with the option `--inplace`. If omitted a new tub is created instead of the manipulation of the existing images.
* There is a small refactoring in `augment.py` to decouple the image transformation from numpy arrays to PIL and back. Also the color scaling has been increased from[0.0, 1.0] to [0.0, 2.0].
* Adding the new command `donkey tubaugment` to the docs
* Small bits of pep-8 reformatting

On my MacBook the image augmentation takes around 3ms, running this as part of the training w/ 100k records adds about 5min / epoch process time. On colab adding the `--aug` flag makes the training prohibitively slow on such a data set. I had to re-start the colab session kernel several times to get it to complete. Augmenting the tub data exogenously also allows to train on both sets of data.