### PR TITLE
Kivy UI fixes

### DIFF
--- a/docs/utility/ui.md
+++ b/docs/utility/ui.md
@@ -11,6 +11,11 @@ The Donkey UI currently contains three screens supporting the following workflow
 
 1. The pilot arena - here you can test two pilots' performance  against each other.
 
+**_Note_:** Under linux the app depends on `xclip`, if this is not installed, then please run:
+```bash
+sudo apt-get install xclip
+```
+
 ## The tub manager
 ![Tub_manager UI](../assets/ui-tub-manager.png)
 

--- a/donkeycar/management/ui.kv
+++ b/donkeycar/management/ui.kv
@@ -1,6 +1,7 @@
 #: import TsPlot donkeycar.management.graph.TsPlot
 #: import get_model_by_type donkeycar.utils.get_model_by_type
 #: import platform sys.platform
+#: import os os
 
 #:set common_height 30 if platform != 'darwin' else 60
 #:set layout_pad_x 10 if platform != 'darwin' else 20
@@ -591,8 +592,9 @@
             # first row
             Label:
                 text: 'Car directory (hit return)'
-            Label:
-                text: 'Select tub'
+            ToggleButton:
+                id: create_dir
+                text: 'Create new folder'
             ProgressBar:
                 value: root.pull_bar
             ProgressBar:
@@ -673,5 +675,6 @@
             id: tab_bar
             manager: root.manager
         Image:
-            source: '../parts/web_controller/templates/static/donkeycar-logo-sideways.png'
+            source: root.img_path
             size: self.texture_size
+


### PR DESCRIPTION
* Make config parameters `PI_USERNAME` and `PI_HOSTNAME` optional, these are only needed in the car connector
* Add button to select copying tub contents (i.e. `rsync mycar/data/` vs `rsync mycar/data` which creates a new directory resulting in `mycar/data/data` on the host pc).
* Fixed path to startup screen image
* Added hint in docs for Kivy dependency on linux