### PR TITLE
Add ability to read config variables from env

### DIFF
--- a/donkeycar/config.py
+++ b/donkeycar/config.py
@@ -62,19 +62,19 @@ def load_config(config_path=None, myconfig="myconfig.py"):
                 config_path = local_config
     
     logger = getLogger()
-    logger.info('loading config file: {}'.format(config_path))
+    logger.info('loading config file: {}' . format(config_path))
     cfg = Config()
     cfg.from_pyfile(config_path)
 
     # look for the optional myconfig.py in the same path.
     personal_cfg_path = config_path.replace("config.py", myconfig)
     if os.path.exists(personal_cfg_path):
-        logger.info("loading personal config over-rides from", myconfig)
+        logger.info(f"loading personal config over-rides from {myconfig}")
         personal_cfg = Config()
         personal_cfg.from_pyfile(personal_cfg_path)
         cfg.from_object(personal_cfg)
     else:
-        logger.info("personal config: file not found ", personal_cfg_path)
+        logger.info(f"personal config: file not found {personal_cfg_path}")
 
     # derived settings
     if hasattr(cfg, 'IMAGE_H') and hasattr(cfg, 'IMAGE_W'): 

--- a/donkeycar/config.py
+++ b/donkeycar/config.py
@@ -72,4 +72,18 @@ def load_config(config_path=None, myconfig="myconfig.py"):
         if hasattr(cfg, 'IMAGE_DEPTH'):
             cfg.TARGET_D = cfg.IMAGE_DEPTH
 
+    # from env
+    import ast
+
+    for attr in dir(cfg):
+        if attr.isupper():
+            cfg_name = f'DONKEYCAR_CFG_{attr}'
+            new_value = os.getenv(cfg_name)
+            if new_value is not None:
+                old_val = getattr(cfg, attr)
+                new_value_casted = ast.literal_eval(new_value)
+                attr_type = type(new_value_casted)
+                setattr(cfg, attr, new_value_casted)
+                print(f'Set cfg var from env: {attr}={new_value} (type={attr_type} old_val={old_val})')
+
     return cfg


### PR DESCRIPTION
Add ability to read config variables from env

Usage example:

`DONKEYCAR_CFG_MAX_LOOPS=2000 python manage.py drive`

this command will override config variable MAX_LOOPS and set it to 2000
this is the equivalent of having MAX_LOOPS=2000 in the myconfig.py
