### PR TITLE
Add support for models with multiple inputs and provide developer guide for model building

### DIFF
--- a/docs/dev_guide/model.md
+++ b/docs/dev_guide/model.md
@@ -1,0 +1,305 @@
+# How to build your own model
+
+* [Overview](model.md#overview)
+* [Constructor](model.md#constructor)
+* [Training Interface](model.md#training interface)
+* [Parts Interface](model.md#parts interface)
+* [Example](model.md#example)
+
+## Overview
+
+You might want to write your own model:
+
+* If you find the models that ship with donkey not sufficient, and you want to
+  experiment with your own model infrastructure
+* If you want to add more input data to the model because your car has more
+  sensors
+
+## Constructor
+
+Models are located in `donkeycar/parts/keras.py`. Your own model needs to
+inherit from `KerasPilot` and initialize your model:
+
+```python
+class KerasSensors(KerasPilot):
+    def __init__(self, input_shape=(120, 160, 3), num_sensors=2):
+        super().__init__()
+        self.num_sensors = num_sensors
+        self.model = self.create_model(input_shape)
+```
+Here, you implement the [keras model](https://www.tensorflow.org/guide/keras/sequential_model)
+in the member function `create_model()`. The model needs to have labelled input
+and output tensors. These are required for the training to work.
+
+
+## Training interface
+
+What is required for your model to work, are the following functions:
+
+```python
+def compile(self):
+    self.model.compile(optimizer=self.optimizer, metrics=['accuracy'],
+                       loss={'angle_out': 'categorical_crossentropy',
+                             'throttle_out': 'categorical_crossentropy'},
+                       loss_weights={'angle_out': 0.5, 'throttle_out': 0.5})
+```
+
+The `compile` function tells keras how to define the loss function for training.
+We are using the `KerasCategorical` model as an example. The loss function here
+makes explicit usage of the output tensors of the
+model (`angle_out, throttle_out`).
+
+```python
+def x_transform(self, record: TubRecord):
+    img_arr = record.image(cached=True)
+    return img_arr
+```
+
+In this function you define how to extract the input data from your
+recorded data. This data is usually called `X` in the ML frame work . We have
+shown the implementation in the base class which works for all models that have
+only the image as input. 
+
+The function returns a single data item if the model has only one input. You 
+need to return a tuple if your model uses more input data.
+**Note:** _If your model has more inputs, the tuple needs to have the image in 
+the first place._ 
+
+```python
+def y_transform(self, record: TubRecord):
+    angle: float = record.underlying['user/angle']
+    throttle: float = record.underlying['user/throttle']
+    return angle, throttle
+```
+In this function you specify how to extract the `y` values (i.e. target
+values) from your recorded data.
+
+
+```python
+def x_translate(self, x: XY) -> Dict[str, Union[float, np.ndarray]]:
+    return {'img_in': x}
+```
+Here we require a translation of how the `X` value that you extracted above will
+be fed into `tf.data`. Note, `tf.data` expects a dictionary if the model has
+more than one input variable, so we have chosen to use dictionaries also in the
+one-argument case for consistency. Above we have shown the implementation in the
+base class which works for all models that have only the image as input. You
+don't have to overwrite neither `x_transform` nor
+`x_translate` if your model only uses the image as input data.
+**Note:** _the keys of the dictionary must match the name of the **input**  
+layers in the model._
+
+```python
+def y_translate(self, y: XY) -> Dict[str, Union[float, np.ndarray]]:
+    if isinstance(y, tuple):
+        angle, throttle = y
+        return {'angle_out': angle, 'throttle_out': throttle}
+    else:
+        raise TypeError('Expected tuple')
+```
+Similar to the above, this provides the translation of the `y` data into the
+dictionary required for `tf.data`. This example shows the implementation of
+`KerasLinear`.
+**Note:** _the keys of the dictionary must match the name of the **output**
+layers in the model._
+
+```python
+def output_shapes(self):
+    # need to cut off None from [None, 120, 160, 3] tensor shape
+    img_shape = self.get_input_shape()[1:]
+    shapes = ({'img_in': tf.TensorShape(img_shape)},
+              {'angle_out': tf.TensorShape([15]),
+               'throttle_out': tf.TensorShape([20])})
+    return shapes
+```
+This function returns a tuple of _two_ dictionaries that tells tensorflow which
+shapes are used in the model. We have shown the example of the 
+`KerasCategorical` model here.
+**Note 1:** _The keys of the two dictionaries must match the name of the
+**input** and **output** layers in the model._
+**Note 2:** _Where the model returns scalar numbers, the corresponding 
+type has to be `tf.TensorShape([])`._
+
+
+## Parts interface
+
+In the car application the model is called through the `run()` function. That
+function is already provided in the base class where the normalisation of the
+input image is happening centrally. Instead, the derived classes have to
+implement
+`inference()` which works on the normalised data. If you have additional data
+that needs to be normalised, too, you might want to override `run()` as well.
+```python
+def inference(self, img_arr, other_arr):
+    img_arr = img_arr.reshape((1,) + img_arr.shape)
+    outputs = self.model.predict(img_arr)
+    steering = outputs[0]
+    throttle = outputs[1]
+    return steering[0][0], throttle[0][0]
+```
+Here we are showing the implementation of the linear model. Please note that 
+the input tensor shape always contains the batch dimension in the first 
+place, hence the shape of the input image is adjusted from 
+`(120, 160, 3) -> (1, 120, 160, 3)`.
+**Note:** _If you are passing another array in the`other_arr` variable, you will
+have to do a similar re-shaping.
+
+
+## Example
+Let's build a new donkey model which is based on the standard linear model 
+but has following changes w.r.t. input data and network design:
+
+1. The model takes an additional vector of input data that represents a set 
+   of values from distance sensors which are attached to the front of the car.
+   
+2. The model adds a couple of more feed-forward layers to combine the CNN 
+   layers of the vision system with the distance sensor data.
+
+### Building the model using keras   
+So here is the example model:
+```python
+class KerasSensors(KerasPilot):
+    def __init__(self, input_shape=(120, 160, 3), num_sensors=2):
+        super().__init__()
+        self.num_sensors = num_sensors
+        self.model = self.create_model(input_shape)
+
+    def create_model(self, input_shape):
+        drop = 0.2
+        img_in = Input(shape=input_shape, name='img_in')
+        x = core_cnn_layers(img_in, drop)
+        x = Dense(100, activation='relu', name='dense_1')(x)
+        x = Dropout(drop)(x)
+        x = Dense(50, activation='relu', name='dense_2')(x)
+        x = Dropout(drop)(x)
+        # up to here, this is the standard linear model, now we add the
+        # sensor data to it
+        sensor_in = Input(shape=(self.num_sensors, ), name='sensor_in')
+        y = sensor_in
+        z = concatenate([x, y])
+        # here we add two more dens layers
+        z = Dense(50, activation='relu', name='dense_3')(z)
+        z = Dropout(drop)(z)
+        z = Dense(50, activation='relu', name='dense_4')(z)
+        z = Dropout(drop)(z)
+        # two outputs for angle and throttle
+        outputs = [
+            Dense(1, activation='linear', name='n_outputs' + str(i))(z)
+            for i in range(2)]
+
+        # the model needs to specify the additional input here
+        model = Model(inputs=[img_in, sensor_in], outputs=outputs)
+        return model
+
+    def compile(self):
+        self.model.compile(optimizer=self.optimizer, loss='mse')
+
+    def inference(self, img_arr, other_arr):
+        img_arr = img_arr.reshape((1,) + img_arr.shape)
+        sens_arr = other_arr.reshape((1,) + other_arr.shape)
+        outputs = self.model.predict([img_arr, sens_arr])
+        steering = outputs[0]
+        throttle = outputs[1]
+        return steering[0][0], throttle[0][0]
+
+    def x_transform(self, record: TubRecord) -> XY:
+        img_arr = super().x_transform(record)
+        # for simplicity we assume the sensor data here is normalised
+        sensor_arr = np.array(record.underlying['sensor'])
+        # we need to return the image data first
+        return img_arr, sensor_arr
+
+    def x_translate(self, x: XY) -> Dict[str, Union[float, np.ndarray]]:
+        assert isinstance(x, tuple), 'Requires tuple as input'
+        # the keys are the names of the input layers of the model
+        return {'img_in': x[0], 'sensor_in': x[1]}
+
+    def y_transform(self, record: TubRecord):
+        angle: float = record.underlying['user/angle']
+        throttle: float = record.underlying['user/throttle']
+        return angle, throttle
+
+    def y_translate(self, y: XY) -> Dict[str, Union[float, np.ndarray]]:
+        if isinstance(y, tuple):
+            angle, throttle = y
+            # the keys are the names of the output layers of the model
+            return {'n_outputs0': angle, 'n_outputs1': throttle}
+        else:
+            raise TypeError('Expected tuple')
+
+    def output_shapes(self):
+        # need to cut off None from [None, 120, 160, 3] tensor shape
+        img_shape = self.get_input_shape()[1:]
+        # the keys need to match the models input/output layers
+        shapes = ({'img_in': tf.TensorShape(img_shape),
+                   'sensor_in': tf.TensorShape([self.num_sensors])},
+                  {'n_outputs0': tf.TensorShape([]),
+                   'n_outputs1': tf.TensorShape([])})
+        return shapes
+```
+We could have inherited from `KerasLinear` which would provide the 
+implementation of `y_transform(), y_translate(), compile()`. The model 
+requires the sensor data to be an array in the TubRecord with key `"sensor"`.
+
+### Creating a tub
+
+Because we don't have a tub with sensor data, let's create one with fake 
+sensor entries:
+```python
+import os
+import tarfile
+import numpy as np
+from donkeycar.parts.tub_v2 import Tub
+from donkeycar.pipeline.types import TubRecord
+from donkeycar.config import load_config
+
+
+if __name__ == '__main__':
+    # put your path to your car app
+    my_car = os.path.expanduser('~/mycar')
+    cfg = load_config(os.path.join(my_car, 'config.py'))
+    # put your path to donkey project
+    tar = tarfile.open(os.path.expanduser(
+        '~/Python/donkeycar/donkeycar/tests/tub/tub.tar.gz'))
+    tub_parent = os.path.join(my_car, 'data2/')
+    tar.extractall(tub_parent)
+    tub_path = os.path.join(tub_parent, 'tub')
+    tub1 = Tub(tub_path)
+    tub2 = Tub(os.path.join(my_car, 'data2/tub_sensor'),
+               inputs=['cam/image_array', 'user/angle', 'user/throttle',
+                       'sensor'],
+               types=['image_array', 'float', 'float', 'list'])
+
+    for record in tub1:
+        t_record = TubRecord(config=cfg,
+                             base_path=tub1.base_path,
+                             underlying=record)
+        img_arr = t_record.image(cached=False)
+        record['sensor'] = list(np.random.uniform(size=2))
+        record['cam/image_array'] = img_arr
+        tub2.write_record(record)
+```
+
+### Making the model available
+We don't have a dynamic factory yet, so we need to add the new model into the 
+function `get_model_by_type()` in the module `donkeycar/utils.py`:
+```python
+...
+elif model_type == 'sensor':
+    kl = KerasSensors(input_shape=input_shape)
+...
+```
+
+### Go train
+In your car app folder now the following should work:
+`donkey train --tub data2/tub_sensor --model models/pilot.h5 --type sensor`
+Because of the random values in the data the model will not converge quickly,
+the goal here is to get it working in the frame work.
+
+
+## Support and discussions
+Please join the [Discord](https://discord.gg/dpvYHhpV2w) Donkey Car group for 
+support and discussions.
+
+
+

--- a/docs/utility/donkey.md
+++ b/docs/utility/donkey.md
@@ -65,6 +65,16 @@ donkey tubclean <folder containing tubs>
 * Opens the web server to delete bad data.
 * Hit `Ctrl + C` to exit
 
+## Train the model
+**Note:** _This section only applies to version 4.x_
+The command train the model.
+```bash
+donkey train --tub=<tub_path> [--config=<config.py>] [--model=<model path>] [--model_type=(linear|categorical|inferred)] 
+```
+The `createcar` command still creates a `train.py` file for backward 
+compatibility, but it's not need and training can be run like this.
+
+
 ## Make Movie from Tub
 
 This command allows you to create a movie file from the images in a Tub.

--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -1,11 +1,14 @@
-__version__ = '4.1.0-dev'
-
-print('using donkey v{} ...'.format(__version__))
-
 import sys
+from pyfiglet import Figlet
 
-if sys.version_info.major < 3:
-    msg = 'Donkey Requires Python 3.6 or greater. You are using {}'.format(sys.version)
+__version__ = '4.1.0-dev'
+f = Figlet(font='speed')
+
+print(f.renderText('Donkey Car'))
+print(f'using donkey v{__version__} ...')
+
+if sys.version_info.major < 3 or sys.version_info.minor < 6:
+    msg = f'Donkey Requires Python 3.6 or greater. You are using {sys.version}'
     raise ValueError(msg)
 
 # The default recursion limits in CPython are too small.

--- a/donkeycar/pipeline/sequence.py
+++ b/donkeycar/pipeline/sequence.py
@@ -132,7 +132,8 @@ class TubSequence(Iterable[TubRecord]):
 
     def build_pipeline(self,
                        x_transform: Callable[[TubRecord], X],
-                       y_transform: Callable[[TubRecord], Y]) -> SizedIterator[Tuple[X, Y]]:
+                       y_transform: Callable[[TubRecord], Y]) \
+            -> TfmIterator:
         return TfmIterator(self, x_transform=x_transform, y_transform=y_transform)
 
     @classmethod

--- a/donkeycar/pipeline/types.py
+++ b/donkeycar/pipeline/types.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, List, Optional, TypeVar, Tuple
 
 import numpy as np
+from donkeycar.config import Config
 from donkeycar.parts.tub_v2 import Tub
 from donkeycar.utils import load_image_arr, normalize_image, train_test_split
 from typing_extensions import TypedDict
@@ -26,7 +27,8 @@ TubRecordDict = TypedDict(
 
 
 class TubRecord(object):
-    def __init__(self, config: Any, base_path: str, underlying: TubRecordDict) -> None:
+    def __init__(self, config: Config, base_path: str,
+                 underlying: TubRecordDict) -> None:
         self.config = config
         self.base_path = base_path
         self.underlying = underlying
@@ -52,7 +54,8 @@ class TubDataset(object):
     Loads the dataset, and creates a train/test split.
     '''
 
-    def __init__(self, config: Any, tub_paths: List[str], shuffle: bool = True):
+    def __init__(self, config: Config, tub_paths: List[str],
+                 shuffle: bool = True) -> None:
         self.config = config
         self.tub_paths = tub_paths
         self.shuffle = shuffle

--- a/donkeycar/tests/test_pipeline.py
+++ b/donkeycar/tests/test_pipeline.py
@@ -3,7 +3,11 @@ import unittest
 from typing import List
 
 import numpy as np
+
+from donkeycar.config import Config
+from donkeycar.parts.keras import KerasLinear
 from donkeycar.pipeline.sequence import SizedIterator, TubSequence
+from donkeycar.pipeline.training import BatchSequence
 from donkeycar.pipeline.types import TubRecord, TubRecordDict
 
 
@@ -25,7 +29,7 @@ def random_record() -> TubRecord:
         'imu/gyr_y': None,
         'imu/gyr_z': None
     }
-    return TubRecord('/base', None, underlying=underlying)
+    return TubRecord(config=Config(), base_path='/base', underlying=underlying)
 
 
 size = 10

--- a/donkeycar/tests/test_train.py
+++ b/donkeycar/tests/test_train.py
@@ -1,14 +1,19 @@
-import tempfile
 import pytest
 import tarfile
 import os
+import numpy as np
+from collections import defaultdict, namedtuple
 
-from donkeycar.pipeline.training import train
+from donkeycar.pipeline.training import train, BatchSequence
 from donkeycar.config import Config
+from donkeycar.pipeline.types import TubDataset
+from donkeycar.utils import get_model_by_type, normalize_image
+
+Data = namedtuple('Data', ['type', 'name', 'convergence', 'pretrained'])
 
 
 @pytest.fixture
-def config():
+def config() -> Config:
     """ Config for the test with relevant parameters"""
     cfg = Config()
     cfg.BATCH_SIZE = 64
@@ -25,39 +30,99 @@ def config():
     return cfg
 
 
-@pytest.fixture
-def car_dir():
-    """ temp directory to extract tub and run training"""
-    return tempfile.mkdtemp()
-
-
-@pytest.fixture
-def tub_dir(car_dir):
-    """ extract tub.tar.gz into temp car_dir/tub """
-    tub_dir = os.path.join(car_dir, 'tub')
+@pytest.fixture(scope='session')
+def car_dir(tmpdir_factory):
+    """ Creating car dir with sub dirs and extracting tub """
+    dir = tmpdir_factory.mktemp('mycar')
+    os.mkdir(os.path.join(dir, 'models'))
+    # extract tub.tar.gz into temp car_dir/tub
     this_dir = os.path.dirname(os.path.abspath(__file__))
     with tarfile.open(os.path.join(this_dir, 'tub', 'tub.tar.gz')) as file:
-        file.extractall(car_dir)
-    return tub_dir
+        file.extractall(dir)
+    return dir
 
 
-@pytest.mark.parametrize('model_type_and_loss', [
-                            ('linear', 0.2),
-                            ('categorical', 2.0)
-                            ])
-def test_train(config, car_dir, tub_dir, model_type_and_loss):
+# define the test data
+d1 = Data(type='linear', name='lin1', convergence=0.6, pretrained=None)
+d2 = Data(type='categorical', name='cat1', convergence=0.85, pretrained=None)
+d3 = Data(type='inferred', name='inf1', convergence=0.6, pretrained=None)
+d4 = Data(type='latent', name='lat1', convergence=0.5, pretrained=None)
+d5 = Data(type='latent', name='lat2', convergence=0.5, pretrained='lat1')
+test_data = [d1, d2, d3]
+
+
+@pytest.mark.skipif("TRAVIS" in os.environ,
+                    reason='Suppress training test in CI')
+@pytest.mark.parametrize('data', test_data)
+def test_train(config: Config, car_dir: str, data: Data) -> None:
     """
     Testing convergence of the linear an categorical models
 
+    :param config:          donkey config
+    :param car_dir:         car directory (this is a temp dir)
+    :param data:            test case data
+    :return:                None
+    """
+    def pilot_path(name):
+        pilot_name = f'pilot_{name}.h5'
+        return os.path.join(car_dir, 'models', pilot_name)
+
+    if data.pretrained:
+        config.LATENT_TRAINED = pilot_path(data.pretrained)
+    tub_dir = os.path.join(car_dir, 'tub')
+    history = train(config, tub_dir, pilot_path(data.name), data.type)
+    loss = history.history['loss']
+    # check loss is converging
+    assert loss[-1] < loss[0] * data.convergence
+
+
+@pytest.mark.parametrize('model_type', ['linear', 'categorical', 'inferred'])
+def test_training_pipeline(config: Config, model_type: str, car_dir: str) \
+        -> None:
+    """
+    Testing consistency of the model interfaces and data used in training
+    pipeline.
+
     :param config:                  donkey config
-    :param car_dir:                 car directory (this is a temp dir)
+    :param model_type:              test specification of model type
     :param tub_dir:                 tub directory (car_dir/tub)
-    :param model_type_and_loss:     test specification of model type and loss
-                                    threshold in training
     :return:                        None
     """
-    model_path = os.path.join(car_dir, 'models', 'pilot.h5')
-    history = train(config, tub_dir, model_path, model_type_and_loss[0])
-    loss = history.history['loss']
-    assert loss[-1] < model_type_and_loss[1]
+    kl = get_model_by_type(model_type, config)
+    tub_dir = os.path.join(car_dir, 'tub')
+    # don't shuffle so we can identify data for testing
+    dataset = TubDataset(config, [tub_dir], shuffle=False)
+    training_records, validation_records = dataset.train_test_split()
+    seq = BatchSequence(kl, config, training_records, True)
+    data_train = seq.create_tf_data()
+    num_whole_batches = len(training_records) // config.BATCH_SIZE
+    # this takes all batches into one list
+    tf_batch = list(data_train.take(num_whole_batches).as_numpy_iterator())
+    it = iter(training_records)
+    for xy_batch in tf_batch:
+        # extract x and y values from records, asymmetric in x and y b/c x
+        # requires image manipulations
+        batch_records = [next(it) for _ in range(config.BATCH_SIZE)]
+        records_x = [kl.x_translate(normalize_image(kl.x_transform(r))) for
+                     r in batch_records]
+        records_y = [kl.y_translate(kl.y_transform(r)) for r in
+                     batch_records]
+        # from here all checks are symmetrical between x and y
+        for batch, o_type, records \
+                in zip(xy_batch, kl.output_types(), (records_x, records_y)):
+            # check batch dictionary have expected keys
+            assert batch.keys() == o_type.keys(), \
+                'batch keys need to match models output types'
+            # convert record values into arrays of batch size
+            values = defaultdict(list)
+            for r in records:
+                for k, v in r.items():
+                    values[k].append(v)
+            # now convert arrays of floats or numpy arrays into numpy arrays
+            np_dict = dict()
+            for k, v in values.items():
+                np_dict[k] = np.array(v)
+            # compare record values with values from tf.data
+            for k, v in batch.items():
+                assert np.isclose(v, np_dict[k]).all()
 

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -21,6 +21,7 @@ from typing import List, Any, Tuple
 from PIL import Image
 import numpy as np
 
+
 '''
 IMAGES
 '''
@@ -385,14 +386,13 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
-def get_model_by_type(model_type, cfg):
+def get_model_by_type(model_type: str, cfg: 'Config') -> 'KerasPilot':
     '''
     given the string model_type and the configuration settings in cfg
     create a Keras model and return it.
     '''
-    from donkeycar.parts.keras import KerasRNN_LSTM, KerasBehavioral, \
-        KerasCategorical, KerasIMU, KerasLinear, Keras3D_CNN, \
-        KerasLocalizer, KerasLatent, KerasInferred
+    from donkeycar.parts.keras import KerasPilot, KerasCategorical, \
+        KerasLinear, KerasInferred
     from donkeycar.parts.tflite import TFLitePilot
 
     if model_type is None:
@@ -400,12 +400,12 @@ def get_model_by_type(model_type, cfg):
     print("\"get_model_by_type\" model Type is: {}".format(model_type))
 
     input_shape = (cfg.IMAGE_H, cfg.IMAGE_W, cfg.IMAGE_DEPTH)
+    kl: KerasPilot
     if model_type == "linear":
         kl = KerasLinear(input_shape=input_shape)
     elif model_type == "categorical":
         kl = KerasCategorical(input_shape=input_shape,
                               throttle_range=cfg.MODEL_CATEGORICAL_MAX_THROTTLE_RANGE)
-
     elif model_type == 'inferred':
         kl = KerasInferred(input_shape=input_shape)
     elif model_type == "tflite_linear":

--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -23,6 +23,8 @@ dependencies:
   - moviepy
   - paho-mqtt
   - PrettyTable
+  - pyfiglet
+  - mypy
   - pip:
     - tensorflow==2.2.0
     - git+https://github.com/autorope/keras-vis.git

--- a/install/envs/ubuntu.yml
+++ b/install/envs/ubuntu.yml
@@ -23,6 +23,8 @@ dependencies:
   - moviepy
   - paho-mqtt
   - PrettyTable
+  - pyfiglet
+  - mypy
   - tensorflow==2.2.0
   - pip:
     - git+https://github.com/autorope/keras-vis.git

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ pages:
       - 'Stop Sign Detection': parts/stop_sign_detection.md
   - Utilities:
       - 'donkey': utility/donkey.md
+  - Developer Guide:
+      - 'Create your own model': dev_guide/model.md
 
   - Supported Cars: supported_cars.md
   - Roll Your Own: roll_your_own.md

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(name='donkeycar',
           "simple_pid",
           'progress',
           'typing_extensions',
+          'pyfiglet'
       ],
       extras_require={
           'pi': [


### PR DESCRIPTION
* Add support for multi-dimensional model input by using dictionaries for tf data inputs
* Symmetric behaviour for `X, Y` data input model  - converting from tub record into numpy arrays and then into dictionaries.
* Simplify model interface by implementing output_types() directly in the base class using output_shapes() dictionary.
* Adding developer guide for own model development.
* Updated donkey command documentation with `train` command.
* Improve asserts and type hints in keras.py
* Added missing __init__.py in parts module.
* Add cool ascii text for donkey init and update yml and setup files including mypy.
* Remove model training test from Travis and change the test to relative convergence. This avoids random fall overs in CI.
* Added test of tf.data as used in the training pipeline through re-implementation of data transformation from tub records to tf expected dictionaries, for all currently supported models.