### PR TITLE
USYD Brakes - Simulator

### DIFF
--- a/donkeycar/parts/dgym.py
+++ b/donkeycar/parts/dgym.py
@@ -24,7 +24,7 @@ class DonkeyGymEnv(object):
         conf['guid'] = 0
         self.env = gym.make(env_name, conf=conf)
         self.frame = self.env.reset()
-        self.action = [0.0, 0.0]
+        self.action = [0.0, 0.0, 0.0]
         self.running = True
         self.info = { 'pos' : (0., 0., 0.)}
         self.delay = float(delay)
@@ -33,13 +33,15 @@ class DonkeyGymEnv(object):
         while self.running:
             self.frame, _, _, self.info = self.env.step(self.action)
 
-    def run_threaded(self, steering, throttle):
+    def run_threaded(self, steering, throttle, brake=None):
         if steering is None or throttle is None:
             steering = 0.0
             throttle = 0.0
+        if brake is None:
+            brake = 0.0
         if self.delay > 0.0:
             time.sleep(self.delay / 1000.0)
-        self.action = [steering, throttle]
+        self.action = [steering, throttle, brake]
         return self.frame
 
     def shutdown(self):

--- a/donkeycar/templates/cfg_simulator.py
+++ b/donkeycar/templates/cfg_simulator.py
@@ -1,0 +1,280 @@
+"""
+CAR CONFIG
+
+This file is read by your car application's manage.py script to change the car
+performance.
+
+EXMAPLE
+-----------
+import dk
+cfg = dk.load_config(config_path='~/mycar/config.py')
+print(cfg.CAMERA_RESOLUTION)
+
+"""
+
+
+import os
+
+#PATHS
+CAR_PATH = PACKAGE_PATH = os.path.dirname(os.path.realpath(__file__))
+DATA_PATH = os.path.join(CAR_PATH, 'data')
+MODELS_PATH = os.path.join(CAR_PATH, 'models')
+
+#VEHICLE
+DRIVE_LOOP_HZ = 20      # the vehicle loop will pause if faster than this speed.
+MAX_LOOPS = None        # the vehicle loop can abort after this many iterations, when given a positive integer.
+
+#CAMERA
+CAMERA_TYPE = "MOCK"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|MOCK|IMAGE_LIST)
+IMAGE_W = 160
+IMAGE_H = 120
+IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
+CAMERA_FRAMERATE = DRIVE_LOOP_HZ
+CAMERA_VFLIP = False
+CAMERA_HFLIP = False
+# For CSIC camera - If the camera is mounted in a rotated position, changing the below parameter will correct the output frame orientation
+CSIC_CAM_GSTREAMER_FLIP_PARM = 0 # (0 => none , 4 => Flip horizontally, 6 => Flip vertically)
+
+# For IMAGE_LIST camera
+# PATH_MASK = "~/mycar/data/tub_1_20-03-12/*.jpg"
+
+#9865, over rides only if needed, ie. TX2..
+PCA9685_I2C_ADDR = 0x40     #I2C address, use i2cdetect to validate this number
+PCA9685_I2C_BUSNUM = None   #None will auto detect, which is fine on the pi. But other platforms should specify the bus num.
+
+#SSD1306_128_32
+USE_SSD1306_128_32 = False    # Enable the SSD_1306 OLED Display
+SSD1306_128_32_I2C_BUSNUM = 1 # I2C bus number
+
+#DRIVETRAIN
+#These options specify which chasis and motor setup you are using. Most are using SERVO_ESC.
+#DC_STEER_THROTTLE uses HBridge pwm to control one steering dc motor, and one drive wheel motor
+#DC_TWO_WHEEL uses HBridge pwm to control two drive motors, one on the left, and one on the right.
+#SERVO_HBRIDGE_PWM use ServoBlaster to output pwm control from the PiZero directly to control steering, and HBridge for a drive motor.
+#PIGPIO_PWM uses Raspberrys internal PWM
+DRIVE_TRAIN_TYPE = "MOCK" # SERVO_ESC|DC_STEER_THROTTLE|DC_TWO_WHEEL|SERVO_HBRIDGE_PWM|PIGPIO_PWM|MM1|MOCK
+
+#STEERING
+STEERING_CHANNEL = 1            #channel on the 9685 pwm board 0-15
+STEERING_LEFT_PWM = 460         #pwm value for full left steering
+STEERING_RIGHT_PWM = 290        #pwm value for full right steering
+
+#STEERING FOR PIGPIO_PWM
+STEERING_PWM_PIN = 13           #Pin numbering according to Broadcom numbers
+STEERING_PWM_FREQ = 50          #Frequency for PWM
+STEERING_PWM_INVERTED = False   #If PWM needs to be inverted
+
+#THROTTLE
+THROTTLE_CHANNEL = 0            #channel on the 9685 pwm board 0-15
+THROTTLE_FORWARD_PWM = 500      #pwm value for max forward throttle
+THROTTLE_STOPPED_PWM = 370      #pwm value for no movement
+THROTTLE_REVERSE_PWM = 220      #pwm value for max reverse throttle
+
+#THROTTLE FOR PIGPIO_PWM
+THROTTLE_PWM_PIN = 18           #Pin numbering according to Broadcom numbers
+THROTTLE_PWM_FREQ = 50          #Frequency for PWM
+THROTTLE_PWM_INVERTED = False   #If PWM needs to be inverted
+
+#DC_STEER_THROTTLE with one motor as steering, one as drive
+#these GPIO pinouts are only used for the DRIVE_TRAIN_TYPE=DC_STEER_THROTTLE
+HBRIDGE_PIN_LEFT = 18
+HBRIDGE_PIN_RIGHT = 16
+HBRIDGE_PIN_FWD = 15
+HBRIDGE_PIN_BWD = 13
+
+#DC_TWO_WHEEL - with two wheels as drive, left and right.
+#these GPIO pinouts are only used for the DRIVE_TRAIN_TYPE=DC_TWO_WHEEL
+HBRIDGE_PIN_LEFT_FWD = 18
+HBRIDGE_PIN_LEFT_BWD = 16
+HBRIDGE_PIN_RIGHT_FWD = 15
+HBRIDGE_PIN_RIGHT_BWD = 13
+
+
+#TRAINING
+#The DEFAULT_MODEL_TYPE will choose which model will be created at training time. This chooses
+#between different neural network designs. You can override this setting by passing the command
+#line parameter --type to the python manage.py train and drive commands.
+DEFAULT_MODEL_TYPE = 'linear'   #(linear|categorical|tflite_linear|tensorrt_linear)
+BATCH_SIZE = 128                #how many records to use when doing one pass of gradient decent. Use a smaller number if your gpu is running out of memory.
+TRAIN_TEST_SPLIT = 0.8          #what percent of records to use for training. the remaining used for validation.
+MAX_EPOCHS = 100                #how many times to visit all records of your data
+SHOW_PLOT = True                #would you like to see a pop up display of final loss?
+VERBOSE_TRAIN = True            #would you like to see a progress bar with text during training?
+USE_EARLY_STOP = True           #would you like to stop the training if we see it's not improving fit?
+EARLY_STOP_PATIENCE = 5         #how many epochs to wait before no improvement
+MIN_DELTA = .0005               #early stop will want this much loss change before calling it improved.
+PRINT_MODEL_SUMMARY = True      #print layers and weights to stdout
+OPTIMIZER = None                #adam, sgd, rmsprop, etc.. None accepts default
+LEARNING_RATE = 0.001           #only used when OPTIMIZER specified
+LEARNING_RATE_DECAY = 0.0       #only used when OPTIMIZER specified
+SEND_BEST_MODEL_TO_PI = False   #change to true to automatically send best model during training
+CACHE_IMAGES = True             #keep images in memory. will speed succesive epochs, but crater if not enough mem.
+
+PRUNE_CNN = False               #This will remove weights from your model. The primary goal is to increase performance.
+PRUNE_PERCENT_TARGET = 75       # The desired percentage of pruning.
+PRUNE_PERCENT_PER_ITERATION = 20 # Percenge of pruning that is perform per iteration.
+PRUNE_VAL_LOSS_DEGRADATION_LIMIT = 0.2 # The max amout of validation loss that is permitted during pruning.
+PRUNE_EVAL_PERCENT_OF_DATASET = .05  # percent of dataset used to perform evaluation of model.
+
+#Model transfer options
+#When copying weights during a model transfer operation, should we freeze a certain number of layers
+#to the incoming weights and not allow them to change during training?
+FREEZE_LAYERS = False               #default False will allow all layers to be modified by training
+NUM_LAST_LAYERS_TO_TRAIN = 7        #when freezing layers, how many layers from the last should be allowed to train?
+
+#WEB CONTROL
+WEB_CONTROL_PORT = 8887             # which port to listen on when making a web controller
+WEB_INIT_MODE = "user"              # which control mode to start in. one of user|local_angle|local. Setting local will start in ai mode.
+
+#JOYSTICK
+USE_JOYSTICK_AS_DEFAULT = False      #when starting the manage.py, when True, will not require a --js option to use the joystick
+JOYSTICK_MAX_THROTTLE = 0.5         #this scalar is multiplied with the -1 to 1 throttle value to limit the maximum throttle. This can help if you drop the controller or just don't need the full speed available.
+JOYSTICK_STEERING_SCALE = 1.0       #some people want a steering that is less sensitve. This scalar is multiplied with the steering -1 to 1. It can be negative to reverse dir.
+AUTO_RECORD_ON_THROTTLE = True      #if true, we will record whenever throttle is not zero. if false, you must manually toggle recording with some other trigger. Usually circle button on joystick.
+CONTROLLER_TYPE = 'xbox'            #(ps3|ps4|xbox|nimbus|wiiu|F710|rc3|MM1|custom) custom will run the my_joystick.py controller written by the `donkey createjs` command
+USE_NETWORKED_JS = False            #should we listen for remote joystick control over the network?
+NETWORK_JS_SERVER_IP = None         #when listening for network joystick control, which ip is serving this information
+JOYSTICK_DEADZONE = 0.01            # when non zero, this is the smallest throttle before recording triggered.
+JOYSTICK_THROTTLE_DIR = 1.0         # use -1.0 to flip forward/backward, use 1.0 to use joystick's natural forward/backward
+USE_FPV = False                     # send camera data to FPV webserver
+JOYSTICK_DEVICE_FILE = "/dev/input/js0" # this is the unix file use to access the joystick.
+
+#For the categorical model, this limits the upper bound of the learned throttle
+#it's very IMPORTANT that this value is matched from the training PC config.py and the robot.py
+#and ideally wouldn't change once set.
+MODEL_CATEGORICAL_MAX_THROTTLE_RANGE = 0.5
+
+#RNN or 3D
+SEQUENCE_LENGTH = 3             #some models use a number of images over time. This controls how many.
+
+#IMU
+HAVE_IMU = False                #when true, this add a Mpu6050 part and records the data. Can be used with a
+IMU_SENSOR = 'mpu6050'          # (mpu6050|mpu9250)
+IMU_DLP_CONFIG = 0              # Digital Lowpass Filter setting (0:250Hz, 1:184Hz, 2:92Hz, 3:41Hz, 4:20Hz, 5:10Hz, 6:5Hz)
+
+#SOMBRERO
+HAVE_SOMBRERO = False           #set to true when using the sombrero hat from the Donkeycar store. This will enable pwm on the hat.
+
+#ROBOHAT MM1
+HAVE_ROBOHAT = False            # set to true when using the Robo HAT MM1 from Robotics Masters.  This will change to RC Control.
+MM1_STEERING_MID = 1500         # Adjust this value if your car cannot run in a straight line
+MM1_MAX_FORWARD = 2000          # Max throttle to go fowrward. The bigger the faster
+MM1_STOPPED_PWM = 1500
+MM1_MAX_REVERSE = 1000          # Max throttle to go reverse. The smaller the faster
+MM1_SHOW_STEERING_VALUE = False
+# Serial port 
+# -- Default Pi: '/dev/ttyS0'
+# -- Jetson Nano: '/dev/ttyTHS1'
+# -- Google coral: '/dev/ttymxc0'
+# -- Windows: 'COM3', Arduino: '/dev/ttyACM0'
+# -- MacOS/Linux:please use 'ls /dev/tty.*' to find the correct serial port for mm1 
+#  eg.'/dev/tty.usbmodemXXXXXX' and replace the port accordingly
+MM1_SERIAL_PORT = '/dev/ttyS0'  # Serial Port for reading and sending MM1 data.
+
+#RECORD OPTIONS
+RECORD_DURING_AI = False        #normally we do not record during ai mode. Set this to true to get image and steering records for your Ai. Be careful not to use them to train.
+AUTO_CREATE_NEW_TUB = False     #create a new tub (tub_YY_MM_DD) directory when recording or append records to data directory directly
+
+#LED
+HAVE_RGB_LED = False            #do you have an RGB LED like https://www.amazon.com/dp/B07BNRZWNF
+LED_INVERT = False              #COMMON ANODE? Some RGB LED use common anode. like https://www.amazon.com/Xia-Fly-Tri-Color-Emitting-Diffused/dp/B07MYJQP8B
+
+#LED board pin number for pwm outputs
+#These are physical pinouts. See: https://www.raspberrypi-spy.co.uk/2012/06/simple-guide-to-the-rpi-gpio-header-and-pins/
+LED_PIN_R = 12
+LED_PIN_G = 10
+LED_PIN_B = 16
+
+#LED status color, 0-100
+LED_R = 0
+LED_G = 0
+LED_B = 1
+
+#LED Color for record count indicator
+REC_COUNT_ALERT = 1000          #how many records before blinking alert
+REC_COUNT_ALERT_CYC = 15        #how many cycles of 1/20 of a second to blink per REC_COUNT_ALERT records
+REC_COUNT_ALERT_BLINK_RATE = 0.4 #how fast to blink the led in seconds on/off
+
+#first number is record count, second tuple is color ( r, g, b) (0-100)
+#when record count exceeds that number, the color will be used
+RECORD_ALERT_COLOR_ARR = [ (0, (1, 1, 1)),
+            (3000, (5, 5, 5)),
+            (5000, (5, 2, 0)),
+            (10000, (0, 5, 0)),
+            (15000, (0, 5, 5)),
+            (20000, (0, 0, 5)), ]
+
+
+#LED status color, 0-100, for model reloaded alert
+MODEL_RELOADED_LED_R = 100
+MODEL_RELOADED_LED_G = 0
+MODEL_RELOADED_LED_B = 0
+
+
+#BEHAVIORS
+#When training the Behavioral Neural Network model, make a list of the behaviors,
+#Set the TRAIN_BEHAVIORS = True, and use the BEHAVIOR_LED_COLORS to give each behavior a color
+TRAIN_BEHAVIORS = False
+BEHAVIOR_LIST = ['Left_Lane', "Right_Lane"]
+BEHAVIOR_LED_COLORS =[ (0, 10, 0), (10, 0, 0) ] #RGB tuples 0-100 per chanel
+
+#Localizer
+#The localizer is a neural network that can learn to predice it's location on the track.
+#This is an experimental feature that needs more developement. But it can currently be used
+#to predict the segement of the course, where the course is divided into NUM_LOCATIONS segments.
+TRAIN_LOCALIZER = False
+NUM_LOCATIONS = 10
+BUTTON_PRESS_NEW_TUB = False #when enabled, makes it easier to divide our data into one tub per track length if we make a new tub on each X button press.
+
+#DonkeyGym
+#Only on Ubuntu linux, you can use the simulator as a virtual donkey and
+#issue the same python manage.py drive command as usual, but have them control a virtual car.
+#This enables that, and sets the path to the simualator and the environment.
+#You will want to download the simulator binary from: https://github.com/tawnkramer/donkey_gym/releases/download/v18.9/DonkeySimLinux.zip
+#then extract that and modify DONKEY_SIM_PATH.
+DONKEY_GYM = True
+DONKEY_SIM_PATH = "path to sim" #"/home/tkramer/projects/sdsandbox/sdsim/build/DonkeySimLinux/donkey_sim.x86_64" when racing on virtual-race-league use "remote", or user "remote" when you want to start the sim manually first.
+DONKEY_GYM_ENV_NAME = "donkey-generated-track-v0" # ("donkey-generated-track-v0"|"donkey-generated-roads-v0"|"donkey-warehouse-v0"|"donkey-avc-sparkfun-v0")
+GYM_CONF = { "body_style" : "donkey", "body_rgb" : (128, 128, 128), "car_name" : "car", "font_size" : 100} # body style(donkey|bare|car01) body rgb 0-255
+GYM_CONF["racer_name"] = "Your Name"
+GYM_CONF["country"] = "Place"
+GYM_CONF["bio"] = "I race robots."
+
+SIM_HOST = "127.0.0.1"              # when racing on virtual-race-league use host "trainmydonkey.com"
+SIM_ARTIFICIAL_LATENCY = 0          # this is the millisecond latency in controls. Can use useful in emulating the delay when useing a remote server. values of 100 to 400 probably reasonable.
+
+#publish camera over network
+#This is used to create a tcp service to pushlish the camera feed
+PUB_CAMERA_IMAGES = False
+
+#When racing, to give the ai a boost, configure these values.
+AI_LAUNCH_DURATION = 0.0            # the ai will output throttle for this many seconds
+AI_LAUNCH_THROTTLE = 0.0            # the ai will output this throttle value
+AI_LAUNCH_ENABLE_BUTTON = 'R2'      # this keypress will enable this boost. It must be enabled before each use to prevent accidental trigger.
+AI_LAUNCH_KEEP_ENABLED = False      # when False ( default) you will need to hit the AI_LAUNCH_ENABLE_BUTTON for each use. This is safest. When this True, is active on each trip into "local" ai mode.
+
+#Scale the output of the throttle of the ai pilot for all model types.
+AI_THROTTLE_MULT = 1.0              # this multiplier will scale every throttle value for all output from NN models
+
+#Path following
+PATH_FILENAME = "donkey_path.pkl"   # the path will be saved to this filename
+PATH_SCALE = 5.0                    # the path display will be scaled by this factor in the web page
+PATH_OFFSET = (0, 0)                # 255, 255 is the center of the map. This offset controls where the origin is displayed.
+PATH_MIN_DIST = 0.3                 # after travelling this distance (m), save a path point
+PID_P = -10.0                       # proportional mult for PID path follower
+PID_I = 0.000                       # integral mult for PID path follower
+PID_D = -0.2                        # differential mult for PID path follower
+PID_THROTTLE = 0.2                  # constant throttle value during path following
+SAVE_PATH_BTN = "cross"             # joystick button to save path
+RESET_ORIGIN_BTN = "triangle"       # joystick button to press to move car back to origin
+
+# Intel Realsense D435 and D435i depth sensing camera
+REALSENSE_D435_RGB = True       # True to capture RGB image
+REALSENSE_D435_DEPTH = True     # True to capture depth as image array
+REALSENSE_D435_IMU = False      # True to capture IMU data (D435i only)
+REALSENSE_D435_ID = None        # serial number of camera or None if you only have one camera (it will autodetect)
+
+# Stop Sign Detector
+STOP_SIGN_DETECTOR = False
+STOP_SIGN_MIN_SCORE = 0.2
+STOP_SIGN_SHOW_BOUNDING_BOX = True

