### PR TITLE
Sim info dict

### DIFF
--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -222,7 +222,7 @@ class Tub(object):
                 # in case val is a numpy.float32, which json doesn't like
                 json_data[key] = float(val)
 
-            elif typ in ['str', 'float', 'int', 'boolean', 'vector']:
+            elif typ in ['str', 'float', 'int', 'boolean', 'vector', 'dict']:
                 json_data[key] = val
 
             elif typ is 'image':

--- a/donkeycar/parts/dgym.py
+++ b/donkeycar/parts/dgym.py
@@ -9,7 +9,7 @@ def is_exe(fpath):
 
 class DonkeyGymEnv(object):
 
-    def __init__(self, sim_path, host="127.0.0.1", port=9091, headless=0, env_name="donkey-generated-track-v0", sync="asynchronous", conf={}, delay=0):
+    def __init__(self, sim_path, host="127.0.0.1", port=9091, headless=0, env_name="donkey-generated-track-v0", sync="asynchronous", conf={}, delay=0, return_info=False):
         os.environ['DONKEY_SIM_PATH'] = sim_path
         os.environ['DONKEY_SIM_PORT'] = str(port)
         os.environ['DONKEY_SIM_HEADLESS'] = str(headless)
@@ -22,11 +22,16 @@ class DonkeyGymEnv(object):
             if not is_exe(sim_path):
                 raise Exception("The path you provided is not an executable.") 
 
+        self.return_info = return_info
+
         self.env = gym.make(env_name, exe_path=sim_path, host=host, port=port)
         self.frame = self.env.reset()
         self.action = [0.0, 0.0]
         self.running = True
         self.info = { 'pos' : (0., 0., 0.)}
+        # only allow known json-able entries from the sim's info dictionary
+        self.valid = ['pos', 'cte', 'speed', 'hit']
+
         self.delay = float(delay)
 
         if "body_style" in conf:
@@ -36,7 +41,10 @@ class DonkeyGymEnv(object):
 
     def update(self):
         while self.running:
-            self.frame, _, _, self.info = self.env.step(self.action)
+            self.frame, reward, done, info = self.env.step(self.action)
+            self.info = {key: info[key] for key in info if key in self.valid}
+            self.info['reward'] = reward
+            self.info['done'] = done
 
     def run_threaded(self, steering, throttle):
         if steering is None or throttle is None:
@@ -45,7 +53,10 @@ class DonkeyGymEnv(object):
         if self.delay > 0.0:
             time.sleep(self.delay / 1000.0)
         self.action = [steering, throttle]
-        return self.frame
+        if self.return_info:
+            return self.frame, self.info
+        else:
+            return self.frame
 
     def shutdown(self):
         self.running = False

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -223,6 +223,7 @@ DONKEY_GYM_ENV_NAME = "donkey-generated-track-v0" # ("donkey-generated-track-v0"
 GYM_CONF = { "body_style" : "donkey", "body_rgb" : (128, 128, 128), "car_name" : "me", "font_size" : 100} # body style(donkey|bare|car01) body rgb 0-255
 SIM_HOST = "127.0.0.1"              # when racing on virtual-race-league use host "trainmydonkey.com"
 SIM_ARTIFICIAL_LATENCY = 0          # this is the millisecond latency in controls. Can use useful in emulating the delay when useing a remote server. values of 100 to 400 probably reasonable.
+DONKEY_GYM_INFO = False             # Include Sim info dict when saving Tub files.
 
 #publish camera over network
 #This is used to create a tcp service to pushlish the camera feed

--- a/donkeycar/templates/cfg_path_follow.py
+++ b/donkeycar/templates/cfg_path_follow.py
@@ -109,3 +109,4 @@ WHEEL_ODOM_CALIB = "calibration_odometry.json"
 DONKEY_GYM = False
 DONKEY_SIM_PATH = "path to sim" #"/home/tkramer/projects/sdsandbox/sdsim/build/DonkeySimLinux/donkey_sim.x86_64"
 DONKEY_GYM_ENV_NAME = "donkey-generated-track-v0" # ("donkey-generated-track-v0"|"donkey-generated-roads-v0"|"donkey-warehouse-v0"|"donkey-avc-sparkfun-v0")
+DONKEY_GYM_INFO = False             # Include Sim info dict when saving Tub files.

--- a/donkeycar/tests/test_tub.py
+++ b/donkeycar/tests/test_tub.py
@@ -48,6 +48,24 @@ def test_tub_write_numpy(tub):
     rec_out = tub.get_record(rec_index)
     assert type(rec_out['user/throttle']) == float
 
+def test_tub_dict(tub):
+    """Tub can save a record that contains a dictionary with json-able types."""
+    d = {'pos': (49.99962, 0.7410042, 50.16277),
+        'cte': -0.0006235633,
+        'hit': None,
+        'done': True }
+    x=123
+    z=0.0
+    rec_in  = {'user/angle': x, 'user/throttle':z, 'sim/info':d}
+    tub.meta['inputs'].append('sim/info')
+    tub.meta['types'].append('dict')
+    rec_index = tub.put_record(rec_in)
+    rec_out = tub.get_record(rec_index)
+    assert type(rec_out['sim/info']) == dict
+    assert type(rec_out['sim/info']['cte']) == float
+    assert rec_out['sim/info']['hit'] is None
+    assert rec_out['sim/info']['done'] is True
+
 
 def test_tub_exclude(tub):
     """ Make sure the Tub will exclude records in the exclude set """


### PR DESCRIPTION
Add support for saving dict's to Tub files, provided all entries are json compatible. Also add an option and support to drive and gym code to save the simulator's info dictionary (reward and done flags, cte, hit flag, position, etc.). 

See issue #583 .