### PR TITLE
Fix moviepy installation on OSX

### DIFF
--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -21,7 +21,6 @@ dependencies:
   - pip
   - imgaug
   - progress
-  - moviepy
   - paho-mqtt
   - PrettyTable
   - pyfiglet
@@ -39,4 +38,5 @@ dependencies:
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid
     - opencv-python-headless
+    - moviepy
 


### PR DESCRIPTION
Move moviepy from conda -> pip as this seems not to be working with conda on OSX atm. Pip is pulling a slightly newer version that has been shown to work. 