### PR TITLE
new: convert prints to python logging

### DIFF
--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -183,6 +183,11 @@ MM1_SHOW_STEERING_VALUE = False
 #  eg.'/dev/tty.usbmodemXXXXXX' and replace the port accordingly
 MM1_SERIAL_PORT = '/dev/ttyS0'  # Serial Port for reading and sending MM1 data.
 
+#LOGGING
+HAVE_CONSOLE_LOGGING = True
+LOGGING_LEVEL = 'INFO'          # (Python logging level) 'NOTSET' / 'DEBUG' / 'INFO' / 'WARNING' / 'ERROR' / 'FATAL' / 'CRITICAL'
+LOGGING_FORMAT = '%(message)s'  # (Python logging format - https://docs.python.org/3/library/logging.html#formatter-objects
+
 #TELEMETRY
 TELEMETRY_DONKEY_NAME = 'my_robot1234'
 TELEMETRY_PUBLISH_PERIOD = 1

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -17,6 +17,7 @@ Options:
 import os
 import time
 
+import logging
 from docopt import docopt
 import numpy as np
 
@@ -31,6 +32,9 @@ from donkeycar.parts.behavior import BehaviorPart
 from donkeycar.parts.file_watcher import FileWatcher
 from donkeycar.parts.launch import AiLaunch
 from donkeycar.utils import *
+
+
+logger = logging.getLogger()
 
 
 def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type='single', meta=[]):
@@ -60,7 +64,14 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     #Initialize car
     V = dk.vehicle.Vehicle()
 
-    print("cfg.CAMERA_TYPE", cfg.CAMERA_TYPE)
+    #Initialize logging before anything else to allow console logging
+    if cfg.HAVE_CONSOLE_LOGGING:
+        logger.setLevel(logging.getLevelName(cfg.LOGGING_LEVEL))
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter(cfg.LOGGING_FORMAT))
+        logger.addHandler(ch)
+
+    logger.info("cfg.CAMERA_TYPE %s"%cfg.CAMERA_TYPE)
     if camera_type == "stereo":
 
         if cfg.CAMERA_TYPE == "WEBCAM":

--- a/donkeycar/vehicle.py
+++ b/donkeycar/vehicle.py
@@ -8,11 +8,13 @@ Created on Sun Jun 25 10:44:24 2017
 
 import time
 import numpy as np
+import logging
 from threading import Thread
 from .memory import Memory
 from prettytable import PrettyTable
 import traceback
 
+logger = logging.getLogger(__name__)
 
 class PartProfiler:
     def __init__(self):
@@ -34,7 +36,7 @@ class PartProfiler:
         self.records[p]['times'][-1] = delta
 
     def report(self):
-        print("Part Profile Summary: (times in ms)")
+        logger.info("Part Profile Summary: (times in ms)")
         pt = PrettyTable()
         field_names = ["part", "max", "min", "avg"]
         pctile = [50, 90, 99, 99.9]
@@ -52,7 +54,7 @@ class PartProfiler:
                    "%.2f" % (sum(arr) / len(arr) * 1000)]
             row += ["%.2f" % (np.percentile(arr, p) * 1000) for p in pctile]
             pt.add_row(row)
-        print(pt)
+        logger.info(pt)
 
 
 class Vehicle:
@@ -89,7 +91,7 @@ class Vehicle:
         assert type(threaded) is bool, "threaded is not a boolean: %r" % threaded
 
         p = part
-        print('Adding part {}.'.format(p.__class__.__name__))
+        logger.info('Adding part {}.'.format(p.__class__.__name__))
         entry = {}
         entry['part'] = p
         entry['inputs'] = inputs
@@ -141,7 +143,7 @@ class Vehicle:
                     entry.get('thread').start()
 
             # wait until the parts warm up.
-            print('Starting vehicle at {} Hz'.format(rate_hz))
+            logger.info('Starting vehicle at {} Hz'.format(rate_hz))
 
             loop_count = 0
             while self.on:
@@ -160,7 +162,7 @@ class Vehicle:
                 else:
                     # print a message when could not maintain loop rate.
                     if verbose:
-                        print('WARN::Vehicle: jitter violation in vehicle loop '
+                        logger.info('WARN::Vehicle: jitter violation in vehicle loop '
                               'with {0:4.0f}ms'.format(abs(1000 * sleep_time)))
 
                 if verbose and loop_count % 200 == 0:
@@ -205,7 +207,7 @@ class Vehicle:
                 self.profiler.on_part_finished(p)
 
     def stop(self):        
-        print('Shutting down vehicle and its parts...')
+        logger.info('Shutting down vehicle and its parts...')
         for entry in self.parts:
             try:
                 entry['part'].shutdown()
@@ -213,6 +215,6 @@ class Vehicle:
                 # usually from missing shutdown method, which should be optional
                 pass
             except Exception as e:
-                print(e)
+                logger.error(e)
 
         self.profiler.report()


### PR DESCRIPTION
The idea is to convert all "prints" into standard Python logging (which by default will look like "prints" in console but can be customized via config) and also sent to MQTT monitoring app.

This is a preliminary PR for review only.

Things to do:
* Convert all "prints" to `logger.info(`