### PR TITLE
Fix issue 912: Cannot start 2D lidar if using a RealSense D435

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -163,16 +163,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         else:
             raise(Exception("Unkown camera type: %s" % cfg.CAMERA_TYPE))
 
-        # add lidar
-        if cfg.USE_LIDAR:
-            from donkeycar.parts.lidar import RPLidar
-            if cfg.LIDAR_TYPE == 'RP':
-                print("adding RP lidar part")
-                lidar = RPLidar(lower_limit = cfg.LIDAR_LOWER_LIMIT, upper_limit = cfg.LIDAR_UPPER_LIMIT)
-                V.add(lidar, inputs=[],outputs=['lidar/dist_array'], threaded=True)
-            if cfg.LIDAR_TYPE == 'YD':
-                print("YD Lidar not yet supported")
-
+        
         # Donkey gym part will output position information if it is configured
         if cfg.DONKEY_GYM:
             if cfg.SIM_RECORD_LOCATION:
@@ -186,6 +177,16 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             
         V.add(cam, inputs=inputs, outputs=outputs, threaded=threaded)
 
+    # add lidar
+    if cfg.USE_LIDAR:
+        from donkeycar.parts.lidar import RPLidar
+        if cfg.LIDAR_TYPE == 'RP':
+            print("adding RP lidar part")
+            lidar = RPLidar(lower_limit = cfg.LIDAR_LOWER_LIMIT, upper_limit = cfg.LIDAR_UPPER_LIMIT)
+            V.add(lidar, inputs=[],outputs=['lidar/dist_array'], threaded=True)
+        if cfg.LIDAR_TYPE == 'YD':
+            print("YD Lidar not yet supported")
+    
 #This web controller will create a web server that is capable
     #of managing steering, throttle, and modes, and more.
     ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)


### PR DESCRIPTION
https://github.com/autorope/donkeycar/issues/912

If you try to configure `CAMERA_TYPE="D435"` and `LIDAR_TYPE="RP"` simultaneously, the D435 part will NOT be correctly started when manage.py is run, but the RPLidar will not. RPLidar works fine if camera is MOCK.

The problem is a bug in manage.py (created from donkeycar/templates/complete.py). The code that configures that camera for some reason includes the lidar config. So on line 90 of https://github.com/autorope/donkeycar/blob/dev/donkeycar/templates/complete.py we start configuration of the camera with the 'stereo' camera, then on line 113 we 'elif' camera is "D435", then on line 136 we 'else' the other cameras. That 'else' block also contains the lidar configuration. So if we configure the D435 then the else is never executed and so the lidar part is not configured.

Solution: move the code block starting on line 166, ` # add lidar`, in  donkeycar/donkeycar/templates/complete.py to outside and after the else, so it gets executed no matter what kind of camera is being configured.
