### PR TITLE
Add code owners file for auto-adding reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, 
+# they will be requested for review when someone opens a pull request.
+* @tawnkramer
+
+# Python files 
+**/*.py @tawnkramer @wroscoe
+
+# Fine-grained owners of specific code parts are below.
+
+# Web UI / Frontend
+**/*.html @Schmill
+**/*.js @Schmill
+
+# Docs
+/docs/*.md @tawnkramer @wroscoe @Ezward @nvtkaszpir
+
+# Robohat - anything under robohat subdir will be owned by @wallarug
+# notice there is no prepending slash
+robohat/ @wallarug
+# specific donkey part file is owned by more people
+/donkeycar/parts/robohat.py @wallarug @sctse999
+
+# Object detection and voice control
+/donkeycar/parts/object_detector/* @sctse999
+/donkeycar/parts/voice_control/* @sctse999
+
+# AI related
+/donkeycar/parts/keras.py @tawnkramer @tikurahul
+/donkeycar/parts/tensorrt.py @tikurahul @dlam
+/donkeycar/parts/tflite.py @dlarue
+
+# Other hardware parts
+/donkeycar/parts/oled.py @tikurahul
+/donkeycar/parts/serial_controller.py @wallarug


### PR DESCRIPTION
This file should help to automatically select code reviewers
when someone creates PR.

Notice this file probably have to be updated with more fine-grained
list, and then cherry-picked or merged to other branches to work.

For reference see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file

Fixes #618