### PR TITLE
Cleanup MacOS install

### DIFF
--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -1,27 +1,28 @@
 name: donkey
+channels: 
+    - conda-forge
 dependencies:
-- python=3.7
-- h5py
-- pillow
-- opencv
-- matplotlib
-- tornado
-- docopt
-- pandas
-- pylint
-- pytest
-- pytest-cov
-- codecov
-- pip
-- imgaug
-- progress
-- moviepy
-- paho-mqtt
-- PrettyTable
-
-- pip:
-  - tensorflow==2.2.0
-  - git+https://github.com/autorope/keras-vis.git
-  - simple-pid
-  - opencv-python-headless
+    - python=3.7
+    - h5py
+    - pillow
+    - opencv
+    - matplotlib
+    - tornado
+    - docopt
+    - pandas
+    - pylint
+    - pytest
+    - pytest-cov
+    - codecov
+    - pip
+    - imgaug
+    - progress
+    - moviepy
+    - paho-mqtt
+    - PrettyTable
+    - pip :
+        - git+https://github.com/autorope/keras-vis.git
+        - simple-pid
+        - opencv-python-headless
+        - tensorflow>=2.2.0
 

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,6 @@ setup(name='donkeycar',
           ],
           'pc': [
               'matplotlib',
-              'imgaug',
-              'progress',
           ],
           'dev': [
               'pytest',


### PR DESCRIPTION
Added channel conda-forge so Conda could install  - paho-mqtt, prettytable, imgaug, moviepy.

Updated mac.yml to match ubuntu.yml as much as possible.

Changed tensorflow command to install latest version.

Removed redundant install setting in setup.py (pc: imaug, progress)