### PR TITLE
Revert to passing full path to model in training 

### DIFF
--- a/donkeycar/pipeline/database.py
+++ b/donkeycar/pipeline/database.py
@@ -33,8 +33,8 @@ class PilotDatabase:
         else:
             this_num = 0
         date = time.strftime('%y-%m-%d')
-        name = 'pilot_' + date + '_' + str(this_num)
-        return name, this_num
+        name = f'pilot_{date}_{this_num}.h5'
+        return os.path.join(self.cfg.MODELS_PATH, name), this_num
 
     def to_df(self) -> pd.DataFrame:
         if self.entries:


### PR DESCRIPTION
This got accidentally broken in 4.2 master. 
* Currently we have `donkey train --tub data --model pilot.h5` which will create the model in the directory `/model/pilot.h5`. 
* Previously we had explicitly give path to the models directory: `donkey train --tub data --model model/pilot.h5`. 

Here, we revert to the previous behaviour.