### PR TITLE
Pin tf to 2.2.0 in setup for pip and yaml for conda.

### DIFF
--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -32,7 +32,7 @@ dependencies:
   - pytorch-lightning
   - numpy
   - pip:
-    - tensorflow>=2.2.0,<=2.3.2
+    - tensorflow=2.2.0
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid
     - opencv-python-headless

--- a/install/envs/pc.yml
+++ b/install/envs/pc.yml
@@ -31,7 +31,7 @@ dependencies:
   - torchaudio
   - pytorch-lightning
   - numpy
-  - tensorflow>=2.2.0,<=2.3.2
+  - tensorflow=2.2.0
   - pip:
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(name='donkeycar',
               'mypy'
           ],
           'ci': ['codecov'],
-          'tf': ['tensorflow>=2.2.0'],
+          'tf': ['tensorflow==2.2.0'],
           'torch': [
               'pytorch>=1.7.1',
               'torchvision',


### PR DESCRIPTION
This solves the issue of getting error: `W tensorflow/core/kernels/data/generator_dataset_op.cc:103] Error occurred when finalizing GeneratorDataset iterator: Failed precondition: Python interpreter state is not initialized. The process may be terminated.` - this seems to occur for all versions >= 2.3.0.