### PR TITLE
Update ubuntu.yml on master

### DIFF
--- a/install/envs/ubuntu.yml
+++ b/install/envs/ubuntu.yml
@@ -1,7 +1,7 @@
 name: donkey
 dependencies:
 
-- h5py==2.10.0
+- h5py==2.8.0
 - pillow
 - tensorflow==1.13.1
 - opencv


### PR DESCRIPTION
Fix dependency issue again

For some reason h5py can't pin to 2.10.0 so falling back to make it the same as mac.yml