### PR TITLE
Allow overriding WEB_CONTROL_PORT from env variable

### DIFF
--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -136,8 +136,8 @@ class LocalWebController(tornado.web.Application):
 
         settings = {'debug': True}
         super().__init__(handlers, **settings)
-        print("... you can now go to {}.local:8887 to drive "
-              "your car.".format(gethostname()))
+        print("... you can now go to {}.local:{} to drive "
+              "your car.".format(gethostname(), port))
 
     def update(self):
         ''' Start the tornado webserver. '''

--- a/donkeycar/templates/basic_web.py
+++ b/donkeycar/templates/basic_web.py
@@ -45,7 +45,7 @@ def drive(cfg, model_path=None, model_type=None):
     V.add(cam, outputs=['cam/image_array'], threaded=True)
         
    
-    V.add(LocalWebController(), 
+    V.add(LocalWebController(port=cfg.WEB_CONTROL_PORT), 
           inputs=['cam/image_array'],
           outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
           threaded=True)
@@ -195,7 +195,7 @@ def drive(cfg, model_path=None, model_type=None):
     tub = th.new_tub_writer(inputs=inputs, types=types)
     V.add(tub, inputs=inputs, outputs=["tub/num_records"], run_condition='recording')
 
-    print("You can now go to <your pis hostname.local>:8887 to drive your car.")
+    print(f"You can now go to <your pis hostname.local>:{cfg.WEB_CONTROL_PORT} to drive your car.")
 
     #run the vehicle for 20 seconds
     V.start(rate_hz=cfg.DRIVE_LOOP_HZ, 

--- a/donkeycar/templates/calibrate.py
+++ b/donkeycar/templates/calibrate.py
@@ -38,7 +38,7 @@ def drive(cfg ):
     #Initialize car
     V = dk.vehicle.Vehicle()
 
-    ctr = LocalWebController()
+    ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT)
     V.add(ctr,
           inputs=['cam/image_array', 'tub/num_records'],
           outputs=['angle', 'throttle', 'user/mode', 'recording'],
@@ -87,7 +87,7 @@ def drive(cfg ):
     
     class ShowHowTo:
         def __init__(self):
-            print(f"Go to http://{gethostname()}.local:8887/calibrate to calibrate ")
+            print(f"Go to http://{gethostname()}.local:{ctr.port}/calibrate to calibrate ")
             
         def run(self):
             pass

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -137,7 +137,7 @@ FREEZE_LAYERS = False               #default False will allow all layers to be m
 NUM_LAST_LAYERS_TO_TRAIN = 7        #when freezing layers, how many layers from the last should be allowed to train?
 
 #WEB CONTROL
-WEB_CONTROL_PORT = 8887             # which port to listen on when making a web controller
+WEB_CONTROL_PORT = int(os.getenv("WEB_CONTROL_PORT", 8887))  # which port to listen on when making a web controller
 WEB_INIT_MODE = "user"              # which control mode to start in. one of user|local_angle|local. Setting local will start in ai mode.
 
 #JOYSTICK

--- a/donkeycar/tests/test_web_controller.py
+++ b/donkeycar/tests/test_web_controller.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 import pytest
 import json
+import os
 from donkeycar.parts.web_controller.web import LocalWebController
+import donkeycar.templates.cfg_complete as cfg
+from importlib import reload
 
 @pytest.fixture
 def server():
-    server = LocalWebController()
+    server = LocalWebController(cfg.WEB_CONTROL_PORT)
     return server
 
 
@@ -13,7 +16,18 @@ def test_json_output(server):
     result = server.run()
     json_result = json.dumps(result)
     d = json.loads(json_result)
+    
+    assert server.port == 8887
+    
     assert d is not None
     assert int(d[0]) == 0
+
+
+def test_web_control_user_defined_port():
+    os.environ['WEB_CONTROL_PORT'] = "12345"
+    reload(cfg)
+    server = LocalWebController(port=cfg.WEB_CONTROL_PORT)
+    
+    assert server.port == 12345
 
 


### PR DESCRIPTION
To test this:
```
export WEB_CONTROL_PORT=12345
python manage.py drive
```
Visit `http://localhost:12345/drive` instead of `http://localhost:8887/drive`
Web Controller should start listening on port 12345. Port 8887 should not work after you specify the port in the env variable.