### PR TITLE
added speed return for simulator in dgym.py

### DIFF
--- a/donkeycar/parts/dgym.py
+++ b/donkeycar/parts/dgym.py
@@ -26,7 +26,7 @@ class DonkeyGymEnv(object):
         self.frame = self.env.reset()
         self.action = [0.0, 0.0, 0.0]
         self.running = True
-        self.info = { 'pos' : (0., 0., 0.)}
+        self.info = { 'pos' : (0., 0., 0.), 'speed' : 0.0}
         self.delay = float(delay)
         
     def update(self):
@@ -42,7 +42,7 @@ class DonkeyGymEnv(object):
         if self.delay > 0.0:
             time.sleep(self.delay / 1000.0)
         self.action = [steering, throttle, brake]
-        return self.frame
+        return self.frame, self.info['speed']
 
     def shutdown(self):
         self.running = False

--- a/donkeycar/templates/simulator.py
+++ b/donkeycar/templates/simulator.py
@@ -68,7 +68,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     threaded = True
     inputs = ['angle', 'throttle', 'brake']
 
-    V.add(cam, inputs=inputs, outputs=['cam/image_array'], threaded=threaded)
+    V.add(cam, inputs=inputs, outputs=['cam/image_array', 'speed'], threaded=threaded)
 
     if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
         #modify max_throttle closer to 1.0 to have more power


### PR DESCRIPTION
as stated.

Does have changes that stop compatibility with other manage.py templates.  Going forward - everyone should use simulator.py template to ensure all new simulator changes are implemented and working.