### PR TITLE
Add real-time calibration 

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -91,10 +91,12 @@ class CreateCar(BaseCommand):
         config_template_path = os.path.join(TEMPLATES_PATH, 'cfg_' + template + '.py')
         myconfig_template_path = os.path.join(TEMPLATES_PATH, 'myconfig.py')
         train_template_path = os.path.join(TEMPLATES_PATH, 'train.py')
+        calibrate_template_path = os.path.join(TEMPLATES_PATH, 'calibrate.py')
         car_app_path = os.path.join(path, 'manage.py')
         car_config_path = os.path.join(path, 'config.py')
         mycar_config_path = os.path.join(path, 'myconfig.py')
         train_app_path = os.path.join(path, 'train.py')
+        calibrate_app_path = os.path.join(path, 'calibrate.py')        
         
         if os.path.exists(car_app_path) and not overwrite:
             print('Car app already exists. Delete it and rerun createcar to replace.')
@@ -113,6 +115,12 @@ class CreateCar(BaseCommand):
         else:
             print("Copying train script. Adjust these before starting your car.")
             shutil.copyfile(train_template_path, train_app_path)
+            
+        if os.path.exists(calibrate_app_path) and not overwrite:
+            print('Calibrate already exists. Delete it and rerun createcar to replace.')
+        else:
+            print("Copying calibrate script. Adjust these before starting your car.")
+            shutil.copyfile(calibrate_template_path, calibrate_app_path)
 
         if not os.path.exists(mycar_config_path):
             print("Copying my car config overrides")

