### PR TITLE
MakeMovie Utility Update - option for turning off line drawing

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -252,7 +252,7 @@ class MakeMovieShell(BaseCommand):
         parser.add_argument('--start', type=int, default=0, help='first frame to process')
         parser.add_argument('--end', type=int, default=-1, help='last frame to process')
         parser.add_argument('--scale', type=int, default=2, help='make image frame output larger by X mult')
-        parser.add_argument('--user', default=True, action='store_false', help='show user input on the video')
+        parser.add_argument('--draw-user-input', default=True, action='store_false', help='show user input on the video')
         parsed_args = parser.parse_args(args)
         return parsed_args, parser
 

--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -252,6 +252,7 @@ class MakeMovieShell(BaseCommand):
         parser.add_argument('--start', type=int, default=0, help='first frame to process')
         parser.add_argument('--end', type=int, default=-1, help='last frame to process')
         parser.add_argument('--scale', type=int, default=2, help='make image frame output larger by X mult')
+        parser.add_argument('--user', default=True, action='store_false', help='show user input on the video')
         parsed_args = parser.parse_args(args)
         return parsed_args, parser
 

--- a/donkeycar/management/makemovie.py
+++ b/donkeycar/management/makemovie.py
@@ -69,7 +69,7 @@ class MakeMovie(object):
         self.scale = args.scale
         self.keras_part = None
         self.do_salient = False
-        self.user = args.user
+        self.user = args.draw_user_input
         if args.model is not None:
             self.keras_part = get_model_by_type(args.type, cfg=self.cfg)
             self.keras_part.load(args.model)

--- a/donkeycar/management/makemovie.py
+++ b/donkeycar/management/makemovie.py
@@ -69,6 +69,7 @@ class MakeMovie(object):
         self.scale = args.scale
         self.keras_part = None
         self.do_salient = False
+        self.user = args.user
         if args.model is not None:
             self.keras_part = get_model_by_type(args.type, cfg=self.cfg)
             self.keras_part.load(args.model)
@@ -249,7 +250,7 @@ class MakeMovie(object):
             image = image * 255
             image = image.astype('uint8')
         
-        self.draw_user_input(rec, image)
+        if self.user: self.draw_user_input(rec, image)
         if self.keras_part is not None:
             self.draw_model_prediction(image)
             self.draw_steering_distribution(image)


### PR DESCRIPTION
add in --user flag for MakeMovie so that you can select if you want to draw the line on the video or not.  default: true

**Details**
Command works exactly the same except now you can add a --user flag to advise the donkey makemovie command that you don't want the user input shown.  The reason for this is that if you draw the green line for the user input from collected data, you cannot use the video for OpenCV or object classification because it throws out the algorithms (a random green line goes across everything).  So the solution is to still compile the video - but leave off the green line.

**Usage**

```bash
donkey makemovie --tub=data/latest --scale=1 --user False --out latest.mp4
```
... will output a video without the green line.

```bash
donkey makemovie --tub=data/latest --scale=1 --out latest.mp4
```
... will output a video with the green line.