### PR TITLE
Improvements in GitHub Actions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,10 @@
 name: Python package and test
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
 
 jobs:
   checkout-test:
@@ -14,7 +18,7 @@ jobs:
 
           - os: ubuntu-latest
             ENV_FILE: install/envs/pc.yml
-
+      fail-fast: false
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,7 +1,7 @@
 name: Super-Linter
 
 # Run this workflow every time a new commit pushed to your repository
-on: push
+on: [push, pull_request]
 
 jobs:
   # Set the job key. The key is displayed as the job name
@@ -11,7 +11,8 @@ jobs:
     name: Lint code base
     # Set the type of machine to run on
     runs-on: ubuntu-latest
-
+    # Don't flag failure
+    continue-on-error: true
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code


### PR DESCRIPTION
Small improvements for GH actions:
* Don't flag linter errors
* Add linter trigger on PRs
* Don't stop build on other platforms if one platform fails
* Don't trigger build if only changes are in `docs/`