### PR TITLE
Patch for #752 - fix wrong operator in pip.

### DIFF
--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -32,7 +32,7 @@ dependencies:
   - pytorch-lightning
   - numpy
   - pip:
-    - tensorflow=2.2.0
+    - tensorflow==2.2.0
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid
     - opencv-python-headless


### PR DESCRIPTION
Accidentally checked in `=` instead of `==` in the pip section of the conda mac.yml