### PR TITLE
Fixed FindCar function for RPi4

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -173,8 +173,10 @@ class FindCar(BaseCommand):
         
         print("Finding your car's IP address...")
         cmd = "sudo nmap -sP " + ip + "/24 | awk '/^Nmap/{ip=$NF}/B8:27:EB/{print ip}'"
+        cmdRPi4 = "sudo nmap -sP " + ip + "/24 | awk '/^Nmap/{ip=$NF}/DC:A6:32/{print ip}'"
         print("Your car's ip address is:" )
         os.system(cmd)
+        os.system(cmdRPi4)
 
 
 class CalibrateCar(BaseCommand):    


### PR DESCRIPTION
As agreed with @DocGarbanzo in this [PR](https://github.com/autorope/donkeycar/pull/712) I'm moving it to 1 commit to dev branch.
_FindCar donkey function will now work with Raspberries model 4 too, whose MAC addresses are different._

