### PR TITLE
docs: fix simple typo, unfarmilar -> unfamiliar

### DIFF
--- a/docs/guide/host_pc/setup_windows.md
+++ b/docs/guide/host_pc/setup_windows.md
@@ -6,7 +6,7 @@ Windows provides a few different methods for setting up and installing Donkey Ca
 2. Native
 3. Windows Subsystem for Linux (WSL) - Experimental
 
-If you are unfarmilar or concerned about the way that you install Donkey Car, please use option 1 above.
+If you are unfamiliar or concerned about the way that you install Donkey Car, please use option 1 above.
 
 ## Install Donkeycar on Windows (miniconda)
 


### PR DESCRIPTION
There is a small typo in docs/guide/host_pc/setup_windows.md.

Should read `unfamiliar` rather than `unfarmilar`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md