### PR TITLE
now donkey gets version from setup.py

### DIFF
--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -1,10 +1,12 @@
 import sys
 from pyfiglet import Figlet
 import logging
+from pkg_resources import get_distribution
+
+__version__ = get_distribution('donkeycar').version
 
 logging.basicConfig(level=logging.INFO)
 f = Figlet(font='speed')
-__version__ = '4.3.0'
 
 
 print(f.renderText('Donkey Car'))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 
 from setuptools import find_packages, setup
-from donkeycar import __version__
 
 
 # include the non python files
@@ -25,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version=__version__,
+      version="4.3.0",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',
@@ -50,7 +49,7 @@ setup(name='donkeycar',
           'progress',
           'typing_extensions',
           'pyfiglet',
-          'psutil'
+          'psutil',
       ],
       extras_require={
           'pi': [


### PR DESCRIPTION
- installation was failing because setup was trying to
  import from donkeycar before it was setup.
- setup.py imports __version__ from donkeycar;
  that causes __init__.py to be loaded,
  which tries to import pyfiglet.
  We can't import from donkeycar in setup.py because it is not yet setup
- this fix uses pkg_resources.get_distribution() to
  get the version set in setup.py and make it
  available to the donkeycar code.

From now on we set the version in setup.py; it will be imported into the donkeycode.  This avoids the circular setup issue.