### PR TITLE
Replace dead mqtt broker server

### DIFF
--- a/donkeycar/parts/perfmon.py
+++ b/donkeycar/parts/perfmon.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Performance monitor for analyzing real-time CPU/mem/execution frequency
+
+author: @miro (Meir Tseitlin) 2020
+
+Note:
+"""
+import time
+import psutil
+
+
+class PerfMonitor:
+
+    def __init__(self, cfg):
+
+        self.STATS_BUFFER_SIZE = 10
+        self._calc_buffer = [cfg.DRIVE_LOOP_HZ for i in range(self.STATS_BUFFER_SIZE)]
+        self._runs_counter = 0
+        self._last_calc_time = time.time()
+        self._on = True
+        self._update_metrics()
+        print("Performance monitor activated.")
+
+    def _update_metrics(self):
+        self._mem_percent = psutil.virtual_memory().percent
+        self._cpu_percent = psutil.cpu_percent()
+
+    def update(self):
+        while self._on:
+            self._update_metrics()
+            time.sleep(2)
+
+    def shutdown(self):
+        # indicate that the thread should be stopped
+        self._on = False
+        print('Stopping Perf Monitor')
+        time.sleep(.2)
+
+    def run_threaded(self):
+
+        # Calc real frequency
+        curr_time = time.time()
+        if curr_time - self._last_calc_time > 1:
+            self._calc_buffer[int(curr_time) % self.STATS_BUFFER_SIZE] = self._runs_counter
+            self._runs_counter = 0
+            self._last_calc_time = curr_time
+
+        self._runs_counter += 1
+
+        vehicle_frequency = float(sum(self._calc_buffer)) / self.STATS_BUFFER_SIZE
+
+        return self._cpu_percent, self._mem_percent, vehicle_frequency

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -177,7 +177,7 @@ TELEMETRY_PUBLISH_PERIOD = 1
 HAVE_MQTT_TELEMETRY = False
 TELEMETRY_MQTT_TOPIC_TEMPLATE = 'donkey/%s/telemetry'
 TELEMETRY_MQTT_JSON_ENABLE = True
-TELEMETRY_MQTT_BROKER_HOST = 'mqtt.eclipse.org'
+TELEMETRY_MQTT_BROKER_HOST = 'broker.emqx.io'  # 'broker.emqx.io' / 'broker.hivemq.com' / 'mqtt.eclipse.org'
 TELEMETRY_MQTT_BROKER_PORT = 1883
 
 # PERF MONITOR

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -180,6 +180,9 @@ TELEMETRY_MQTT_JSON_ENABLE = True
 TELEMETRY_MQTT_BROKER_HOST = 'mqtt.eclipse.org'
 TELEMETRY_MQTT_BROKER_PORT = 1883
 
+# PERF MONITOR
+HAVE_PERFMON = False
+
 #RECORD OPTIONS
 RECORD_DURING_AI = False        #normally we do not record during ai mode. Set this to true to get image and steering records for your Ai. Be careful not to use them to train.
 AUTO_CREATE_NEW_TUB = False     #create a new tub (tub_YY_MM_DD) directory when recording or append records to data directory directly

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -304,6 +304,12 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     if cfg.USE_FPV:
         V.add(WebFpv(), inputs=['cam/image_array'], threaded=True)
 
+    #PERFMON
+    if cfg.HAVE_PERFMON:
+        from donkeycar.parts.perfmon import PerfMonitor
+        mon = PerfMonitor(cfg)
+        V.add(mon, inputs=[], outputs=['perf/cpu', 'perf/mem', 'perf/freq'], threaded=True)
+
     #Behavioral state
     if cfg.TRAIN_BEHAVIORS:
         bh = BehaviorPart(cfg.BEHAVIOR_LIST)
@@ -579,6 +585,10 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     if cfg.RECORD_DURING_AI:
         inputs += ['pilot/angle', 'pilot/throttle']
         types += ['float', 'float']
+
+    if cfg.HAVE_PERFMON:
+        inputs += ['perf/cpu', 'perf/mem', 'perf/freq']
+        types += ['float', 'float', 'float']
 
     # do we want to store new records into own dir or append to existing
     tub_path = TubHandler(path=cfg.DATA_PATH).create_tub_path() if \

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='donkeycar',
           "simple_pid",
           'progress',
           'typing_extensions',
+          'psutil'
       ],
       extras_require={
           'pi': [


### PR DESCRIPTION
Replacing default `mqtt.eclipse.org` server which seems to be dead for several days with `broker.emqx.io`