--- a/donkeycar/templates/simulator.py
+++ b/donkeycar/templates/simulator.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""
+Scripts to drive a donkey 4 car
+
+Usage:
+    manage.py (drive) [--model=<model>] [--js] [--type=(linear|categorical)] [--camera=(single|stereo)] [--meta=<key:value> ...] [--myconfig=<filename>]
+    manage.py (train) [--tubs=tubs] (--model=<model>) [--type=(linear|inferred|tensorrt_linear|tflite_linear)]
+
+Options:
+    -h --help               Show this screen.
+    --js                    Use physical joystick.
+    -f --file=<file>        A text file containing paths to tub files, one per line. Option may be used more than once.
+    --meta=<key:value>      Key/Value strings describing describing a piece of meta data about this drive. Option may be used more than once.
+    --myconfig=filename     Specify myconfig file to use. 
+                            [default: myconfig.py]
+"""
+import os
+import time
+
+from docopt import docopt
+import numpy as np
+
+import donkeycar as dk
+
+from donkeycar.parts.transform import TriggeredCallback, DelayedTrigger
+from donkeycar.parts.tub_v2 import TubWriter
+from donkeycar.parts.datastore import TubHandler
+from donkeycar.parts.controller import LocalWebController, JoystickController, WebFpv
+from donkeycar.parts.throttle_filter import ThrottleFilter
+from donkeycar.parts.behavior import BehaviorPart
+from donkeycar.parts.file_watcher import FileWatcher
+from donkeycar.parts.launch import AiLaunch
+from donkeycar.utils import *
+
+
+def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type='single', meta=[]):
+    '''
+    Construct a working robotic vehicle from many parts.
+    Each part runs as a job in the Vehicle loop, calling either
+    it's run or run_threaded method depending on the constructor flag `threaded`.
+    All parts are updated one after another at the framerate given in
+    cfg.DRIVE_LOOP_HZ assuming each part finishes processing in a timely manner.
+    Parts may have named outputs and inputs. The framework handles passing named outputs
+    to parts requesting the same named input.
+    '''
+
+    if cfg.DONKEY_GYM:
+        #the simulator will use cuda and then we usually run out of resources
+        #if we also try to use cuda. so disable for donkey_gym.
+        os.environ["CUDA_VISIBLE_DEVICES"]="-1"
+
+    if model_type is None:
+        if cfg.TRAIN_LOCALIZER:
+            model_type = "localizer"
+        elif cfg.TRAIN_BEHAVIORS:
+            model_type = "behavior"
+        else:
+            model_type = cfg.DEFAULT_MODEL_TYPE
+
+    #Initialize car
+    V = dk.vehicle.Vehicle()
+
+    from donkeycar.parts.dgym import DonkeyGymEnv
+
+    inputs = []
+
+    cam = DonkeyGymEnv(cfg.DONKEY_SIM_PATH, host=cfg.SIM_HOST, env_name=cfg.DONKEY_GYM_ENV_NAME, conf=cfg.GYM_CONF, delay=cfg.SIM_ARTIFICIAL_LATENCY)
+    threaded = True
+    inputs = ['angle', 'throttle', 'brake']
+
+    V.add(cam, inputs=inputs, outputs=['cam/image_array'], threaded=threaded)
+
+    if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
+        #modify max_throttle closer to 1.0 to have more power
+        #modify steering_scale lower than 1.0 to have less responsive steering
+        if cfg.CONTROLLER_TYPE == "MM1":
+            from donkeycar.parts.robohat import RoboHATController            
+            ctr = RoboHATController(cfg)
+        elif "custom" == cfg.CONTROLLER_TYPE:
+            #
+            # custom controller created with `donkey createjs` command
+            #
+            from my_joystick import MyJoystickController
+            ctr = MyJoystickController(
+                throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
+                throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
+                steering_scale=cfg.JOYSTICK_STEERING_SCALE,
+                auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
+            ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)
+        else:
+            from donkeycar.parts.controller import get_js_controller
+
+            ctr = get_js_controller(cfg)
+
+            if cfg.USE_NETWORKED_JS:
+                from donkeycar.parts.controller import JoyStickSub
+                netwkJs = JoyStickSub(cfg.NETWORK_JS_SERVER_IP)
+                V.add(netwkJs, threaded=True)
+                ctr.js = netwkJs
+        
+        V.add(ctr, 
+          inputs=['cam/image_array'],
+          outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
+          threaded=True)
+
+    else:
+        #This web controller will create a web server that is capable
+        #of managing steering, throttle, and modes, and more.
+        ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
+        
+        V.add(ctr,
+          inputs=['cam/image_array', 'tub/num_records'],
+          outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
+          threaded=True)
+
+    #this throttle filter will allow one tap back for esc reverse
+    th_filter = ThrottleFilter()
+    V.add(th_filter, inputs=['user/throttle'], outputs=['user/throttle'])
+
+    #See if we should even run the pilot module.
+    #This is only needed because the part run_condition only accepts boolean
+    class PilotCondition:
+        def run(self, mode):
+            if mode == 'user':
+                return False
+            else:
+                return True
+
+    V.add(PilotCondition(), inputs=['user/mode'], outputs=['run_pilot'])
+
+    class LedConditionLogic:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def run(self, mode, recording, recording_alert, behavior_state, model_file_changed, track_loc):
+            #returns a blink rate. 0 for off. -1 for on. positive for rate.
+
+            if track_loc is not None:
+                led.set_rgb(*self.cfg.LOC_COLORS[track_loc])
+                return -1
+
+            if model_file_changed:
+                led.set_rgb(self.cfg.MODEL_RELOADED_LED_R, self.cfg.MODEL_RELOADED_LED_G, self.cfg.MODEL_RELOADED_LED_B)
+                return 0.1
+            else:
+                led.set_rgb(self.cfg.LED_R, self.cfg.LED_G, self.cfg.LED_B)
+
+            if recording_alert:
+                led.set_rgb(*recording_alert)
+                return self.cfg.REC_COUNT_ALERT_BLINK_RATE
+            else:
+                led.set_rgb(self.cfg.LED_R, self.cfg.LED_G, self.cfg.LED_B)
+
+            if behavior_state is not None and model_type == 'behavior':
+                r, g, b = self.cfg.BEHAVIOR_LED_COLORS[behavior_state]
+                led.set_rgb(r, g, b)
+                return -1 #solid on
+
+            if recording:
+                return -1 #solid on
+            elif mode == 'user':
+                return 1
+            elif mode == 'local_angle':
+                return 0.5
+            elif mode == 'local':
+                return 0.1
+            return 0
+
+    if cfg.HAVE_RGB_LED and not cfg.DONKEY_GYM:
+        from donkeycar.parts.led_status import RGB_LED
+        led = RGB_LED(cfg.LED_PIN_R, cfg.LED_PIN_G, cfg.LED_PIN_B, cfg.LED_INVERT)
+        led.set_rgb(cfg.LED_R, cfg.LED_G, cfg.LED_B)
+
+        V.add(LedConditionLogic(cfg), inputs=['user/mode', 'recording', "records/alert", 'behavior/state', 'modelfile/modified', "pilot/loc"],
+              outputs=['led/blink_rate'])
+
+        V.add(led, inputs=['led/blink_rate'])
+
+    def get_record_alert_color(num_records):
+        col = (0, 0, 0)
+        for count, color in cfg.RECORD_ALERT_COLOR_ARR:
+            if num_records >= count:
+                col = color
+        return col
+
+    class RecordTracker:
+        def __init__(self):
+            self.last_num_rec_print = 0
+            self.dur_alert = 0
+            self.force_alert = 0
+
+        def run(self, num_records):
+            if num_records is None:
+                return 0
+
+            if self.last_num_rec_print != num_records or self.force_alert:
+                self.last_num_rec_print = num_records
+
+                if num_records % 10 == 0:
+                    print("recorded", num_records, "records")
+
+                if num_records % cfg.REC_COUNT_ALERT == 0 or self.force_alert:
+                    self.dur_alert = num_records // cfg.REC_COUNT_ALERT * cfg.REC_COUNT_ALERT_CYC
+                    self.force_alert = 0
+
+            if self.dur_alert > 0:
+                self.dur_alert -= 1
+
+            if self.dur_alert != 0:
+                return get_record_alert_color(num_records)
+
+            return 0
+
+    rec_tracker_part = RecordTracker()
+    V.add(rec_tracker_part, inputs=["tub/num_records"], outputs=['records/alert'])
+
+    if cfg.AUTO_RECORD_ON_THROTTLE and isinstance(ctr, JoystickController):
+        #then we are not using the circle button. hijack that to force a record count indication
+        def show_record_acount_status():
+            rec_tracker_part.last_num_rec_print = 0
+            rec_tracker_part.force_alert = 1
+        ctr.set_button_down_trigger('circle', show_record_acount_status)
+
+    # Use the FPV preview, which will show the cropped image output, or the full frame.
+    if cfg.USE_FPV:
+        V.add(WebFpv(), inputs=['cam/image_array'], threaded=True)
+
+    #Behavioral state
+    if cfg.TRAIN_BEHAVIORS:
+        bh = BehaviorPart(cfg.BEHAVIOR_LIST)
+        V.add(bh, outputs=['behavior/state', 'behavior/label', "behavior/one_hot_state_array"])
+        try:
+            ctr.set_button_down_trigger('L1', bh.increment_state)
+        except:
+            pass
+
+        inputs = ['cam/image_array', "behavior/one_hot_state_array"]
+    else:
+        inputs=['cam/image_array']
+
+    def load_model(kl, model_path):
+        start = time.time()
+        print('loading model', model_path)
+        kl.load(model_path)
+        print('finished loading in %s sec.' % (str(time.time() - start)) )
+
+    def load_weights(kl, weights_path):
+        start = time.time()
+        try:
+            print('loading model weights', weights_path)
+            kl.model.load_weights(weights_path)
+            print('finished loading in %s sec.' % (str(time.time() - start)) )
+        except Exception as e:
+            print(e)
+            print('ERR>> problems loading weights', weights_path)
+
+    def load_model_json(kl, json_fnm):
+        start = time.time()
+        print('loading model json', json_fnm)
+        from tensorflow.python import keras
+        try:
+            with open(json_fnm, 'r') as handle:
+                contents = handle.read()
+                kl.model = keras.models.model_from_json(contents)
+            print('finished loading json in %s sec.' % (str(time.time() - start)) )
+        except Exception as e:
+            print(e)
+            print("ERR>> problems loading model json", json_fnm)
+
+    if model_path:
+        #When we have a model, first create an appropriate Keras part
+        kl = dk.utils.get_model_by_type(model_type, cfg)
+
+        model_reload_cb = None
+
+        if '.h5' in model_path or '.uff' in model_path or 'tflite' in model_path or '.pkl' in model_path:
+            #when we have a .h5 extension
+            #load everything from the model file
+            load_model(kl, model_path)
+
+            def reload_model(filename):
+                load_model(kl, filename)
+
+            model_reload_cb = reload_model
+
+        elif '.json' in model_path:
+            #when we have a .json extension
+            #load the model from there and look for a matching
+            #.wts file with just weights
+            load_model_json(kl, model_path)
+            weights_path = model_path.replace('.json', '.weights')
+            load_weights(kl, weights_path)
+
+            def reload_weights(filename):
+                weights_path = filename.replace('.json', '.weights')
+                load_weights(kl, weights_path)
+
+            model_reload_cb = reload_weights
+
+        else:
+            print("ERR>> Unknown extension type on model file!!")
+            return
+
+        #this part will signal visual LED, if connected
+        V.add(FileWatcher(model_path, verbose=True), outputs=['modelfile/modified'])
+
+        #these parts will reload the model file, but only when ai is running so we don't interrupt user driving
+        V.add(FileWatcher(model_path), outputs=['modelfile/dirty'], run_condition="ai_running")
+        V.add(DelayedTrigger(100), inputs=['modelfile/dirty'], outputs=['modelfile/reload'], run_condition="ai_running")
+        V.add(TriggeredCallback(model_path, model_reload_cb), inputs=["modelfile/reload"], run_condition="ai_running")
+
+        outputs=['pilot/angle', 'pilot/throttle']
+
+        if cfg.TRAIN_LOCALIZER:
+            outputs.append("pilot/loc")
+
+        V.add(kl, inputs=inputs,
+              outputs=outputs,
+              run_condition='run_pilot')
+    
+    if cfg.STOP_SIGN_DETECTOR:
+        from donkeycar.parts.object_detector.stop_sign_detector import StopSignDetector
+        V.add(StopSignDetector(cfg.STOP_SIGN_MIN_SCORE, cfg.STOP_SIGN_SHOW_BOUNDING_BOX), inputs=['cam/image_array', 'pilot/throttle'], outputs=['pilot/throttle', 'cam/image_array'])
+
+    #Choose what inputs should change the car.
+    class DriveMode:
+        def run(self, mode,
+                    user_angle, user_throttle, user_brake,
+                    pilot_angle, pilot_throttle, pilot_brake):
+            if mode == 'user':
+                return user_angle, user_throttle, user_brake
+
+            elif mode == 'local_angle':
+                return pilot_angle if pilot_angle else 0.0, user_throttle, user_brake
+
+            else:
+                return pilot_angle if pilot_angle else 0.0, pilot_throttle * cfg.AI_THROTTLE_MULT, pilot_brake if pilot_brake else 0.0
+
+    V.add(DriveMode(),
+          inputs=['user/mode', 'user/angle', 'user/throttle', 'user/brake',
+                  'pilot/angle', 'pilot/throttle', 'pilot/brake'],
+          outputs=['angle', 'throttle', 'brake'])
+
+
+    #to give the car a boost when starting ai mode in a race.
+    aiLauncher = AiLaunch(cfg.AI_LAUNCH_DURATION, cfg.AI_LAUNCH_THROTTLE, cfg.AI_LAUNCH_KEEP_ENABLED)
+
+    V.add(aiLauncher,
+        inputs=['user/mode', 'throttle'],
+        outputs=['throttle'])
+
+    if isinstance(ctr, JoystickController):
+        ctr.set_button_down_trigger(cfg.AI_LAUNCH_ENABLE_BUTTON, aiLauncher.enable_ai_launch)
+
+
+    class AiRunCondition:
+        '''
+        A bool part to let us know when ai is running.
+        '''
+        def run(self, mode):
+            if mode == "user":
+                return False
+            return True
+
+    V.add(AiRunCondition(), inputs=['user/mode'], outputs=['ai_running'])
+
+    #Ai Recording
+    class AiRecordingCondition:
+        '''
+        return True when ai mode, otherwize respect user mode recording flag
+        '''
+        def run(self, mode, recording):
+            if mode == 'user':
+                return recording
+            return True
+
+    if cfg.RECORD_DURING_AI:
+        V.add(AiRecordingCondition(), inputs=['user/mode', 'recording'], outputs=['recording'])
+
+    #add tub to save data
+
+    inputs=['cam/image_array',
+            'user/angle', 'user/throttle',
+            'user/mode']
+
+    types=['image_array',
+           'float', 'float',
+           'str']
+
+    if cfg.TRAIN_BEHAVIORS:
+        inputs += ['behavior/state', 'behavior/label', "behavior/one_hot_state_array"]
+        types += ['int', 'str', 'vector']
+
+    if cfg.RECORD_DURING_AI:
+        inputs += ['pilot/angle', 'pilot/throttle']
+        types += ['float', 'float']
+
+    # do we want to store new records into own dir or append to existing
+    tub_path = TubHandler(path=cfg.DATA_PATH).create_tub_path() if \
+        cfg.AUTO_CREATE_NEW_TUB else cfg.DATA_PATH
+    tub_writer = TubWriter(tub_path, inputs=inputs, types=types, metadata=meta)
+    V.add(tub_writer, inputs=inputs, outputs=["tub/num_records"], run_condition='recording')
+
+    if cfg.PUB_CAMERA_IMAGES:
+        from donkeycar.parts.network import TCPServeValue
+        from donkeycar.parts.image import ImgArrToJpg
+        pub = TCPServeValue("camera")
+        V.add(ImgArrToJpg(), inputs=['cam/image_array'], outputs=['jpg/bin'])
+        V.add(pub, inputs=['jpg/bin'])
+
+    if type(ctr) is LocalWebController:
+        if cfg.DONKEY_GYM:
+            print("You can now go to http://localhost:%d to drive your car." % cfg.WEB_CONTROL_PORT)
+        else:
+            print("You can now go to <your hostname.local>:%d to drive your car." % cfg.WEB_CONTROL_PORT)
+    elif isinstance(ctr, JoystickController):
+        print("You can now move your joystick to drive your car.")
+        ctr.set_tub(tub_writer.tub)
+        ctr.print_controls()
+
+    #run the vehicle for 20 seconds
+    V.start(rate_hz=cfg.DRIVE_LOOP_HZ, max_loop_count=cfg.MAX_LOOPS)
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    cfg = dk.load_config(myconfig=args['--myconfig'])
+
+    if args['drive']:
+        model_type = args['--type']
+        camera_type = args['--camera']
+        drive(cfg, model_path=args['--model'], use_joystick=args['--js'],
+              model_type=model_type, camera_type=camera_type,
+              meta=args['--meta'])
+    elif args['train']:
+        print('Use python train.py instead.\n')
+


### PR DESCRIPTION
added in brake functionality for simulator only

**Updates**
- changed `dgym.py` file
- added new simulator.py template and configuration to keep other ones untouched.
- retains backwards compatibility with complete.py and other templates that have the simulator.
- doesn't interfere with training / data collection.

**Background**

This is to allow custom object and sign detection to stop the car effectively in the simulator (see _StopSignDetector_).   At the moment, the only way to control the car is via throttle.  To stop the car in the simulator (with it's low friction) you have to send very high reverse throttle values.  This leads to the car bouncing / rolling and not really being able to come to a complete stop.  With this update, brakes can be deployed and allow the algorithm to stop the car.