### PR TITLE
A configurable training pipeline.

### DIFF
--- a/donkeycar/pipeline/__init__.py
+++ b/donkeycar/pipeline/__init__.py
@@ -1,0 +1,1 @@
+# The new donkey car training pipeline.

--- a/donkeycar/pipeline/sequence.py
+++ b/donkeycar/pipeline/sequence.py
@@ -1,0 +1,217 @@
+from typing import Any, Callable, Generic, Iterable, Iterator, List, Sized, Tuple, TypeVar
+
+import math
+import numpy as np
+from donkeycar.pipeline.types import TubRecord
+
+# Note: Be careful when re-using `TypeVar`s.
+# If you are not-consistent mypy gets easily confused.
+
+R = TypeVar('R', covariant=True)
+X = TypeVar('X', covariant=True)
+Y = TypeVar('Y', covariant=True)
+XOut = TypeVar('XOut', covariant=True)
+YOut = TypeVar('YOut', covariant=True)
+
+
+class SizedIterator(Generic[X], Iterator[X], Sized):
+    def __init__(self) -> None:
+        # This is a protocol type without explicitly using a `Protocol`
+        # Using `Protocol` requires Python 3.7
+        pass
+
+    def batched(self, batch_size: int) -> Iterator[List[X]]:
+        # Produces a batch of results
+        # Ideally we should be able to return a `SizedIterator` but `mypy`
+        # won't resolve this kind of recursive type
+        raise NotImplemented
+
+
+class TubSeqIterator(SizedIterator[TubRecord]):
+    def __init__(self, records: List[TubRecord]) -> None:
+        self.records = records or list()
+        self.current_index = 0
+
+    def __len__(self):
+        return len(self.records)
+
+    def __iter__(self) -> SizedIterator[TubRecord]:
+        return self
+
+    def __next__(self):
+        if self.current_index >= len(self.records):
+            raise StopIteration('No more records')
+
+        record = self.records[self.current_index]
+        self.current_index += 1
+        return record
+
+    next = __next__
+
+
+class TfmIterator(Generic[R, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+    def __init__(self,
+                 iterator: Iterable[R],
+                 x_transform: Callable[[R], XOut],
+                 y_transform: Callable[[R], YOut]) -> None:
+
+        self.iterator = BaseTfmIterator_(
+            iterator=iterator, x_transform=x_transform, y_transform=y_transform)
+
+    def __len__(self):
+        return len(self.iterator)
+
+    def __iter__(self) -> SizedIterator[Tuple[XOut, YOut]]:
+        return self
+
+    def __next__(self):
+        return next(self.iterator)
+
+    def batched(self, batch_size=64) -> SizedIterator[List[Tuple[XOut, YOut]]]:
+        return self.iterator.batched(batch_size=batch_size)
+
+
+class TfmTupleIterator(Generic[X, Y, XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+    def __init__(self,
+                 iterator: Iterable[Tuple[X, Y]],
+                 x_transform: Callable[[X], XOut],
+                 y_transform: Callable[[Y], YOut]) -> None:
+
+        self.iterator = BaseTfmIterator_(
+            iterator=iterator, x_transform=x_transform, y_transform=y_transform)
+
+    def __len__(self):
+        return len(self.iterator)
+
+    def __iter__(self) -> SizedIterator[Tuple[XOut, YOut]]:
+        return self
+
+    def __next__(self):
+        return next(self.iterator)
+
+    def batched(self, batch_size=64) -> SizedIterator[List[Tuple[XOut, YOut]]]:
+        return self.iterator.batched(batch_size=batch_size)
+
+
+class BaseTfmIterator_(Generic[XOut, YOut],  SizedIterator[Tuple[XOut, YOut]]):
+    '''
+    A basic transforming iterator.
+    Do no use this class directly.
+    '''
+
+    def __init__(self,
+                 # Losing a bit of type safety here for a common implementation
+                 iterator: Iterable[Any],
+                 x_transform: Callable[[R], XOut],
+                 y_transform: Callable[[R], YOut]) -> None:
+
+        self.iterator = iter(iterator)
+        self.x_transform = x_transform
+        self.y_transform = y_transform
+
+    def __len__(self):
+        return len(self.iterator)
+
+    def __iter__(self) -> SizedIterator[Tuple[XOut, YOut]]:
+        return self
+
+    def __next__(self):
+        record = next(self.iterator)
+        if (isinstance(record, tuple) and len(record) == 2):
+            x, y = record
+            return self.x_transform(x), self.y_transform(y)
+        else:
+            return self.x_transform(record), self.y_transform(record)
+
+    def batched(self, batch_size=64) -> SizedIterator[List[Tuple[XOut, YOut]]]:
+        batched_iterator = BatchedIterator(self, batch_size=batch_size)
+        return batched_iterator
+
+
+class BatchedIterator(SizedIterator[List[R]]):
+    def __init__(self, pipeline: SizedIterator[R], batch_size: int) -> None:
+        self.pipeline = pipeline
+        self.batch_size = batch_size
+        self.consumed = 0
+
+    def __len__(self):
+        return math.ceil(len(self.pipeline) / self.batch_size)
+
+    def __next__(self) -> List[R]:
+        count = 0
+        batch = list()
+        while count < self.batch_size and self.consumed < len(self.pipeline):
+            r = next(self.pipeline)
+            batch.append(r)
+            count += 1
+            self.consumed += 1
+
+        if len(batch) > 0:
+            return batch
+        else:
+            raise StopIteration('No more records')
+
+    def __iter__(self) -> Iterator[List[R]]:
+        return self
+
+
+class TubSequence(Iterable[TubRecord]):
+    def __init__(self, records: List[TubRecord]) -> None:
+        self.records = records
+
+    def __iter__(self) -> SizedIterator[TubRecord]:
+        return TubSeqIterator(self.records)
+
+    def __len__(self):
+        return len(self.records)
+
+    def build_pipeline(self,
+                       x_transform: Callable[[TubRecord], X],
+                       y_transform: Callable[[TubRecord], Y]) -> SizedIterator[Tuple[X, Y]]:
+        return TfmIterator(self, x_transform=x_transform, y_transform=y_transform)
+
+    @classmethod
+    def map_pipeline(
+            cls,
+            x_transform: Callable[[X], XOut],
+            y_transform: Callable[[Y], YOut],
+            pipeline: SizedIterator[Tuple[X, Y]]) -> SizedIterator[Tuple[XOut, YOut]]:
+        return TfmTupleIterator(pipeline, x_transform=x_transform, y_transform=y_transform)
+
+    @classmethod
+    def map_pipeline_factory(
+            cls,
+            x_transform: Callable[[X], XOut],
+            y_transform: Callable[[Y], YOut],
+            factory: Callable[[], SizedIterator[Tuple[X, Y]]]) -> SizedIterator[Tuple[XOut, YOut]]:
+
+        pipeline = factory()
+        return cls.map_pipeline(pipeline=pipeline, x_transform=x_transform, y_transform=y_transform)
+
+
+R1 = TypeVar('R1', covariant=True)
+R2 = TypeVar('R2', covariant=True)
+
+
+class Reshaper(Generic[R1, R2], SizedIterator[Tuple[np.ndarray, np.ndarray]]):
+    def __init__(self, batched: SizedIterator[List[Tuple[R1, R2]]]) -> None:
+        self.batch = batched
+
+    def __len__(self) -> int:
+        return len(self.batch)
+
+    def __next__(self):
+        records: List[Tuple[R1, R2]] = next(self.batch)
+        X: List[R1] = list()
+        Y: List[R2] = list()
+        for record in records:
+            x, y = record
+            X.append(x)
+            Y.append(y)
+
+        return np.array(X), np.array(Y)
+
+    def __iter__(self) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
+        return self
+
+    next = __next__

--- a/donkeycar/pipeline/types.py
+++ b/donkeycar/pipeline/types.py
@@ -1,0 +1,67 @@
+import os
+from typing import Any, List, Optional, TypeVar, cast
+
+import numpy as np
+from donkeycar.parts.tub_v2 import Tub
+from donkeycar.utils import load_image_arr, normalize_image
+from typing_extensions import TypedDict
+
+X = TypeVar('X', covariant=True)
+
+TubRecordDict = TypedDict(
+    'TubRecordDict',
+    {
+        'cam/image_array': str,
+        'user/angle': float,
+        'user/throttle': float,
+        'user/mode': str,
+        'imu/acl_x': Optional[float],
+        'imu/acl_y': Optional[float],
+        'imu/acl_z': Optional[float],
+        'imu/gyr_x': Optional[float],
+        'imu/gyr_y': Optional[float],
+        'imu/gyr_z': Optional[float],
+    }
+)
+
+
+class TubRecord(object):
+    def __init__(self, config: Any, base_path: str, underlying: TubRecordDict) -> None:
+        self.config = config
+        self.base_path = base_path
+        self.underlying = underlying
+        self._image: Optional[Any] = None
+
+    def image(self, cached=True, normalize=False) -> np.ndarray:
+        if not self._image:
+            image_path = self.underlying['cam/image_array']
+            full_path = os.path.join(self.base_path, 'images', image_path)
+            _image = load_image_arr(full_path, cfg=self.config)
+            if normalize:
+                _image = normalize_image(_image)
+            if cached:
+                self._image = _image
+            return _image
+        else:
+            return self._image
+
+    def __repr__(self) -> str:
+        return repr(self.underlying)
+
+
+class TubDataset(object):
+    def __init__(self, paths: List[str], config: Any) -> None:
+        self.paths = paths
+        self.config = config
+        self.tubs = [Tub(path) for path in self.paths]
+        self.records: List[TubRecord] = list()
+
+    def load_records(self) -> List[TubRecord]:
+        self.records.clear()
+        for tub in self.tubs:
+            for record in tub:
+                underlying = cast(TubRecordDict, record)
+                tub_record = TubRecord(self.config, tub.base_path, underlying)
+                self.records.append(tub_record)
+
+        return self.records

--- a/donkeycar/templates/train.py
+++ b/donkeycar/templates/train.py
@@ -10,23 +10,22 @@ Options:
     -h --help              Show this screen.
 """
 
+import math
 import os
-import random
 from pathlib import Path
-
-import cv2
-import numpy as np
-from docopt import docopt
-from PIL import Image
-from tensorflow.python.keras.callbacks import EarlyStopping, ModelCheckpoint
-from tensorflow.python.keras.utils.data_utils import Sequence
+from typing import Any, List, Optional, Tuple, cast
 
 import donkeycar
-from donkeycar.parts.keras import KerasInferred, KerasCategorical
+import numpy as np
+from docopt import docopt
+from donkeycar.parts.keras import KerasCategorical, KerasInferred, KerasLinear
 from donkeycar.parts.tflite import keras_model_to_tflite
 from donkeycar.parts.tub_v2 import Tub
-from donkeycar.utils import get_model_by_type, load_image_arr, \
-    train_test_split, linear_bin, normalize_image
+from donkeycar.pipeline.sequence import TubRecord
+from donkeycar.pipeline.sequence import TubSequence as PipelineSequence
+from donkeycar.utils import get_model_by_type, linear_bin, train_test_split
+from tensorflow.python.keras.callbacks import EarlyStopping, ModelCheckpoint
+from tensorflow.python.keras.utils.data_utils import Sequence
 
 
 class TubDataset(object):
@@ -34,85 +33,106 @@ class TubDataset(object):
     Loads the dataset, and creates a train/test split.
     '''
 
-    def __init__(self, tub_paths, test_size=0.2, shuffle=True):
+    def __init__(self, config, tub_paths, test_size=0.2, shuffle=True):
+        self.config = config
         self.tub_paths = tub_paths
         self.test_size = test_size
         self.shuffle = shuffle
-        self.tubs = [Tub(tub_path, read_only=True) for tub_path in
-                     self.tub_paths]
-        self.records = list()
+        self.tubs = [Tub(tub_path, read_only=True)
+                     for tub_path in self.tub_paths]
+        self.records: List[TubRecord] = list()
 
-    def train_test_split(self):
+    def train_test_split(self) -> Tuple[List[TubRecord], List[TubRecord]]:
         print('Loading tubs from paths %s' % (self.tub_paths))
         for tub in self.tubs:
-            for record in tub:
-                record['_image_base_path'] = tub.images_base_path
+            for underlying in tub:
+                record = TubRecord(self.config, tub.base_path,
+                                   underlying=underlying)
                 self.records.append(record)
 
         return train_test_split(self.records, shuffle=self.shuffle, test_size=self.test_size)
 
 
 class TubSequence(Sequence):
-    def __init__(self, keras_model, config, records=list()):
+    # Improve batched_pipeline to make most of this go away as well.
+    # The idea is to have a shallow sequence with types that can hydrate themselves to an ndarray
+
+    def __init__(self, keras_model, config, records: List[TubRecord] = list()):
         self.keras_model = keras_model
         self.config = config
         self.records = records
+        self.sequence = PipelineSequence(self.records)
         self.batch_size = self.config.BATCH_SIZE
+        self.consumed = 0
+
+        # Keep track of model type
+        # Eventually move this part into the model itself.
+        self.is_linear = type(self.keras_model) is KerasLinear
+        self.is_inferred = type(self.keras_model) is KerasInferred
+        self.is_categorical = type(self.keras_model) is KerasCategorical
+
+        # Define transformations
+        def x_transform(record: TubRecord):
+            # Using an identity transform to delay image loading
+            return record
+
+        def y_categorical(record: TubRecord):
+            angle: np.ndarray = record.underlying['user/angle']
+            throttle: np.ndarray = record.underlying['user/throttle']
+            R = self.config.MODEL_CATEGORICAL_MAX_THROTTLE_RANGE
+            angle = linear_bin(angle, N=15, offset=1, R=2.0)
+            throttle = linear_bin(throttle, N=20, offset=0.0, R=R)
+            return angle, throttle
+
+        def y_inferred(record: TubRecord):
+            return record.underlying['user/angle']
+
+        def y_linear(record: TubRecord):
+            angle: float = record.underlying['user/angle']
+            throttle: float = record.underlying['user/throttle']
+            return angle, throttle
+
+        if self.is_linear:
+            self.pipeline = list(self.sequence.build_pipeline(x_transform=x_transform, y_transform=y_linear))
+        elif self.is_categorical:
+            self.pipeline = list(self.sequence.build_pipeline(x_transform=x_transform, y_transform=y_categorical))
+        else:
+            self.pipeline = list(self.sequence.build_pipeline(x_transform=x_transform, y_transform=y_inferred))
 
     def __len__(self):
-        return len(self.records) // self.batch_size
+        if not self.pipeline:
+            raise RuntimeError('Pipeline is not initialized')
+
+        return math.ceil(len(self.pipeline) / self.batch_size)
 
     def __getitem__(self, index):
         count = 0
-        records = []
         images = []
         angles = []
         throttles = []
-
-        is_inferred = type(self.keras_model) is KerasInferred
-        is_categorical = type(self.keras_model) is KerasCategorical
-
         while count < self.batch_size:
             i = (index * self.batch_size) + count
-            if i >= len(self.records):
+            if i >= len(self.pipeline):
                 break
 
-            record = self.records[i]
-            record = self._transform_record(record)
-            records.append(record)
+            record, r = self.pipeline[i]
+            images.append(record.image(cached=False, normalize=True))
+
+            if isinstance(r, tuple):
+                angle, throttle = r
+                angles.append(angle)
+                throttles.append(throttle)
+            else:
+                angles.append(r)
+
             count += 1
 
-        for record in records:
-            image = record['cam/image_array']
-            angle = record['user/angle']
-            throttle = record['user/throttle']
-
-            images.append(image)
-            # for categorical convert to one-hot vector
-            if is_categorical:
-                R = self.config.MODEL_CATEGORICAL_MAX_THROTTLE_RANGE
-                angle = linear_bin(angle, N=15, offset=1, R=2.0)
-                throttle = linear_bin(throttle, N=20, offset=0.0, R=R)
-            angles.append(angle)
-            throttles.append(throttle)
-
         X = np.array(images)
-
-        if is_inferred:
+        if self.is_inferred:
             Y = np.array(angles)
         else:
             Y = [np.array(angles), np.array(throttles)]
-
         return X, Y
-
-    def _transform_record(self, record):
-        for key, value in record.items():
-            if key == 'cam/image_array' and isinstance(value, str):
-                image_path = os.path.join(record['_image_base_path'], value)
-                image = load_image_arr(image_path, self.config)
-                record[key] = normalize_image(image)
-
-        return record
 
 
 class ImagePreprocessing(Sequence):
@@ -152,7 +172,7 @@ def train(cfg, tub_paths, output_path, model_type):
         print(kl.model.summary())
 
     batch_size = cfg.BATCH_SIZE
-    dataset = TubDataset(tub_paths, test_size=(1. - cfg.TRAIN_TEST_SPLIT))
+    dataset = TubDataset(cfg, tub_paths, test_size=(1. - cfg.TRAIN_TEST_SPLIT))
     training_records, validation_records = dataset.train_test_split()
     print('Records # Training %s' % len(training_records))
     print('Records # Validation %s' % len(validation_records))

--- a/donkeycar/tests/test_pipeline.py
+++ b/donkeycar/tests/test_pipeline.py
@@ -1,0 +1,169 @@
+import time
+import unittest
+from os import pipe
+from typing import List, Tuple, cast
+
+import numpy as np
+from donkeycar.pipeline.sequence import SizedIterator, TubSequence, Reshaper
+from donkeycar.pipeline.types import TubRecord, TubRecordDict
+
+
+def random_records(size: int = 100) -> List[TubRecord]:
+    return [random_record() for _ in range(size)]
+
+
+def random_record():
+    now = int(time.time())
+    underlying: TubRecordDict = {
+        'cam/image_array': f'/path/to/{now}.txt',
+        'user/angle': np.random.uniform(0, 1.),
+        'user/throttle': np.random.uniform(0, 1.),
+        'user/mode': 'driving',
+        'imu/acl_x': None,
+        'imu/acl_y': None,
+        'imu/acl_z': None,
+        'imu/gyr_x': None,
+        'imu/gyr_y': None,
+        'imu/gyr_z': None
+    }
+    return TubRecord('/base', None, underlying=underlying)
+
+
+size = 10
+
+
+class TestPipeline(unittest.TestCase):
+
+    def setUp(self):
+        records = random_records(size=size)
+        self.sequence = TubSequence(records=records)
+
+    def test_basic_iteration(self):
+        self.assertEqual(len(self.sequence), size)
+        count = 0
+        for record in self.sequence:
+            print(f'Record {record}')
+            count += 1
+
+        self.assertEqual(count, size)
+
+    def test_basic_map_operations(self):
+        transformed = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'],
+            y_transform=lambda record: record.underlying['user/throttle'])
+
+        transformed_2 = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'] * 2,
+            y_transform=lambda record: record.underlying['user/throttle'] * 2)
+
+        self.assertEqual(len(transformed), size)
+        self.assertEqual(len(transformed_2), size)
+
+        transformed_list = list(transformed)
+        transformed_list_2 = list(transformed_2)
+        index = np.random.randint(0, 9)
+
+        x1, y1 = transformed_list[index]
+        x2, y2 = transformed_list_2[index]
+
+        self.assertAlmostEqual(x1 * 2, x2)
+        self.assertAlmostEqual(y1 * 2, y2)
+
+    def test_more_map_operations(self):
+        transformed = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'],
+            y_transform=lambda record: record.underlying['user/throttle'])
+
+        transformed_2 = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'] * 2,
+            y_transform=lambda record: record.underlying['user/throttle'] * 2)
+
+        transformed_3 = TubSequence.map_pipeline(
+            x_transform=lambda x: x,
+            y_transform=lambda y: y,
+            pipeline=transformed_2
+        )
+
+        self.assertEqual(len(transformed), size)
+        self.assertEqual(len(transformed_2), size)
+        self.assertEqual(len(transformed_3), size)
+
+        transformed_list = list(transformed)
+        transformed_list_2 = list(transformed_3)
+        index = np.random.randint(0, 9)
+
+        x1, y1 = transformed_list[index]
+        x2, y2 = transformed_list_2[index]
+
+        self.assertAlmostEqual(x1 * 2, x2)
+        self.assertAlmostEqual(y1 * 2, y2)
+
+    def test_map_factory(self):
+        transformed = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'],
+            y_transform=lambda record: record.underlying['user/throttle'])
+
+        transformed_2 = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'] * 2,
+            y_transform=lambda record: record.underlying['user/throttle'] * 2)
+
+        transformed_3 = TubSequence.map_pipeline_factory(
+            x_transform=lambda x: x,
+            y_transform=lambda y: y,
+            factory=lambda: transformed_2
+        )
+
+        self.assertEqual(len(transformed), size)
+        self.assertEqual(len(transformed_2), size)
+        self.assertEqual(len(transformed_3), size)
+
+        transformed_list = list(transformed)
+        transformed_list_2 = list(transformed_3)
+        index = np.random.randint(0, 9)
+
+        x1, y1 = transformed_list[index]
+        x2, y2 = transformed_list_2[index]
+
+        self.assertAlmostEqual(x1 * 2, x2)
+        self.assertAlmostEqual(y1 * 2, y2)
+
+    def test_batch_1(self):
+        transformed = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'],
+            y_transform=lambda record: record.underlying['user/throttle'])
+
+        batch_size = 4
+        batched = transformed.batched(batch_size=batch_size)
+        self.assertEqual(len(batched), 3)
+        for records in batched:
+            print(f'Records {records}')
+            self.assertLessEqual(len(records), batch_size)
+
+    def test_batch_2(self):
+        transformed = TubSequence.build_pipeline(
+            self.sequence,
+            x_transform=lambda record: record.underlying['user/angle'],
+            y_transform=lambda record: record.underlying['user/throttle'])
+
+        batch_size = 4
+        batched = transformed.batched(batch_size=batch_size)
+        batched = cast(SizedIterator[List[Tuple[float, float]]], batched)
+        reshaped = Reshaper(batched=batched)
+        self.assertEqual(len(batched), len(reshaped))
+        count = 0
+        for X, Y in reshaped:
+            print(f'X = {X}, Y = {Y}')
+            count += 1
+
+        self.assertEqual(count, len(batched))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(name='donkeycar',
           'PrettyTable',
           'paho-mqtt',
           "simple_pid",
-          'progress'
+          'progress',
+          'typing_extensions',
       ],
       extras_require={
           'pi': [
@@ -69,6 +70,7 @@ setup(name='donkeycar',
               'pytest',
               'pytest-cov',
               'responses',
+              'mypy'
           ],
           'ci': ['codecov'],
           'tf': ['tensorflow>=2.2.0'],


### PR DESCRIPTION
* We start off with a list of shallow records, because it makes
  things easier with a train_test_split.
* The rest of the pipeline is lazy.
* The `pipeline` module is typed.