### PR TITLE
Fix template docopt, as it's called managed.py and not drive.py

### DIFF
--- a/donkeycar/templates/basic.py
+++ b/donkeycar/templates/basic.py
@@ -3,7 +3,7 @@
 Scripts to drive a donkey car
 
 Usage:
-    drive.py [--model=<model>] [--type=(linear|categorical|tflite_linear)]
+    manage.py drive [--model=<model>] [--type=(linear|categorical|tflite_linear)]
 
 Options:
     -h --help          Show this screen.


### PR DESCRIPTION
Docopt throws a usage error as template gets renamed to manage.py and not drive.py