### PR TITLE
Minor fixes for Python3.5 and RPi4 compatibility

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -173,11 +173,12 @@ class FindCar(BaseCommand):
         
         print("Finding your car's IP address...")
         cmd = "sudo nmap -sP " + ip + "/24 | awk '/^Nmap/{ip=$NF}/B8:27:EB/{print ip}'"
+        cmdRPi4 = "sudo nmap -sP " + ip + "/24 | awk '/^Nmap/{ip=$NF}/DC:A6:32/{print ip}'"
         print("Your car's ip address is:" )
         os.system(cmd)
-        
-        
-        
+        os.system(cmdRPi4)
+
+
 class CalibrateCar(BaseCommand):    
     
     def parse_args(self, args):

--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -237,7 +237,7 @@ class WebSocketCalibrateAPI(tornado.websocket.WebSocketHandler):
         print("New client connected")
 
     def on_message(self, message):
-        print(f"wsCalibrate {message}")
+        print("wsCalibrate ",message)
         data = json.loads(message)
         if 'throttle' in data:
             print(data['throttle'])


### PR DESCRIPTION
-print(f"wsCalibrate {message}") replaced with print("wsCalibrate ",message) in donkeycar/donkeycar/parts/web_controller/web.py  so that it works with Python 3.5 (in case using Ubuntu 16.04).
-FindCar donkey function now works with RPi model 4 too, whose MAC addresses are different.