### PR TITLE
Threading TubWriter for better performance

### DIFF
--- a/donkeycar/templates/basic.py
+++ b/donkeycar/templates/basic.py
@@ -193,7 +193,7 @@ def drive(cfg, model_path=None, model_type=None):
     # do we want to store new records into own dir or append to existing
     tub_path = TubHandler(path=cfg.DATA_PATH).create_tub_path() if \
         cfg.AUTO_CREATE_NEW_TUB else cfg.DATA_PATH
-    tub_writer = TubWriter(base_path=tub_path, inputs=inputs, types=types)
+    tub_writer = TubWriter(base_path=tub_path, inputs=inputs, types=types, threaded=True)
     car.add(tub_writer, inputs=inputs, outputs=["tub/num_records"],
             run_condition='recording')
     if not model_path and cfg.USE_RC:

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -693,7 +693,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     tub_path = TubHandler(path=cfg.DATA_PATH).create_tub_path() if \
         cfg.AUTO_CREATE_NEW_TUB else cfg.DATA_PATH
     tub_writer = TubWriter(tub_path, inputs=inputs, types=types, metadata=meta)
-    V.add(tub_writer, inputs=inputs, outputs=["tub/num_records"], run_condition='recording')
+    V.add(tub_writer, inputs=inputs, outputs=["tub/num_records"], run_condition='recording', threaded=True)
 
     # Telemetry (we add the same metrics added to the TubHandler
     if cfg.HAVE_MQTT_TELEMETRY:

--- a/donkeycar/templates/simulator.py
+++ b/donkeycar/templates/simulator.py
@@ -399,7 +399,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None, camera_type
     tub_path = TubHandler(path=cfg.DATA_PATH).create_tub_path() if \
         cfg.AUTO_CREATE_NEW_TUB else cfg.DATA_PATH
     tub_writer = TubWriter(tub_path, inputs=inputs, types=types, metadata=meta)
-    V.add(tub_writer, inputs=inputs, outputs=["tub/num_records"], run_condition='recording')
+    V.add(tub_writer, inputs=inputs, outputs=["tub/num_records"], run_condition='recording', threaded=True)
 
     if cfg.PUB_CAMERA_IMAGES:
         from donkeycar.parts.network import TCPServeValue


### PR DESCRIPTION
The disk writing on RPi 4 is pretty slow compared to desktops, unless you mount a SSD on the car with it.

The idea is to unblock the TubWriter's IO from main thread. I see a performance boost from average 4ms to 0.2ms:
Before (IO on main thread):
```
+------------------------------+-------+------+------+------+------+-------+-------+
|             part             |  max  | min  | avg  | 50%  | 90%  |  99%  | 99.9% |
+------------------------------+-------+------+------+------+------+-------+-------+
|          TubWriter           | 14.07 | 2.46 | 4.41 | 3.47 | 7.24 | 11.31 | 13.32 |
+------------------------------+-------+------+------+------+------+-------+-------+
```

After (IO threaded):
```
+------------------------------+-------+------+------+------+------+------+-------+
|             part             |  max  | min  | avg  | 50%  | 90%  | 99%  | 99.9% |
+------------------------------+-------+------+------+------+------+------+-------+
|          TubWriter           | 79.88 | 0.07 | 0.19 | 0.08 | 0.09 | 0.13 | 21.36 |
+------------------------------+-------+------+------+------+------+------+-------+
```

