### PR TITLE
Make model type optional in makemovie and check model type if salient is true

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -246,7 +246,7 @@ class MakeMovieShell(BaseCommand):
         parser.add_argument('--out', default='tub_movie.mp4', help='The movie filename to create. default: tub_movie.mp4')
         parser.add_argument('--config', default='./config.py', help='location of config file to use. default: ./config.py')
         parser.add_argument('--model', default=None, help='the model to use to show control outputs')
-        parser.add_argument('--type', default=None, help='the model type to load')
+        parser.add_argument('--type', default=None, required=False, help='the model type to load')
         parser.add_argument('--salient', action="store_true", help='should we overlay salient map showing activations')
         parser.add_argument('--start', type=int, default=0, help='first frame to process')
         parser.add_argument('--end', type=int, default=-1, help='last frame to process')

--- a/donkeycar/management/makemovie.py
+++ b/donkeycar/management/makemovie.py
@@ -31,16 +31,6 @@ class MakeMovie(object):
             parser.print_help()
             return
 
-        if args.type is None and args.model is not None:
-            print("ERR>> --type argument missing. Required when providing a model.")
-            parser.print_help()
-            return
-
-        if args.salient:
-            if args.model is None:
-                print("ERR>> salient visualization requires a model. Pass with the --model arg.")
-                parser.print_help()
-
         conf = os.path.expanduser(args.config)
         if not os.path.exists(conf):
             print("No config file at location: %s. Add --config to specify\
@@ -48,6 +38,21 @@ class MakeMovie(object):
             return
 
         self.cfg = dk.load_config(conf)
+
+        if args.type is None and args.model is not None:
+            args.type = self.cfg.DEFAULT_MODEL_TYPE
+            print("Model type not provided. Using default model type from config file")
+
+        if args.salient:
+            if args.model is None:
+                print("ERR>> salient visualization requires a model. Pass with the --model arg.")
+                parser.print_help()
+
+            if args.type not in ['linear', 'categorical']:
+                print("Model type {} is not supported. Only linear or categorical is supported for salient visualization".format(args.type))
+                parser.print_help()
+                return
+
         self.tub = Tub(args.tub)
         self.index = self.tub.get_index(shuffled=False)
         start = args.start


### PR DESCRIPTION
1. Make model type optional in makemovie. If model type is not provided, use config file
2. If salient is true, check whether model type is linear or categorical. If not, exit and warn user.