### PR TITLE
Correct version of Tensorflow to use with Jetpack installation on Jetson Nano

### DIFF
--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.4'
+__version__ = '3.1.5'
 
 print('using donkey v{} ...'.format(__version__))
 

--- a/scripts/multi_train.py
+++ b/scripts/multi_train.py
@@ -10,6 +10,7 @@ import os
 import time
 import random
 import subprocess
+import uuid
 
 num_clients = 4
 model_file = "mtn_drv2.h5" #or any model in ~/mycar/models/
@@ -35,6 +36,7 @@ for i in range(num_clients):
 		outfile.write('GYM_CONF["racer_name"] = "ai-%d"\n' % (i+1))
 		outfile.write('GYM_CONF["country"] = "USA"\n')
 		outfile.write('GYM_CONF["bio"] = "I am an ai!"\n')
+		outfile.write('GYM_CONF["guid"] = "%d"\n' % i)
 		outfile.close()
 
 	command = "python manage.py drive --model=models/%s --myconfig=%s" % (model_file, conf_file)
@@ -42,7 +44,7 @@ for i in range(num_clients):
 	print(com_list)
 	proc = subprocess.Popen(com_list)
 	procs.append(proc)
-	time.sleep(1)
+	time.sleep(2)
 
 
 print("running for 30 min...")

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md", "r") as fh:
 
 
 setup(name='donkeycar',
-    version='3.1.4',
+    version='3.1.5',
     long_description = long_description,
     description='Self driving library for python.',
     url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
For JetPack 4.4 product release, it’s recommended to use following package:
v2.2.0
https://developer.download.nvidia.com/compute/redist/jp/v44/tensorflow/tensorflow-2.2.0+nv20.7-cp36-cp36m-linux_aarch64.whl
v1.15.3
https://developer.download.nvidia.com/compute/redist/jp/v44/tensorflow/tensorflow-1.15.3+nv20.7-cp36-cp36m-linux_aarch64.whl

Therefore when installing Jetpack4.4 (the latest Jetpack) use the "v1.15.3 version. When installing Jetpack4.2 (https://developer.nvidia.com/jetpack-4_2) which was the latest Jetpack when the DC Nano install docs were generated, use https://developer.download.nvidia.com/compute/redist/jp/v42 tensorflow-gpu==1.13.1+nv19.3