### PR TITLE
readme.md_fixme_import_TubWriter_from_datastore_v2.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The donkey car is controlled by running a sequence of events
 import time
 from donkeycar import Vehicle
 from donkeycar.parts.cv import CvCam
-from donkeycar.parts.datastore_v2 import TubWriter
+# FIXME from donkeycar.parts.datastore_v2 import TubWriter => needs class TubWriter in ./datastore_v2.py
+from donkeycar.parts.datastore import TubWriter
 V = Vehicle()
 
 IMAGE_W = 160

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ The donkey car is controlled by running a sequence of events
 import time
 from donkeycar import Vehicle
 from donkeycar.parts.cv import CvCam
-# FIXME from donkeycar.parts.datastore_v2 import TubWriter => needs class TubWriter in ./datastore_v2.py
-from donkeycar.parts.datastore import TubWriter
+from donkeycar.parts.tub_v2 import TubWriter
 V = Vehicle()
 
 IMAGE_W = 160


### PR DESCRIPTION
due to following the readme while trying to deploy donkeycar in an DGX env we faced the problem that the file ./datastore_v2.py is missing the `class TubWriter`. Please merge to fix the README.md