### PR TITLE
Support imgaug on nano and pi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(name='donkeycar',
           "simple_pid",
           'progress',
           'typing_extensions',
-          'pyfiglet'
+          'pyfiglet',
+          'imgaug',
       ],
       extras_require={
           'pi': [
@@ -65,7 +66,6 @@ setup(name='donkeycar',
           ],
           'pc': [
               'matplotlib',
-              'imgaug',
           ],
           'dev': [
               'pytest',


### PR DESCRIPTION
Move imgaug from pc section to install_requires so it can be used on nano and pi as well.