### PR TITLE
Restrict support to python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 ---
 language: python
-
+# this is required for python 3.7
+dist: xenial
 # This list should match the versions listed in setup.py
 python:
-  - 3.5
-  - 3.6
+- 3.6
+- 3.7
 
 os:
   - linux

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(name='donkeycar',
           # Specify the Python versions you support here. In particular, ensure
           # that you indicate whether you support Python 2, Python 3 or both.
 
-          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
       ],


### PR DESCRIPTION
# Stop supporting Python 3.5
Raspbian Buster is using Python 3.7. Previous OS Stretch was on Python 3.5 which now seems outdated. Raspberry Pi4 are coming with Buster but RPi 3 users should upgrade their OS. For compatibility to older Python installations on the PC version 3.6 is kept. 