--- a/donkeycar/parts/web_controller/templates/calibrate.html
+++ b/donkeycar/parts/web_controller/templates/calibrate.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1">
+    <title>Donkey Real-time calibration</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+        integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+
+</head>
+
+
+<body>
+    <h1>Donkey Real-time calibration</h1>
+
+
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <textarea id="replyBox" rows="40" cols="60">
+                </textarea>
+            </div>
+            <div class="col">
+                <h2>Introduction</h2>
+                <p> This page allow you to dynamically re-adjust the calibration
+                    value of PCA9685 or MM1. Please note that after finding the
+                    desire value, you need to update the value in myconfig.py manually </p>
+                <h2>Instruction</h2>
+
+                <h3>Steering</h3>
+                <p>Simply use +/- and your steering will be adjusted
+                    incrementally</p>
+
+                <h3>Throttle</h3>
+                <p>After adjusting the throttle value, use the up arrow will
+                    trigger a 5 seconds (default, configurable below) full throttle to test the result</p>
+
+                <form name="calibrate_form">
+                    <fieldset>
+
+                        <legend>PCA9685</legend>
+                        <div>
+                            <label for="STEERING_LEFT_PWM">
+                                <span>STEERING_LEFT_PWM:</span>
+                                <input name="STEERING_LEFT_PWM" type="text" value="460"> </input>
+                                <input type="button" value="+">
+                                <input type="button" value="-">
+                            </label>
+                        </div>
+                        <div>
+                            <label for="STEERING_RIGHT_PWM">
+                                <span>STEERING_RIGHT_PWM:</span>
+                                <input name="STEERING_RIGHT_PWM" type="text" value="290"> </input>
+                                <input type="button" value="+">
+                                <input type="button" value="-">
+                            </label>
+                        </div>
+                        <p>
+                            <label for="THROTTLE_FORWARD_PWM">
+                                <span>THROTTLE_FORWARD_PWM:</span>
+                                <input name="THROTTLE_FORWARD_PWM" type="text" value="500"> </input>
+                                <input type="button" value="+">
+                                <input type="button" value="-">
+                            </label>
+                        </p>
+                    </fieldset>
+
+
+                    <fieldset>
+                        <legend>MM1</legend>
+                        <div>
+                            <label for="MM1_STEERING_MID">
+                                <span>MM1_STEERING_MID:</span>
+                                <input name="MM1_STEERING_MID" type="text" value="1500"> </input>
+                                <input type="button" value="+">
+                                <input type="button" value="-">
+                            </label>
+                        </div>
+
+                        <p>
+                            <label for="MM1_MAX_FORWARD">
+                                <span>MM1_MAX_FORWARD:</span>
+                                <input name="MM1_MAX_FORWARD" type="text" value="1800"> </input>
+                                <input type="button" value="+">
+                                <input type="button" value="-">
+                            </label>
+                        </p>
+                        
+                        <p>
+                            <label for="MM1_MAX_REVERSE">
+                                <span>MM1_MAX_REVERSE:</span>
+                                <input name="MM1_MAX_REVERSE" type="text" value="1200"> </input>
+                                <input type="button" value="+">
+                                <input type="button" value="-">
+                            </label>
+                        </p>
+
+                    </fieldset>
+
+
+                    <fieldset>
+                        <legend>Calibrate Settings</legend>
+
+                        <div>
+                            <span>Throttle seconds:</span>
+                            <input name="throttle_second" type="text" value="5">
+                            </input> seconds
+                        </div>
+
+                    </fieldset>
+
+
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.1/jquery.min.js"></script>
+
+
+    <script>
+        $(document).ready(function () {
+            var textarea = document.getElementById('replyBox');
+
+            var buttons = $('input[type=button]')
+
+            buttons.click(function () {
+                $(this).css('color', 'blue')
+                button_value = $(this).val()
+
+                console.log(button_value)
+
+
+                text_el = $(this).parent().find('input[type=text]')
+
+
+                var config_value = parseInt(text_el.val())
+                if (button_value == '+') {
+                    config_value = config_value + 10
+                } else {
+                    config_value = config_value - 10
+                }
+
+                text_el.val(config_value)
+
+                var config_name = text_el.attr('name')
+
+                var data = { 'config': { [config_name]: config_value } }
+                sendMsg(data)
+
+            });
+
+            autoscroll = function (event) {
+                textarea.scrollTop = textarea.scrollHeight
+            }
+
+            var socket = new WebSocket('ws://' + window.location.hostname + ':8887/wsCalibrate');
+
+            socket.onopen = async function (event) {
+                textarea.append('Connected');
+
+
+            }
+
+            socket.onmessage = function (event) {
+                textarea.append(event.data + "\n");
+                autoscroll()
+
+                console.log(event.data);
+            };
+
+            socket.addEventListener('error', function (event) {
+                console.log(event)
+                textarea.append(event);
+            });
+
+
+            socket.addEventListener('close', (event) => {
+                console.log('The connection has been closed successfully.');
+            });
+
+
+            $(window).unload(function (event) {
+                $('#replyBox').append('socket closed');
+                socket.close();
+            });
+
+            function sendMsg(data) {
+                msg = JSON.stringify(data)
+                socket.send(msg)
+                textarea.append(msg + '\n');
+
+                autoscroll()
+            }
+
+            $(document).keydown(async function (e) {
+                switch (e.which) {
+                    case 37: // left
+                        MM1_STEERING_MID = MM1_STEERING_MID - 10
+                        data = { config: { 'MM1_STEERING_MID': MM1_STEERING_MID } }
+                        sendMsg(data)
+                        break;
+
+                    case 38: // up
+                        data = { "angle": 0.0, "throttle": 1.0, "recording": true, "drive_mode": "user" }
+                        sendMsg(data)
+                        throttle_second = $('input[name="throttle_second"]').val()
+                        await sleep(throttle_second * 1000)
+                        data = { "angle": 0.0, "throttle": 0.0, "recording": true, "drive_mode": "user" }
+
+                        sendMsg(data)
+                        break;
+
+                    case 39: // right
+                        MM1_STEERING_MID = MM1_STEERING_MID + 10
+                        data = { config: { 'MM1_STEERING_MID': MM1_STEERING_MID } }
+                        sendMsg(data)
+
+                        break;
+
+                    case 40: // down
+                        data = { "angle": 0.0, "throttle": -1.0, "recording": true, "drive_mode": "user" }
+                        sendMsg(data)
+                        await sleep(500)
+                        data = { "angle": 0.0, "throttle": 0.0, "recording": true, "drive_mode": "user" }
+
+                        sendMsg(data)
+
+                        break;
+
+                    default: return; // exit this handler for other keys
+                }
+                e.preventDefault(); // prevent the default action (scroll / move caret)
+            });
+
+
+            function sleep(ms) {
+                return new Promise(resolve => setTimeout(resolve, ms));
+            }
+
+        });
+
+    </script>
+</body>
+
+</html>

--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -7,7 +7,7 @@ Created on Sat Jun 24 20:10:44 2017
 
 remotes.py
 
