### PR TITLE
Fix for memory model inferencing

### DIFF
--- a/donkeycar/management/kivy_ui.py
+++ b/donkeycar/management/kivy_ui.py
@@ -713,7 +713,6 @@ class OverlayImage(FullImage):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.last_output = (0, 0)
 
     def augment(self, img_arr):
         if pilot_screen().trans_list:
@@ -737,16 +736,13 @@ class OverlayImage(FullImage):
         if not self.pilot:
             return img_arr
 
-        args = (aug_img_arr, np.array(self.last_output)) \
-            if type(self.pilot) is KerasMemory else (aug_img_arr,)
         output = (0, 0)
         try:
             # Not each model is supported in each interpreter
-            output = self.pilot.run(*args)
+            output = self.pilot.run(aug_img_arr)
         except Exception as e:
             Logger.error(e)
 
-        self.last_output = output
         rgb = (0, 0, 255)
         MakeMovie.draw_line_into_image(output[0], output[1], True, img_arr, rgb)
         out_record = copy(record)

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -378,8 +378,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         inputs = ['cam/image_array',
                   'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
                   'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z']
-    elif cfg.USE_LIDAR:
-        inputs = ['cam/image_array', 'lidar/dist_array']
+
     else:
         inputs = ['cam/image_array']
 
@@ -470,7 +469,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             inputs = ['cam/image_array_trans'] + inputs[1:]
 
         V.add(kl, inputs=inputs, outputs=outputs, run_condition='run_pilot')
-    
+
     if cfg.STOP_SIGN_DETECTOR:
         from donkeycar.parts.object_detector.stop_sign_detector \
             import StopSignDetector


### PR DESCRIPTION
 # Fix the `KerasMemory.run()` function 

_Currently_: the function expects the previous steering throttle values in the second argument
_Fix_: ignore the second argument and cache the previous return steering and throttle values from the network for the memory vector to be passed to the model.

Also fix the UI code accordingly. There are no changes to the car templates required.