### PR TITLE
Refactoring `KerasLatent` into auto-encoder-controller and other tub improvements

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -1,10 +1,7 @@
 
 import argparse
-import os
 import shutil
-import socket
 import stat
-import sys
 from socket import *
 
 
@@ -342,7 +339,8 @@ class ShowCnnActivations(BaseCommand):
 
 class ShowPredictionPlots(BaseCommand):
 
-    def plot_predictions(self, cfg, tub_paths, model_path, limit, model_type):
+    def plot_predictions(self, cfg, tub_paths, model_path, start, limit,
+                         model_type):
         '''
         Plot model predictions for angle and throttle against data from tubs.
 
@@ -368,7 +366,7 @@ class ShowPredictionPlots(BaseCommand):
         base_path = Path(os.path.expanduser(tub_paths)).absolute().as_posix()
         tub = Tub(base_path)
         records = list(tub)
-        records = records[:limit]
+        records = records[start:limit]
         bar = IncrementalBar('Inferencing', max=len(records))
 
         for record in records:
@@ -405,12 +403,19 @@ class ShowPredictionPlots(BaseCommand):
         plt.show()
 
     def parse_args(self, args):
-        parser = argparse.ArgumentParser(prog='tubplot', usage='%(prog)s [options]')
-        parser.add_argument('--tub', nargs='+', help='The tub to make plot from')
-        parser.add_argument('--model', default=None, help='name of record to create histogram')
-        parser.add_argument('--limit', type=int, default=1000, help='how many records to process')
+        parser = argparse.ArgumentParser(prog='tubplot',
+                                         usage='%(prog)s [options]')
+        parser.add_argument('--tub', nargs='+',
+                            help='The tub to make plot from')
+        parser.add_argument('--model', default=None,
+                            help='name of record to create histogram')
+        parser.add_argument('--start', type=int, default=0,
+                            help='from which record to start')
+        parser.add_argument('--limit', type=int, default=1000,
+                            help='how many records to process')
         parser.add_argument('--type', default=None, help='model type')
-        parser.add_argument('--config', default='./config.py', help='location of config file to use. default: ./config.py')
+        parser.add_argument('--config', default='./config.py',
+                            help='location of config file to use. default: ./config.py')
         parsed_args = parser.parse_args(args)
         return parsed_args
 
@@ -418,7 +423,8 @@ class ShowPredictionPlots(BaseCommand):
         args = self.parse_args(args)
         args.tub = ','.join(args.tub)
         cfg = load_config(args.config)
-        self.plot_predictions(cfg, args.tub, args.model, args.limit, args.type)
+        self.plot_predictions(cfg, args.tub, args.model, args.start,
+                              args.limit, args.type)
 
 
 def execute_from_command_line():
@@ -450,3 +456,4 @@ def execute_from_command_line():
     
 if __name__ == "__main__":
     execute_from_command_line()
+

--- a/donkeycar/parts/datastore_v2.py
+++ b/donkeycar/parts/datastore_v2.py
@@ -256,6 +256,11 @@ class Manifest(object):
         self.deleted_indexes.add(record_index)
         self._update_catalog_metadata(update=True)
 
+    def undelete_record(self, record_index):
+        # Does not actually delete the record, but marks it as deleted.
+        self.deleted_indexes.discard(record_index)
+        self._update_catalog_metadata(update=True)
+
     def _add_catalog(self):
         current_length = len(self.catalog_paths)
         catalog_name = 'catalog_%s.catalog' % (current_length)

--- a/donkeycar/parts/tub_v2.py
+++ b/donkeycar/parts/tub_v2.py
@@ -68,6 +68,33 @@ class Tub(object):
     def delete_record(self, record_index):
         self.manifest.delete_record(record_index)
 
+    def delete_records_by_value(self, key, value):
+        """
+        Deletes records where record[key] == value
+
+        :param key:     key to compare against
+        :param value:   value to compare with
+        :return:        list of indexes which are marked deleted
+        """
+        indexes = [record['_index'] for record in self if key in record and
+                   record[key] == value]
+        for i in indexes:
+            self.delete_record(i)
+
+        return indexes
+
+    def undelete_records(self, indexes):
+        """
+        Resurrecting deleted indexes
+
+        :param int or list indexes:     indexes to be resurrected
+        :return:                        None
+        """
+        if type(indexes) is int:
+            indexes = [indexes]
+        for i in indexes:
+            self.manifest.undelete_record(i)
+
     def delete_last_n_records(self, n):
         last_index = self.manifest.current_index
         first_index = last_index - n

--- a/donkeycar/tests/test_tub_v2.py
+++ b/donkeycar/tests/test_tub_v2.py
@@ -9,30 +9,50 @@ class TestTub(unittest.TestCase):
 
     def setUp(self):
         self._path = tempfile.mkdtemp()
-        inputs = ['input']
-        types = ['int']
+        inputs = ['input', 'key']
+        types = ['int', 'str']
         self.tub = Tub(self._path, inputs, types)
 
-    def test_basic_tub_operations(self):
-        entries = list(self.tub)
-        self.assertEqual(len(entries), 0)
-        write_count = 10
-        delete_indexes = [0, 8]
-
-        records = [{'input': i} for i in range(write_count)]
+    def _prepare_tub(self, write_count, delete_indexes):
+        records = [{'input': i, 'key': 'foo' if i < write_count // 2 else 'bar'}
+                   for i in range(write_count)]
         for record in records:
             self.tub.write_record(record)
 
         for index in delete_indexes:
             self.tub.delete_record(index)
 
+    def test_basic_tub_operations(self):
+        entries = list(self.tub)
+        self.assertEqual(len(entries), 0)
+        write_count = 10
+        delete_indexes = [0, 8]
+        self._prepare_tub(write_count, delete_indexes)
         count = 0
         for record in self.tub:
-            print('Record %s' % (record))
+            print('Record %s' % record)
             count += 1
 
         self.assertEqual(count, (write_count - len(delete_indexes)))
         self.assertEqual(len(self.tub), (write_count - len(delete_indexes)))
+
+    def test_delete_and_resurrect_by_key(self):
+        write_count = 16
+        delete_indexes = [0, 5, 6, 13]
+        self._prepare_tub(write_count, delete_indexes)
+        orig_len = len(self.tub)
+        orig_items = list(self.tub)
+        deleted = self.tub.delete_records_by_value('key', 'foo')
+
+        self.assertTrue(len(deleted) > 0, "There should be some foos to delete")
+        self.assertEqual(len(self.tub), orig_len - len(deleted),
+                         "Mismatching tub size")
+        self.tub.undelete_records(deleted)
+        self.assertEqual(len(self.tub), len(orig_items),
+                         "Deleting and undeleting didn't return start tub")
+        for o, n in zip(orig_items, self.tub):
+            self.assertEqual(o, n, f"Undeleted items don't match original "
+                                   f"items for {o} and {n}")
 
     def tearDown(self):
         shutil.rmtree(self._path)

--- a/scripts/convert_to_tub_v2.py
+++ b/scripts/convert_to_tub_v2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 '''
 Usage:
