### PR TITLE
Fix deletion of last records in tub

### DIFF
--- a/donkeycar/parts/tub_v2.py
+++ b/donkeycar/parts/tub_v2.py
@@ -75,9 +75,11 @@ class Tub(object):
         self.manifest.delete_records(record_indexes)
 
     def delete_last_n_records(self, n):
-        last_index = self.manifest.current_index
-        first_index = max(last_index - n, 0)
-        self.manifest.delete_records(range(first_index, last_index))
+        # build ordered list of non-deleted indexes
+        all_alive_indexes = sorted(set(range(self.manifest.current_index))
+                                   - self.manifest.deleted_indexes)
+        to_delete_indexes = all_alive_indexes[-n:]
+        self.manifest.delete_records(to_delete_indexes)
 
     def restore_records(self, record_indexes):
         self.manifest.restore_records(record_indexes)

--- a/donkeycar/parts/tub_v2.py
+++ b/donkeycar/parts/tub_v2.py
@@ -130,8 +130,6 @@ class TubWriter(object):
         self.close()
 
 
-
-
 class TubWiper:
     """
     Donkey part which deletes a bunch of records from the end of tub.

--- a/donkeycar/tests/test_tub_v2.py
+++ b/donkeycar/tests/test_tub_v2.py
@@ -7,11 +7,12 @@ from donkeycar.parts.tub_v2 import Tub
 
 class TestTub(unittest.TestCase):
 
-    def setUp(self):
-        self._path = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._path = tempfile.mkdtemp()
         inputs = ['input']
         types = ['int']
-        self.tub = Tub(self._path, inputs, types)
+        cls.tub = Tub(cls._path, inputs, types)
 
     def test_basic_tub_operations(self):
         entries = list(self.tub)
@@ -34,8 +35,18 @@ class TestTub(unittest.TestCase):
         self.assertEqual(count, (write_count - len(delete_indexes)))
         self.assertEqual(len(self.tub), (write_count - len(delete_indexes)))
 
-    def tearDown(self):
-        shutil.rmtree(self._path)
+    def test_delete_last_n_records(self):
+        start_len = len(self.tub)
+        self.tub.delete_last_n_records(2)
+        self.assertEqual(start_len - 2, len(self.tub),
+                         "error in deleting 2 last records")
+        self.tub.delete_last_n_records(3)
+        self.assertEqual(start_len - 5, len(self.tub),
+                         "error in deleting 3 last records")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls._path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is a bug in deleting the last n records of a tub. We fix it by correctly building the set of non-deleted indexes and removing the largest n entries from that.