### PR TITLE
Refactored RC control for GPIO pins 

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -200,7 +200,7 @@ class JHat:
     def set_pulse(self, pulse):
         self.set_pwm(self.channel, 0, pulse) 
 
-    def set_pwm(self, channel, on, off:
+    def set_pwm(self, channel, on, off):
         # sets a single PWM channel
         self.pwm._device.writeList(self.register, [off & 0xFF, off >> 8])
         

--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -61,110 +61,25 @@ class PiGPIO_PWM():
 
     def __init__(self, pin, pgio=None, freq=75, inverted=False):
         import pigpio
-
         self.pin = pin
         self.pgio = pgio or pigpio.pi()
         self.freq = freq
         self.inverted = inverted
         self.pgio.set_mode(self.pin, pigpio.OUTPUT)
+        self.dead_zone = 37000
 
     def __del__(self):
         self.pgio.stop()
 
     def set_pulse(self, pulse):
-        self.pgio.hardware_PWM(self.pin, self.freq, int(pulse if self.inverted == False else 1e6 - pulse))
+#
+        self.output = pulse * 200
+        if self.output > 0:
+            self.pgio.hardware_PWM(self.pin, self.freq, int(self.output if self.inverted == False else 1e6 - self.output))
+
 
     def run(self, pulse):
         self.set_pulse(pulse)
-
-
-class JHat:
-    ''' 
-    PWM motor controler using Teensy emulating PCA9685. 
-    '''
-    def __init__(self, channel, address=0x40, frequency=60, busnum=None):
-        print("Firing up the Hat")
-        import Adafruit_PCA9685
-        LED0_OFF_L = 0x08
-        # Initialise the PCA9685 using the default address (0x40).
-        if busnum is not None:
-            from Adafruit_GPIO import I2C
-            # replace the get_bus function with our own
-            def get_bus():
-                return busnum
-            I2C.get_default_bus = get_bus
-        self.pwm = Adafruit_PCA9685.PCA9685(address=address)
-        self.pwm.set_pwm_freq(frequency)
-        self.channel = channel
-        self.register = LED0_OFF_L+4*channel
-
-        # we install our own write that is more efficient use of interrupts
-        self.pwm.set_pwm = self.set_pwm
-        
-    def set_pulse(self, pulse):
-        self.set_pwm(self.channel, 0, pulse) 
-
-    def set_pwm(self, channel, on, off):
-        # sets a single PWM channel
-        self.pwm._device.writeList(self.register, [off & 0xFF, off >> 8])
-        
-    def run(self, pulse):
-        self.set_pulse(pulse)
-
-class JHatReader:
-    ''' 
-    Read RC controls from teensy 
-    '''
-    def __init__(self, channel, address=0x40, frequency=60, busnum=None):
-        import Adafruit_PCA9685
-        self.pwm = Adafruit_PCA9685.PCA9685(address=address)
-        self.pwm.set_pwm_freq(frequency)
-        self.register = 0 #i2c read doesn't take an address
-        self.steering = 0
-        self.throttle = 0
-        self.running = True
-        #send a reset
-        self.pwm._device.writeRaw8(0x06)
-
-    def read_pwm(self):
-        '''
-        send read requests via i2c bus to Teensy to get
-        pwm control values from last RC input  
-        '''
-        h1 = self.pwm._device.readU8(self.register)
-        # first byte of header must be 100, otherwize we might be reading
-        # in the wrong byte offset
-        while h1 != 100:
-            print("skipping to start of header")
-            h1 = self.pwm._device.readU8(self.register)
-        
-        h2 = self.pwm._device.readU8(self.register)
-        # h2 ignored now
-
-        val_a = self.pwm._device.readU8(self.register)
-        val_b = self.pwm._device.readU8(self.register)
-        self.steering = (val_b << 8) + val_a
-        
-        val_c = self.pwm._device.readU8(self.register)
-        val_d = self.pwm._device.readU8(self.register)
-        self.throttle = (val_d << 8) + val_c
-
-        # scale the values from -1 to 1
-        self.steering = (((float)(self.steering)) - 1500.0) / 500.0  + 0.158
-        self.throttle = (((float)(self.throttle)) - 1500.0) / 500.0  + 0.136
-
-    def update(self):
-        while(self.running):
-            self.read_pwm()
-            time.sleep(0.015)
-        
-    def run_threaded(self):
-        return self.steering, self.throttle
-
-    def shutdown(self):
-        self.running = False
-        time.sleep(0.1)
-
 
 class PWMSteering:
     """
@@ -258,6 +173,95 @@ class PWMThrottle:
         # stop vehicle
         self.run(0)
         self.running = False
+
+class JHat:
+    ''' 
+    PWM motor controler using Teensy emulating PCA9685. 
+    '''
+    def __init__(self, channel, address=0x40, frequency=60, busnum=None):
+        print("Firing up the Hat")
+        import Adafruit_PCA9685
+        LED0_OFF_L = 0x08
+        # Initialise the PCA9685 using the default address (0x40).
+        if busnum is not None:
+            from Adafruit_GPIO import I2C
+            # replace the get_bus function with our own
+            def get_bus():
+                return busnum
+            I2C.get_default_bus = get_bus
+        self.pwm = Adafruit_PCA9685.PCA9685(address=address)
+        self.pwm.set_pwm_freq(frequency)
+        self.channel = channel
+        self.register = LED0_OFF_L+4*channel
+
+        # we install our own write that is more efficient use of interrupts
+        self.pwm.set_pwm = self.set_pwm
+        
+    def set_pulse(self, pulse):
+        self.set_pwm(self.channel, 0, pulse) 
+
+    def set_pwm(self, channel, on, off:
+        # sets a single PWM channel
+        self.pwm._device.writeList(self.register, [off & 0xFF, off >> 8])
+        
+    def run(self, pulse):
+        self.set_pulse(pulse)
+
+class JHatReader:
+    ''' 
+    Read RC controls from teensy 
+    '''
+    def __init__(self, channel, address=0x40, frequency=60, busnum=None):
+        import Adafruit_PCA9685
+        self.pwm = Adafruit_PCA9685.PCA9685(address=address)
+        self.pwm.set_pwm_freq(frequency)
+        self.register = 0 #i2c read doesn't take an address
+        self.steering = 0
+        self.throttle = 0
+        self.running = True
+        #send a reset
+        self.pwm._device.writeRaw8(0x06)
+
+    def read_pwm(self):
+        '''
+        send read requests via i2c bus to Teensy to get
+        pwm control values from last RC input  
+        '''
+        h1 = self.pwm._device.readU8(self.register)
+        # first byte of header must be 100, otherwize we might be reading
+        # in the wrong byte offset
+        while h1 != 100:
+            print("skipping to start of header")
+            h1 = self.pwm._device.readU8(self.register)
+        
+        h2 = self.pwm._device.readU8(self.register)
+        # h2 ignored now
+
+        val_a = self.pwm._device.readU8(self.register)
+        val_b = self.pwm._device.readU8(self.register)
+        self.steering = (val_b << 8) + val_a
+        
+        val_c = self.pwm._device.readU8(self.register)
+        val_d = self.pwm._device.readU8(self.register)
+        self.throttle = (val_d << 8) + val_c
+
+        # scale the values from -1 to 1
+        self.steering = (self.steering - 1500.0) / 500.0  + 0.158
+        self.throttle = (self.throttle - 1500.0) / 500.0  + 0.136
+
+    def update(self):
+        while(self.running):
+            self.read_pwm()
+        
+    def run_threaded(self):
+        return self.steering, self.throttle
+
+    def shutdown(self):
+        self.running = False
+        time.sleep(0.1)
+
+
+
 
 
 class Adafruit_DCMotor_Hat:

--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -246,7 +246,7 @@ class WebSocketCalibrateAPI(tornado.websocket.WebSocketHandler):
 
         if 'config' in data:
             config = data['config']
-            if self.application.drive_train_type == "SERVO_ESC":
+            if self.application.drive_train_type == "I2C_SERVO":
                 if 'STEERING_LEFT_PWM' in config:
                     self.application.drive_train['steering'].left_pulse = config['STEERING_LEFT_PWM']
 

--- a/donkeycar/templates/calibrate.py
+++ b/donkeycar/templates/calibrate.py
@@ -54,7 +54,7 @@ def drive(cfg ):
     if cfg.DONKEY_GYM or cfg.DRIVE_TRAIN_TYPE == "MOCK":
         pass
 
-    elif cfg.DRIVE_TRAIN_TYPE == "SERVO_ESC":
+    elif cfg.DRIVE_TRAIN_TYPE == "I2C_SERVO":
 
         from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
 

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -47,19 +47,19 @@ USE_SSD1306_128_32 = False    # Enable the SSD_1306 OLED Display
 SSD1306_128_32_I2C_ROTATION = 0 # 0 = text is right-side up, 1 = rotated 90 degrees clockwise, 2 = 180 degrees (flipped), 3 = 270 degrees
 
 #DRIVETRAIN
-#These options specify which chasis and motor setup you are using. Most are using SERVO_ESC.
+#These options specify which chasis and motor setup you are using. Most are using I2C_SERVO.
 #DC_STEER_THROTTLE uses HBridge pwm to control one steering dc motor, and one drive wheel motor
 #DC_TWO_WHEEL uses HBridge pwm to control two drive motors, one on the left, and one on the right.
 #SERVO_HBRIDGE_PWM use ServoBlaster to output pwm control from the PiZero directly to control steering, and HBridge for a drive motor.
 #PIGPIO_PWM uses Raspberrys internal PWM
-DRIVE_TRAIN_TYPE = "SERVO_ESC" # SERVO_ESC|DC_STEER_THROTTLE|DC_TWO_WHEEL|DC_TWO_WHEEL_L298N|SERVO_HBRIDGE_PWM|PIGPIO_PWM|MM1|MOCK
+DRIVE_TRAIN_TYPE = "I2C_SERVO" # I2C_SERVO|DC_STEER_THROTTLE|DC_TWO_WHEEL|DC_TWO_WHEEL_L298N|SERVO_HBRIDGE_PWM|PIGPIO_PWM|MM1|MOCK
 
 #STEERING
 STEERING_CHANNEL = 1            #channel on the 9685 pwm board 0-15
 STEERING_LEFT_PWM = 460         #pwm value for full left steering
 STEERING_RIGHT_PWM = 290        #pwm value for full right steering
 
-#STEERING FOR PIGPIO_PWM
+#STEERING FOR PIGPIO_PWM OUTPUT
 STEERING_PWM_PIN = 13           #Pin numbering according to Broadcom numbers
 STEERING_PWM_FREQ = 50          #Frequency for PWM
 STEERING_PWM_INVERTED = False   #If PWM needs to be inverted
@@ -70,7 +70,7 @@ THROTTLE_FORWARD_PWM = 500      #pwm value for max forward throttle
 THROTTLE_STOPPED_PWM = 370      #pwm value for no movement
 THROTTLE_REVERSE_PWM = 220      #pwm value for max reverse throttle
 
-#THROTTLE FOR PIGPIO_PWM
+#THROTTLE FOR PIGPIO_PWM OUTPUT
 THROTTLE_PWM_PIN = 18           #Pin numbering according to Broadcom numbers
 THROTTLE_PWM_FREQ = 50          #Frequency for PWM
 THROTTLE_PWM_INVERTED = False   #If PWM needs to be inverted
@@ -102,13 +102,6 @@ USE_LIDAR = False
 LIDAR_TYPE = 'RP' #(RP|YD)
 LIDAR_LOWER_LIMIT = 90 # angles that will be recorded. Use this to block out obstructed areas on your car, or looking backwards. Note that for the RP A1M8 Lidar, "0" is in the direction of the motor
 LIDAR_UPPER_LIMIT = 270
-
-
-# #RC CONTROL
-USE_RC = False
-STEERING_RC_GPIO = 26
-THROTTLE_RC_GPIO = 20
-DATA_WIPER_RC_GPIO = 19
 
 #DC_TWO_WHEEL_L298N - with two wheels as drive, left and right.
 #these GPIO pinouts are only used for the DRIVE_TRAIN_TYPE=DC_TWO_WHEEL_L298N
@@ -173,7 +166,7 @@ USE_JOYSTICK_AS_DEFAULT = False      #when starting the manage.py, when True, wi
 JOYSTICK_MAX_THROTTLE = 0.5         #this scalar is multiplied with the -1 to 1 throttle value to limit the maximum throttle. This can help if you drop the controller or just don't need the full speed available.
 JOYSTICK_STEERING_SCALE = 1.0       #some people want a steering that is less sensitve. This scalar is multiplied with the steering -1 to 1. It can be negative to reverse dir.
 AUTO_RECORD_ON_THROTTLE = True      #if true, we will record whenever throttle is not zero. if false, you must manually toggle recording with some other trigger. Usually circle button on joystick.
-CONTROLLER_TYPE = 'xbox'            #(ps3|ps4|xbox|nimbus|wiiu|F710|rc3|MM1|custom) custom will run the my_joystick.py controller written by the `donkey createjs` command
+CONTROLLER_TYPE = 'xbox'            #(ps3|ps4|xbox|pigpio_rc|nimbus|wiiu|F710|rc3|MM1|custom) custom will run the my_joystick.py controller written by the `donkey createjs` command
 USE_NETWORKED_JS = False            #should we listen for remote joystick control over the network?
 NETWORK_JS_SERVER_IP = None         #when listening for network joystick control, which ip is serving this information
 JOYSTICK_DEADZONE = 0.01            # when non zero, this is the smallest throttle before recording triggered.
@@ -196,6 +189,20 @@ IMU_DLP_CONFIG = 0              # Digital Lowpass Filter setting (0:250Hz, 1:184
 
 #SOMBRERO
 HAVE_SOMBRERO = False           #set to true when using the sombrero hat from the Donkeycar store. This will enable pwm on the hat.
+
+#PIGPIO RC control
+STEERING_RC_GPIO = 26
+THROTTLE_RC_GPIO = 20
+DATA_WIPER_RC_GPIO = 19
+PIGPIO_STEERING_MID = 1500         # Adjust this value if your car cannot run in a straight line
+PIGPIO_MAX_FORWARD = 2000          # Max throttle to go fowrward. The bigger the faster
+PIGPIO_STOPPED_PWM = 1500
+PIGPIO_MAX_REVERSE = 1000          # Max throttle to go reverse. The smaller the faster
+PIGPIO_SHOW_STEERING_VALUE = False
+PIGPIO_INVERT = False
+PIGPIO_JITTER = 0.025   # threshold below which no signal is reported
+
+
 
 #ROBOHAT MM1
 MM1_STEERING_MID = 1500         # Adjust this value if your car cannot run in a straight line

--- a/donkeycar/templates/cfg_simulator.py
+++ b/donkeycar/templates/cfg_simulator.py
@@ -52,7 +52,7 @@ SSD1306_128_32_I2C_BUSNUM = 1 # I2C bus number
 #DC_TWO_WHEEL uses HBridge pwm to control two drive motors, one on the left, and one on the right.
 #SERVO_HBRIDGE_PWM use ServoBlaster to output pwm control from the PiZero directly to control steering, and HBridge for a drive motor.
 #PIGPIO_PWM uses Raspberrys internal PWM
-DRIVE_TRAIN_TYPE = "MOCK" # SERVO_ESC|DC_STEER_THROTTLE|DC_TWO_WHEEL|SERVO_HBRIDGE_PWM|PIGPIO_PWM|MM1|MOCK
+DRIVE_TRAIN_TYPE = "MOCK" # I2C_SERVO|DC_STEER_THROTTLE|DC_TWO_WHEEL|DC_TWO_WHEEL_L298N|SERVO_HBRIDGE_PWM|PIGPIO_PWM|MM1|MOCK
 
 #STEERING
 STEERING_CHANNEL = 1            #channel on the 9685 pwm board 0-15

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -201,7 +201,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         if cfg.CONTROLLER_TYPE == "pigpio_rc":    # an RC controllers read by GPIO pins. They typically don't have buttons
             from donkeycar.parts.controller import RCReceiver
             ctr = RCReceiver(cfg)
-            V.add(ctr, inputs=['cam/image_array'], outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],threaded=False)
+            V.add(ctr, outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],threaded=False)
         else:
             if cfg.CONTROLLER_TYPE == "custom":  #custom controller created with `donkey createjs` command
                 from my_joystick import MyJoystickController

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -19,11 +19,12 @@ import time
 import logging
 from docopt import docopt
 
+
 import donkeycar as dk
 from donkeycar.parts.transform import TriggeredCallback, DelayedTrigger
 from donkeycar.parts.tub_v2 import TubWriter
 from donkeycar.parts.datastore import TubHandler
-from donkeycar.parts.controller import LocalWebController, JoystickController, WebFpv
+from donkeycar.parts.controller import LocalWebController, WebFpv, JoystickController
 from donkeycar.parts.throttle_filter import ThrottleFilter
 from donkeycar.parts.behavior import BehaviorPart
 from donkeycar.parts.file_watcher import FileWatcher
@@ -185,7 +186,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             
         V.add(cam, inputs=inputs, outputs=outputs, threaded=threaded)
 
-    #This web controller will create a web server that is capable
+#This web controller will create a web server that is capable
     #of managing steering, throttle, and modes, and more.
     ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
     
@@ -197,35 +198,32 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
         #modify max_throttle closer to 1.0 to have more power
         #modify steering_scale lower than 1.0 to have less responsive steering
-        if cfg.CONTROLLER_TYPE == "MM1":
-            from donkeycar.parts.robohat import RoboHATController            
-            ctr = RoboHATController(cfg)
-        elif "custom" == cfg.CONTROLLER_TYPE:
-            #
-            # custom controller created with `donkey createjs` command
-            #
-            from my_joystick import MyJoystickController
-            ctr = MyJoystickController(
+        if cfg.CONTROLLER_TYPE == "pigpio_rc":    # an RC controllers read by GPIO pins. They typically don't have buttons
+            from donkeycar.parts.controller import RCReceiver
+            ctr = RCReceiver(cfg)
+            V.add(ctr, inputs=['cam/image_array'], outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],threaded=False)
+        else:
+            if cfg.CONTROLLER_TYPE == "custom":  #custom controller created with `donkey createjs` command
+                from my_joystick import MyJoystickController
+                ctr = MyJoystickController(
                 throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
                 throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
                 steering_scale=cfg.JOYSTICK_STEERING_SCALE,
                 auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
-            ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)
-        else:
-            from donkeycar.parts.controller import get_js_controller
-
-            ctr = get_js_controller(cfg)
-
-            if cfg.USE_NETWORKED_JS:
-                from donkeycar.parts.controller import JoyStickSub
-                netwkJs = JoyStickSub(cfg.NETWORK_JS_SERVER_IP)
-                V.add(netwkJs, threaded=True)
-                ctr.js = netwkJs
+                ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)          
+            elif cfg.CONTROLLER_TYPE == "MM1":
+                from donkeycar.parts.robohat import RoboHATController            
+                ctr = RoboHATController(cfg)
+            else:
+                from donkeycar.parts.controller import get_js_controller
+                ctr = get_js_controller(cfg)
+                if cfg.USE_NETWORKED_JS:
+                    from donkeycar.parts.controller import JoyStickSub
+                    netwkJs = JoyStickSub(cfg.NETWORK_JS_SERVER_IP)
+                    V.add(netwkJs, threaded=True)
+                    ctr.js = netwkJs
+            V.add(ctr, inputs=['cam/image_array'], outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],threaded=True)
         
-        V.add(ctr, 
-          inputs=['cam/image_array'],
-          outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
-          threaded=True)
 
     #this throttle filter will allow one tap back for esc reverse
     th_filter = ThrottleFilter()
@@ -328,12 +326,16 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     rec_tracker_part = RecordTracker()
     V.add(rec_tracker_part, inputs=["tub/num_records"], outputs=['records/alert'])
 
-    if cfg.AUTO_RECORD_ON_THROTTLE and isinstance(ctr, JoystickController):
-        #then we are not using the circle button. hijack that to force a record count indication
-        def show_record_acount_status():
+    if cfg.AUTO_RECORD_ON_THROTTLE:
+        def show_record_count_status():
             rec_tracker_part.last_num_rec_print = 0
             rec_tracker_part.force_alert = 1
-        ctr.set_button_down_trigger('circle', show_record_acount_status)
+        if (cfg.CONTROLLER_TYPE != "pigpio_rc") and (cfg.CONTROLLER_TYPE != "MM1"):  # these controllers don't use the joystick class
+            if isinstance(ctr, JoystickController):
+                ctr.set_button_down_trigger('circle', show_record_count_status) #then we are not using the circle button. hijack that to force a record count indication
+        else:
+            
+            show_record_count_status()
 
     #Sombrero
     if cfg.HAVE_SOMBRERO:
@@ -490,8 +492,9 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         inputs=['user/mode', 'throttle'],
         outputs=['throttle'])
 
-    if isinstance(ctr, JoystickController):
-        ctr.set_button_down_trigger(cfg.AI_LAUNCH_ENABLE_BUTTON, aiLauncher.enable_ai_launch)
+    if (cfg.CONTROLLER_TYPE != "pigpio_rc") and (cfg.CONTROLLER_TYPE != "MM1"):
+        if isinstance(ctr, JoystickController):
+            ctr.set_button_down_trigger(cfg.AI_LAUNCH_ENABLE_BUTTON, aiLauncher.enable_ai_launch)
 
 
     class AiRunCondition:
@@ -521,7 +524,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     #Drive train setup
     if cfg.DONKEY_GYM or cfg.DRIVE_TRAIN_TYPE == "MOCK":
         pass
-    elif cfg.DRIVE_TRAIN_TYPE == "SERVO_ESC":
+    elif cfg.DRIVE_TRAIN_TYPE == "I2C_SERVO":
         from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
 
         steering_controller = PCA9685(cfg.STEERING_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
@@ -698,11 +701,12 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         if cfg.DONKEY_GYM:
             print("You can now go to http://localhost:%d to drive your car." % cfg.WEB_CONTROL_PORT)
         else:
-            print("You can now go to <your hostname.local>:%d to drive your car." % cfg.WEB_CONTROL_PORT)
-    elif isinstance(ctr, JoystickController):
-        print("You can now move your joystick to drive your car.")
-        ctr.set_tub(tub_writer.tub)
-        ctr.print_controls()
+            print("You can now go to <your hostname.local>:%d to drive your car." % cfg.WEB_CONTROL_PORT)        
+    elif (cfg.CONTROLLER_TYPE != "pigpio_rc") and (cfg.CONTROLLER_TYPE != "MM1"):
+        if isinstance(ctr, JoystickController):
+            print("You can now move your joystick to drive your car.")
+            ctr.set_tub(tub_writer.tub)
+            ctr.print_controls()
 
     #run the vehicle for 20 seconds
     V.start(rate_hz=cfg.DRIVE_LOOP_HZ, max_loop_count=cfg.MAX_LOOPS)

--- a/donkeycar/tests/test_web_socket.py
+++ b/donkeycar/tests/test_web_socket.py
@@ -33,7 +33,7 @@ class WebSocketCalibrateTest(testing.AsyncHTTPTestCase):
         # Now we can run a test on the WebSocket.
         self.app.drive_train = dict()
         self.app.drive_train['steering'] = Mock()
-        self.app.drive_train_type = "SERVO_ESC"
+        self.app.drive_train_type = "I2C_SERVO"
 
         data = {"config": {"STEERING_LEFT_PWM": 444}}
         yield ws_client.write_message(json.dumps(data))
@@ -49,7 +49,7 @@ class WebSocketCalibrateTest(testing.AsyncHTTPTestCase):
         # Now we can run a test on the WebSocket.
         self.app.drive_train = dict()
         self.app.drive_train['steering'] = Mock()
-        self.app.drive_train_type = "SERVO_ESC"
+        self.app.drive_train_type = "I2C_SERVO"
 
         data = {"config": {"STEERING_RIGHT_PWM": 555}}
         yield ws_client.write_message(json.dumps(data))
@@ -65,7 +65,7 @@ class WebSocketCalibrateTest(testing.AsyncHTTPTestCase):
         # Now we can run a test on the WebSocket.
         self.app.drive_train = dict()
         self.app.drive_train['throttle'] = Mock()
-        self.app.drive_train_type = "SERVO_ESC"
+        self.app.drive_train_type = "I2C_SERVO"
 
         data = {"config": {"THROTTLE_FORWARD_PWM": 666}}
         yield ws_client.write_message(json.dumps(data))


### PR DESCRIPTION
Moved RC control to the Complete template and made it so you can use both RC in and out on the GPIO pins at the same time. This will support a RC hat for the Rpi.

Other changes:

--Got rid of the "USE_RC" config setting and instead conformed to standard for other controllers and actuators by creating a "pigpio_pwm" type for both
--I've done a global replace of the "SERVO_ESC" drivetrain type to "I2C_SERVO", which says what it is properly.
--Upped default loop speed to 40Hz

Tested with RC and joystick input, RC and I2C servo board output

Not working yet: auto record on throttle when in RC mode. Will refactor to work like Robohat MM1 part to gain that functionality