### PR TITLE
Updated stop sign detector part to allow reversing for few iterations

### DIFF
--- a/donkeycar/parts/throttle_filter.py
+++ b/donkeycar/parts/throttle_filter.py
@@ -9,14 +9,17 @@ class ThrottleFilter(object):
         self.last_throttle = 0.0
 
     def run(self, throttle_in):
+        if throttle_in is None:
+            return throttle_in
+
         throttle_out = throttle_in
 
         if throttle_out < 0.0:
             if not self.reverse_triggered and self.last_throttle < 0.0:
                 throttle_out = 0.0
-                self.reverse_triggered = True                
+                self.reverse_triggered = True
         else:
-            self.reverse_triggered = False   
+            self.reverse_triggered = False
 
         self.last_throttle = throttle_out
         return throttle_out

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -373,3 +373,5 @@ REALSENSE_D435_ID = None        # serial number of camera or None if you only ha
 STOP_SIGN_DETECTOR = False
 STOP_SIGN_MIN_SCORE = 0.2
 STOP_SIGN_SHOW_BOUNDING_BOX = True
+STOP_SIGN_MAX_REVERSE_COUNT = 10    # How many times should the car reverse when detected a stop sign, set to 0 to disable reversing
+STOP_SIGN_REVERSE_THROTTLE = -0.5     # Throttle during reversing when detected a stop sign

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -474,9 +474,14 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         from donkeycar.parts.object_detector.stop_sign_detector \
             import StopSignDetector
         V.add(StopSignDetector(cfg.STOP_SIGN_MIN_SCORE,
-                               cfg.STOP_SIGN_SHOW_BOUNDING_BOX),
+                               cfg.STOP_SIGN_SHOW_BOUNDING_BOX,
+                               cfg.STOP_SIGN_MAX_REVERSE_COUNT,
+                               cfg.STOP_SIGN_REVERSE_THROTTLE),
               inputs=['cam/image_array', 'pilot/throttle'],
               outputs=['pilot/throttle', 'cam/image_array'])
+        V.add(ThrottleFilter(), 
+              inputs=['pilot/throttle'],
+              outputs=['pilot/throttle'])
 
     # Choose what inputs should change the car.
     class DriveMode:


### PR DESCRIPTION
Added a feature to force reverse the car for few iterations when it detected a stop sign, then stop the car until the stop sign is undetected. As when the car is driving at high speed, the stop sign could already be passed and is out of view before the car stops, which makes the car drive again. Therefore this reverse feature is added.