-The client and web server needed to control a car remotely. 
+The client and web server needed to control a car remotely.
 """
 
 
@@ -31,9 +31,9 @@ from ... import utils
 class RemoteWebServer():
     '''
     A controller that repeatedly polls a remote webserver and expects
-    the response to be angle, throttle and drive mode. 
+    the response to be angle, throttle and drive mode.
     '''
-    
+
     def __init__(self, remote_url, connection_timeout=.25):
 
         self.control_url = remote_url
@@ -47,8 +47,8 @@ class RemoteWebServer():
 
     def update(self):
         '''
-        Loop to run in separate thread the updates angle, throttle and 
-        drive mode. 
+        Loop to run in separate thread the updates angle, throttle and
+        drive mode.
         '''
 
         while True:
@@ -56,7 +56,7 @@ class RemoteWebServer():
             self.angle, self.throttle, self.mode, self.recording = self.run()
 
     def run_threaded(self):
-        ''' 
+        '''
         Return the last state given from the remote server.
         '''
         return self.angle, self.throttle, self.mode, self.recording
@@ -64,9 +64,9 @@ class RemoteWebServer():
     def run(self):
         '''
         Posts current car sensor data to webserver and returns
-        angle and throttle recommendations. 
+        angle and throttle recommendations.
         '''
-        
+
         data = {}
         response = None
         while response is None:
@@ -96,13 +96,13 @@ class RemoteWebServer():
 
     def shutdown(self):
         pass
-    
-    
+
+
 class LocalWebController(tornado.web.Application):
 
     def __init__(self, port=8887, mode='user'):
-        ''' 
-        Create and publish variables needed on many of 
+        '''
+        Create and publish variables needed on many of
         the web handlers.
         '''
 
@@ -115,7 +115,7 @@ class LocalWebController(tornado.web.Application):
         self.mode = mode
         self.recording = False
         self.port = port
-        
+
         self.num_records = 0
         self.wsclients = []
 
@@ -124,6 +124,8 @@ class LocalWebController(tornado.web.Application):
             (r"/", RedirectHandler, dict(url="/drive")),
             (r"/drive", DriveAPI),
             (r"/wsDrive", WebSocketDriveAPI),
+            (r"/wsCalibrate", WebSocketCalibrateAPI),
+            (r"/calibrate", CalibrateHandler),
             (r"/video", VideoAPI),
             (r"/static/(.*)", StaticFileHandler,
              {"path": self.static_file_path}),
@@ -149,9 +151,9 @@ class LocalWebController(tornado.web.Application):
             if self.num_records % 10 == 0:
                 for wsclient in self.wsclients:
                     wsclient.write_message(json.dumps({'num_records': self.num_records}))
-        
+
         return self.angle, self.throttle, self.mode, self.recording
-        
+
     def run(self, img_arr=None):
         self.img_arr = img_arr
         return self.angle, self.throttle, self.mode, self.recording
@@ -178,6 +180,12 @@ class DriveAPI(RequestHandler):
         self.application.recording = data['recording']
 
 
+class CalibrateHandler(RequestHandler):
+    """ Serves the calibration web page"""
+    async def get(self):
+        await self.render("templates/calibrate.html")
+
+
 class WebSocketDriveAPI(tornado.websocket.WebSocketHandler):
     def check_origin(self, origin):
         return True
@@ -196,6 +204,51 @@ class WebSocketDriveAPI(tornado.websocket.WebSocketHandler):
     def on_close(self):
         # print("Client disconnected")
         self.application.wsclients.remove(self)
+
+
+class WebSocketCalibrateAPI(tornado.websocket.WebSocketHandler):
+    def check_origin(self, origin):
+        return True
+
+    def open(self):
+        print("New client connected")
+
+    def on_message(self, message):
+        print(f"wsCalibrate {message}")
+        data = json.loads(message)
+        if 'throttle' in data:
+            print(data['throttle'])
+            self.application.throttle = data['throttle']
+
+        if 'config' in data:
+            config = data['config']
+            if self.application.drive_train_type == "SERVO_ESC":
+                if 'STEERING_LEFT_PWM' in config:
+                    self.application.drive_train['steering'].left_pulse = config['STEERING_LEFT_PWM']
+
+                if 'STEERING_RIGHT_PWM' in config:
+                    self.application.drive_train['steering'].right_pulse = config['STEERING_RIGHT_PWM']
+
+                if 'THROTTLE_FORWARD_PWM' in config:
+                    self.application.drive_train['throttle'].max_pulse = config['THROTTLE_FORWARD_PWM']
+
+                if 'THROTTLE_STOPPED_PWM' in config:
+                    self.application.drive_train['throttle'].zero_pulse = config['THROTTLE_STOPPED_PWM']
+
+                if 'THROTTLE_REVERSE_PWM' in config:
+                    self.application.drive_train['throttle'].min_pulse = config['THROTTLE_REVERSE_PWM']
+
+            elif self.application.drive_train_type == "MM1":
+                if 'MM1_STEERING_MID' in config:
+                    self.application.drive_train.STEERING_MID = config['MM1_STEERING_MID']
+                if 'MM1_MAX_FORWARD' in config:
+                    self.application.drive_train.MAX_FORWARD = config['MM1_MAX_FORWARD']
+                if 'MM1_MAX_REVERSE' in config:
+                    self.application.drive_train.MAX_REVERSE = config['MM1_MAX_REVERSE']
+
+
+    def on_close(self):
+        print("Client disconnected")
 
 
 class VideoAPI(RequestHandler):

--- a/donkeycar/templates/calibrate.py
+++ b/donkeycar/templates/calibrate.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Scripts to drive a donkey 2 car
+
+Usage:
+    manage.py (drive)
+
+
+Options:
+    -h --help          Show this screen.
+"""
+import os
+import time
+
+from docopt import docopt
+
+import donkeycar as dk
+
+#import parts
+from donkeycar.parts.controller import LocalWebController, \
+    JoystickController, WebFpv
+from donkeycar.parts.throttle_filter import ThrottleFilter
+from donkeycar.utils import *
+
+from socket import gethostname
+
+def drive(cfg ):
+    '''
+    Construct a working robotic vehicle from many parts.
+    Each part runs as a job in the Vehicle loop, calling either
+    it's run or run_threaded method depending on the constructor flag `threaded`.
+    All parts are updated one after another at the framerate given in
+    cfg.DRIVE_LOOP_HZ assuming each part finishes processing in a timely manner.
+    Parts may have named outputs and inputs. The framework handles passing named outputs
+    to parts requesting the same named input.
+    '''
+
+    #Initialize car
+    V = dk.vehicle.Vehicle()
+
+    ctr = LocalWebController()
+    V.add(ctr,
+          inputs=['cam/image_array', 'tub/num_records'],
+          outputs=['angle', 'throttle', 'user/mode', 'recording'],
+          threaded=True)
+
+    #this throttle filter will allow one tap back for esc reverse
+    th_filter = ThrottleFilter()
+    V.add(th_filter, inputs=['throttle'], outputs=['throttle'])
+
+    drive_train = None
+
+    #Drive train setup
+    if cfg.DONKEY_GYM or cfg.DRIVE_TRAIN_TYPE == "MOCK":
+        pass
+
+    elif cfg.DRIVE_TRAIN_TYPE == "SERVO_ESC":
+
+        from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
+
+        steering_controller = PCA9685(cfg.STEERING_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
+        steering = PWMSteering(controller=steering_controller,
+                                        left_pulse=cfg.STEERING_LEFT_PWM,
+                                        right_pulse=cfg.STEERING_RIGHT_PWM)
+
+        throttle_controller = PCA9685(cfg.THROTTLE_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
+        throttle = PWMThrottle(controller=throttle_controller,
+                                        max_pulse=cfg.THROTTLE_FORWARD_PWM,
+                                        zero_pulse=cfg.THROTTLE_STOPPED_PWM,
+                                        min_pulse=cfg.THROTTLE_REVERSE_PWM)
+
+        drive_train = dict()
+        drive_train['steering'] = steering
+        drive_train['throttle'] = throttle
+
+        V.add(steering, inputs=['angle'], threaded=True)
+        V.add(throttle, inputs=['throttle'], threaded=True)
+
+    elif cfg.DRIVE_TRAIN_TYPE == "MM1":
+        from donkeycar.parts.robohat import RoboHATDriver
+        drive_train = RoboHATDriver(cfg)
+        V.add(drive_train, inputs=['angle', 'throttle'])
+
+
+    ctr.drive_train = drive_train
+    ctr.drive_train_type = cfg.DRIVE_TRAIN_TYPE
+    
+    class ShowHowTo:
+        def __init__(self):
+            print(f"Go to http://{gethostname()}.local:8887/calibrate to calibrate ")
+            
+        def run(self):
+            pass
+        
+    V.add(ShowHowTo())
+
+    #run the vehicle for 20 seconds
+    V.start(rate_hz=cfg.DRIVE_LOOP_HZ,
+            max_loop_count=cfg.MAX_LOOPS)
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    cfg = dk.load_config()
+
+    if args['drive']:
+        drive(cfg)

--- a/donkeycar/tests/test_web_socket.py
+++ b/donkeycar/tests/test_web_socket.py
@@ -1,0 +1,88 @@
+
+from donkeycar.parts.web_controller.web import WebSocketCalibrateAPI
+from functools import partial
+
+from tornado import testing
+import tornado.websocket
+import tornado.web
+import tornado.ioloop
+import json
+from unittest.mock import Mock
+from donkeycar.parts.actuator import PWMSteering, PWMThrottle
+
+
+class WebSocketCalibrateTest(testing.AsyncHTTPTestCase):
+    """
+    Example of WebSocket usage as a client
+    in AsyncHTTPTestCase-based unit tests.
+    """
+
+    def get_app(self):
+        app = tornado.web.Application([('/', WebSocketCalibrateAPI)])
+        self.app = app
+
+        return app
+
+    def get_ws_url(self):
+        return "ws://localhost:" + str(self.get_http_port()) + "/"
+
+    @tornado.testing.gen_test
+    def test_calibrate_servo_esc_1(self):
+        ws_client = yield tornado.websocket.websocket_connect(self.get_ws_url())
+
+        # Now we can run a test on the WebSocket.
+        self.app.drive_train = dict()
+        self.app.drive_train['steering'] = Mock()
+        self.app.drive_train_type = "SERVO_ESC"
+
+        data = {"config": {"STEERING_LEFT_PWM": 444}}
+        yield ws_client.write_message(json.dumps(data))
+        yield ws_client.close()
+
+        assert self.app.drive_train['steering'].left_pulse == 444
+        assert isinstance(self.app.drive_train['steering'].right_pulse, Mock)
+
+    @tornado.testing.gen_test
+    def test_calibrate_servo_esc_2(self):
+        ws_client = yield tornado.websocket.websocket_connect(self.get_ws_url())
+
+        # Now we can run a test on the WebSocket.
+        self.app.drive_train = dict()
+        self.app.drive_train['steering'] = Mock()
+        self.app.drive_train_type = "SERVO_ESC"
+
+        data = {"config": {"STEERING_RIGHT_PWM": 555}}
+        yield ws_client.write_message(json.dumps(data))
+        yield ws_client.close()
+
+        assert self.app.drive_train['steering'].right_pulse == 555
+        assert isinstance(self.app.drive_train['steering'].left_pulse, Mock)
+
+    @tornado.testing.gen_test
+    def test_calibrate_servo_esc_3(self):
+        ws_client = yield tornado.websocket.websocket_connect(self.get_ws_url())
+
+        # Now we can run a test on the WebSocket.
+        self.app.drive_train = dict()
+        self.app.drive_train['throttle'] = Mock()
+        self.app.drive_train_type = "SERVO_ESC"
+
+        data = {"config": {"THROTTLE_FORWARD_PWM": 666}}
+        yield ws_client.write_message(json.dumps(data))
+        yield ws_client.close()
+
+        assert self.app.drive_train['throttle'].max_pulse == 666
+        assert isinstance(self.app.drive_train['throttle'].min_pulse, Mock)
+
+    @tornado.testing.gen_test
+    def test_calibrate_mm1(self):
+        ws_client = yield tornado.websocket.websocket_connect(self.get_ws_url())
+
+        # Now we can run a test on the WebSocket.
+        self.app.drive_train = Mock()
+        self.app.drive_train_type = "MM1"
+        data = {"config": {"MM1_STEERING_MID": 1234}}
+        yield ws_client.write_message(json.dumps(data))
+        yield ws_client.close()
+
+        assert self.app.drive_train.STEERING_MID == 1234


### PR DESCRIPTION
Allow user to change config value such as STEERING_LEFT_PWM or MM1_STEERING_MID without restarting the car or running donkey calibrate command. I have added the following:

1. A much simplified verison of manage.py called "calibrate.py" to wire up the drive train to the web controller without changing manage.py. It will be created when user run createapp 

2. A /calibrate web page to perform the calibration

3. A websocket endpoint /wsCalibrate to support calibration message from mobile app and web page 

Currently the real-time calibration support PCA9685 and MM1 only. 



![screencapture-yingwa-local-8887-calibrate-2020-06-07-16_17_06](https://user-images.githubusercontent.com/6903470/83964539-60e54400-a8e0-11ea-801e-26729abb00a0.png)