-    convert_to_tub_v2.py --tub=<path> --output=<path>
+    convert_to_tub_v2.py --tub=<path> --output=<path> [--include_name]
 
 Note:
     This script converts the old datastore format, to the new datastore format.
@@ -16,21 +16,27 @@ from docopt import docopt
 from PIL import Image
 from progress.bar import IncrementalBar
 
-import donkeycar as dk
 from donkeycar.parts.datastore import Tub as LegacyTub
 from donkeycar.parts.tub_v2 import Tub
 
 
-def convert_to_tub_v2(paths, output_path):
+def convert_to_tub_v2(paths, output_path, include_tub_name=False):
     legacy_tubs = [LegacyTub(path) for path in paths]
     output_tub = None
     print('Total number of tubs: %s' % (len(legacy_tubs)))
 
     for legacy_tub in legacy_tubs:
         if not output_tub:
-            output_tub = Tub(output_path, legacy_tub.inputs, legacy_tub.types, list(legacy_tub.meta.items()))
+            inputs = legacy_tub.inputs
+            types = legacy_tub.types
+            if include_tub_name:
+                inputs.append('tub_name')
+                types.append('str')
+            output_tub = Tub(output_path, inputs, types,
+                             list(legacy_tub.meta.items()))
 
         record_paths = legacy_tub.gather_records()
+        legacy_path = os.path.normpath(legacy_tub.path)
         bar = IncrementalBar('Converting', max=len(record_paths))
 
         for record_path in record_paths:
@@ -41,10 +47,12 @@ def convert_to_tub_v2(paths, output_path):
                 image_path = os.path.join(legacy_tub.path, image_path)
                 image_data = Image.open(image_path)
                 record['cam/image_array'] = image_data
+                if include_tub_name:
+                    record['tub_name'] = legacy_path
                 output_tub.write_record(record)
                 bar.next()
             except Exception as exception:
-                print('Ignoring record path %s\n' % (record_path), exception)
+                print('Ignoring record path %s\n' % record_path, exception)
                 traceback.print_exc()
 
 
@@ -53,5 +61,6 @@ if __name__ == '__main__':
 
     input_path = args["--tub"]
     output_path = args["--output"]
+    include_name = args["--include_name"]
     paths = input_path.split(',')
-    convert_to_tub_v2(paths, output_path)
+    convert_to_tub_v2(paths, output_path, include_tub_name=include_name)


### PR DESCRIPTION
## Refactoring of `KerasLatent` model
* decomposing the latent model into encoder, decoder and controller - the first two parts are the auto-encoder, the controller takes the latent vector as input and outputs steering and throttle
* the encoder cnn now matches the linear model so the models are comparable
* added support to build the latent model from a trained encoder, that can be loaded from a trained latent model
* integration of latent model into training

## Additional features for new tub
* deleting records by values - useful to suppress certain records in training
* undeleting records - useful to temporarily suppress records and then set them back
* added test of new features

## Additional features for training
* allow suppressing of shuffling - mostly useful to keep tests more repeatable
* train script now shows train time again
* changed train test to relative convergence

## Additional features in donkey
* donkey tubplot now accepts an optional start parameter too

## Additional features in conversion script
* add flag to put legacy tub path into new tub, so records can be identified w/o having to use multiple new tubs