### PR TITLE
fix-encoder-pipeline

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -78,11 +78,11 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     if cfg.HAVE_ODOM:
         if cfg.ENCODER_TYPE == "GPIO":
             from donkeycar.parts.encoder import RotaryEncoder
-            enc = RotaryEncoder(mm_per_tick=0.306096, pin = cfg.ODOM_PIN, debug = cfg.ODOM_DEBUG)
+            enc = RotaryEncoder(mm_per_tick=cfg.MM_PER_TICK, pin=cfg.ODOM_PIN, poll_delay=1.0/(cfg.DRIVE_LOOP_HZ*3), debug=cfg.ODOM_DEBUG)
             V.add(enc, inputs=['throttle'], outputs=['enc/speed'], threaded=True)
         elif cfg.ENCODER_TYPE == "arduino":
             from donkeycar.parts.encoder import ArduinoEncoder
-            enc = ArduinoEncoder()
+            enc = ArduinoEncoder(mm_per_tick=cfg.MM_PER_TICK, debug=cfg.ODOM_DEBUG)
             V.add(enc, outputs=['enc/speed'], threaded=True)
         else:
             print("No supported encoder found")


### PR DESCRIPTION
- the complete.py template hooked up the encoder parts
  using hard-coded value for mm_per_tick and ignored
  the configuration for MM_PER_TICK.
- The RotaryEncoder was also using a default
  value for the poll_delay so polling was incorrect
  in anything except the default vehicle loop rate.
- This commit fixes the building of the pipeline
  in complete.py to use the correct configuration.
  It also calculates the poll_delay for the RotaryEncoder
  based on the DRIVE_LOOP_HZ configuration.