### PR TITLE
Add performance monitor

### DIFF
--- a/donkeycar/parts/perfmon.py
+++ b/donkeycar/parts/perfmon.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Performance monitor for analyzing real-time CPU/mem/execution frequency
+
+author: @miro (Meir Tseitlin) 2020
+
+Note:
+"""
+import time
+import psutil
+
+
+class PerfMonitor:
+
+    def __init__(self, cfg):
+
+        self.STATS_BUFFER_SIZE = 10
+        self._calc_buffer = [cfg.DRIVE_LOOP_HZ for i in range(self.STATS_BUFFER_SIZE)]
+        self._runs_counter = 0
+        self._last_calc_time = time.time()
+        self._on = True
+        self._update_metrics()
+        print("Performance monitor activated.")
+
+    def _update_metrics(self):
+        self._mem_percent = psutil.virtual_memory().percent
+        self._cpu_percent = psutil.cpu_percent()
+
+    def update(self):
+        while self._on:
+            self._update_metrics()
+            time.sleep(2)
+
+    def shutdown(self):
+        # indicate that the thread should be stopped
+        self._on = False
+        print('Stopping Perf Monitor')
+        time.sleep(.2)
+
+    def run_threaded(self):
+
+        # Calc real frequency
+        curr_time = time.time()
+        if curr_time - self._last_calc_time > 1:
+            self._calc_buffer[int(curr_time) % self.STATS_BUFFER_SIZE] = self._runs_counter
+            self._runs_counter = 0
+            self._last_calc_time = curr_time
+
+        self._runs_counter += 1
+
+        vehicle_frequency = float(sum(self._calc_buffer)) / self.STATS_BUFFER_SIZE
+
+        return self._cpu_percent, self._mem_percent, vehicle_frequency

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -192,6 +192,9 @@ TELEMETRY_MQTT_JSON_ENABLE = True
 TELEMETRY_MQTT_BROKER_HOST = 'broker.emqx.io'
 TELEMETRY_MQTT_BROKER_PORT = 1883
 
+# PERF MONITOR
+HAVE_PERFMON = False
+
 #RECORD OPTIONS
 RECORD_DURING_AI = False        #normally we do not record during ai mode. Set this to true to get image and steering records for your Ai. Be careful not to use them to train.
 AUTO_CREATE_NEW_TUB = False     #create a new tub (tub_YY_MM_DD) directory when recording or append records to data directory directly

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -580,6 +580,14 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
         inputs += ['pilot/angle', 'pilot/throttle']
         types += ['float', 'float']
 
+    if cfg.HAVE_PERFMON:
+        from donkeycar.parts.perfmon import PerfMonitor
+        mon = PerfMonitor(cfg)
+        perfmon_outputs = ['perf/cpu', 'perf/mem', 'perf/freq']
+        inputs += perfmon_outputs
+        types += ['float', 'float', 'float']
+        V.add(mon, inputs=[], outputs=perfmon_outputs, threaded=True)
+
     # do we want to store new records into own dir or append to existing
     tub_path = TubHandler(path=cfg.DATA_PATH).create_tub_path() if \
         cfg.AUTO_CREATE_NEW_TUB else cfg.DATA_PATH
@@ -591,7 +599,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
         from donkeycar.parts.telemetry import MqttTelemetry
         published_inputs, published_types = MqttTelemetry.filter_supported_metrics(inputs, types)
         tel = MqttTelemetry(cfg, default_inputs=published_inputs, default_types=published_types)
-        V.add(tel, inputs=published_inputs, outputs=["tub/queue_size"], threaded=False)
+        V.add(tel, inputs=published_inputs, outputs=["tub/queue_size"], threaded=True)
 
     if cfg.PUB_CAMERA_IMAGES:
         from donkeycar.parts.network import TCPServeValue

--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -31,6 +31,7 @@ dependencies:
   - torchaudio
   - pytorch-lightning
   - numpy
+  - psutil
   - pip:
     - tensorflow==2.2.0
     - git+https://github.com/autorope/keras-vis.git

--- a/install/envs/pc.yml
+++ b/install/envs/pc.yml
@@ -32,6 +32,7 @@ dependencies:
   - pytorch-lightning
   - numpy
   - tensorflow=2.2.0
+  - psutil
   - pip:
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(name='donkeycar',
           "simple_pid",
           'progress',
           'typing_extensions',
-          'pyfiglet'
+          'pyfiglet',
+          'psutil'
       ],
       extras_require={
           'pi': [


### PR DESCRIPTION
Performance monitor allows monitoring CPU / Memory and real Donkey execution frequency. I noticed that my own execution loop is considerably lower than 20Hz on Jetson Nano (~8Hz) and decided to measure it. On PC  simulator everything runs at 20hz as required.


This pull request includes performance monitor together with MQTT telemetry from another pull request (https://github.com/autorope/donkeycar/pull/688).