### PR TITLE
Documentation innacuracy ubuntu.yml was renamed pc.yml

### DIFF
--- a/docs/guide/host_pc/setup_ubuntu.md
+++ b/docs/guide/host_pc/setup_ubuntu.md
@@ -38,7 +38,7 @@ conda env remove -n donkey
 * Create the Python anaconda environment
 
 ```bash
-conda env create -f install/envs/ubuntu.yml
+conda env create -f install/envs/pc.yml
 conda activate donkey
 pip install -e .[pc]
 ```


### PR DESCRIPTION
conda env create -f install/envs/ubuntu.yml

The error is visible on this website https://docs.donkeycar.com/guide/host_pc/setup_ubuntu/

link to modified file in your repo
https://github.com/autorope/donkeycar/blob/dev/install/envs/pc.yml

Thx for the open source sim