### PR TITLE
Support running webcontroller and physical joystick at the same time

### DIFF
--- a/donkeycar/parts/web_controller/templates/vehicle.html
+++ b/donkeycar/parts/web_controller/templates/vehicle.html
@@ -52,6 +52,7 @@
       </div>
     </div>
     <hr>
+
     <div class="row">
       <div class="col-xs-4 col-sm-2 col-md-2">
         <div id="control-bars">
@@ -114,6 +115,9 @@
           </div>
         </div><!-- end right col -->
       </div><!-- end right col -->
+    </div>
+    <div class="row">
+      <p  style="text-align:center;color:rgb(255, 27, 65)">Caution: If a Physical Joystick is Used, It overides the Web Controller.</p>
     </div>
     <div id="joystick-padding"></div>
     

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -171,6 +171,15 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             
         V.add(cam, inputs=inputs, outputs=outputs, threaded=threaded)
 
+    #This web controller will create a web server that is capable
+    #of managing steering, throttle, and modes, and more.
+    ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
+    
+    V.add(ctr,
+        inputs=['cam/image_array', 'tub/num_records'],
+        outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
+        threaded=True)
+        
     if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
         #modify max_throttle closer to 1.0 to have more power
         #modify steering_scale lower than 1.0 to have less responsive steering
@@ -201,16 +210,6 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         
         V.add(ctr, 
           inputs=['cam/image_array'],
-          outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
-          threaded=True)
-
-    else:
-        #This web controller will create a web server that is capable
-        #of managing steering, throttle, and modes, and more.
-        ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
-        
-        V.add(ctr,
-          inputs=['cam/image_array', 'tub/num_records'],
           outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
           threaded=True)
 


### PR DESCRIPTION
This address one of the most popular requests from the community. With this PR, the web controller is always turned on no matter a joysticker is used or not. Please note the outputs of physical joystick overide the outputs of the local web controller, meaning that one can only use joystick to drive the car after enabling a joystick. 