### PR TITLE
Add support for TensorFlow >= 2.2.0 <= 2.3.2 in conda env 

### DIFF
--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -32,7 +32,7 @@ dependencies:
   - pytorch-lightning
   - numpy
   - pip:
-    - tensorflow==2.2.0
+    - tensorflow>=2.2.0,<=2.3.2
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid
     - opencv-python-headless

--- a/install/envs/ubuntu.yml
+++ b/install/envs/ubuntu.yml
@@ -31,7 +31,7 @@ dependencies:
   - torchaudio
   - pytorch-lightning
   - numpy
-  - tensorflow==2.2.0
+  - tensorflow>=2.2.0,<=2.3.2
   - pip:
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid


### PR DESCRIPTION
Updated yaml files for conda envs to allow tf versions >= 2.2.0 <= 2.3.2. I checked that training w/ 2.3.2 and inferencing w/ 2.2.0 works w/o problems. However training w/ 2.4.0 seems to be not backward compatible to 2.2.x / 2.3.x, hence we keep the highest version at 2.3.2.