### PR TITLE
Update OLED part to use non-deprecated library and add rotation

### DIFF
--- a/donkeycar/parts/oled.py
+++ b/donkeycar/parts/oled.py
@@ -1,6 +1,3 @@
-from PIL import Image
-from PIL import ImageDraw
-from PIL import ImageFont
 import subprocess
 import time
 from board import SCL, SDA

--- a/donkeycar/parts/oled.py
+++ b/donkeycar/parts/oled.py
@@ -1,9 +1,12 @@
+# requires the Adafruit ssd1306 library: pip install adafruit-circuitpython-ssd1306
+
 import subprocess
 import time
 from board import SCL, SDA
 import busio
 from PIL import Image, ImageDraw, ImageFont
 import adafruit_ssd1306
+
 
 class OLEDDisplay(object):
     '''

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -44,7 +44,7 @@ PCA9685_I2C_BUSNUM = None   #None will auto detect, which is fine on the pi. But
 
 #SSD1306_128_32
 USE_SSD1306_128_32 = False    # Enable the SSD_1306 OLED Display
-SSD1306_128_32_I2C_BUSNUM = 1 # I2C bus number
+SSD1306_128_32_I2C_ROTATION = 0 # 0 = text is right-side up, 1 = rotated 90 degrees clockwise, 2 = 180 degrees (flipped), 3 = 270 degrees
 
 #DRIVETRAIN
 #These options specify which chasis and motor setup you are using. Most are using SERVO_ESC.

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -618,7 +618,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     if cfg.USE_SSD1306_128_32:
         from donkeycar.parts.oled import OLEDPart
         auto_record_on_throttle = cfg.USE_JOYSTICK_AS_DEFAULT and cfg.AUTO_RECORD_ON_THROTTLE
-        oled_part = OLEDPart(cfg.SSD1306_128_32_I2C_BUSNUM, auto_record_on_throttle=auto_record_on_throttle)
+        oled_part = OLEDPart(cfg.SSD1306_128_32_I2C_ROTATION, auto_record_on_throttle=auto_record_on_throttle)
         V.add(oled_part, inputs=['recording', 'tub/num_records', 'user/mode'], outputs=[], threaded=True)
 
     #add tub to save data

--- a/install/pi/install.sh
+++ b/install/pi/install.sh
@@ -40,8 +40,8 @@ source ~/env/bin/activate
 #make sure the virtual environment is active
 source ~/env/bin/activate
 
-# install pandas and numpy
+# install pandas and numpy and Adafruit CircuitPython
 pip install pandas #also installs numpy
-
+pip install adafruit-circuitpython-lis3dh
 
 pip install tensorflow==1.9

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,12 @@ setup(name='donkeycar',
           'pi': [
               'picamera',
               'Adafruit_PCA9685',
-              'Adafruit_SSD1306',
+              'adafruit-circuitpython-lis3dh',
               'RPi.GPIO',
               'pyserial',
           ],
           'nano': [
               'Adafruit_PCA9685',
-              'Adafruit_SSD1306',
               'RPi.GPIO'
           ],
           'pc': [

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,14 @@ setup(name='donkeycar',
               'picamera',
               'Adafruit_PCA9685',
               'adafruit-circuitpython-lis3dh',
+              'adafruit-circuitpython-ssd1306',
               'RPi.GPIO',
               'pyserial',
           ],
           'nano': [
               'Adafruit_PCA9685',
+              'adafruit-circuitpython-lis3dh',
+              'adafruit-circuitpython-ssd1306',
               'RPi.GPIO'
           ],
           'pc': [


### PR DESCRIPTION
The Adafruit OLED library were were using has been deprecated and replaced by a CircuitPython-based version. This PR updates the OLED part to use the new library and adds a rotation option. 

Changes include: 

- Updated part
- Updated config file to add rotation option
- Updated install script to install CircuitPython dependencies

Tested on RPi.