### PR TITLE
937-import-imageaugmentation-causes-error

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -29,7 +29,6 @@ from donkeycar.parts.throttle_filter import ThrottleFilter
 from donkeycar.parts.behavior import BehaviorPart
 from donkeycar.parts.file_watcher import FileWatcher
 from donkeycar.parts.launch import AiLaunch
-from donkeycar.pipeline.augmentations import ImageAugmentation
 from donkeycar.utils import *
 
 logger = logging.getLogger(__name__)
@@ -464,6 +463,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             outputs.append("pilot/loc")
         # Add image transformations like crop or trapezoidal mask
         if hasattr(cfg, 'TRANSFORMATIONS') and cfg.TRANSFORMATIONS:
+            from donkeycar.pipeline.augmentations import ImageAugmentation
             V.add(ImageAugmentation(cfg, 'TRANSFORMATIONS'),
                   inputs=['cam/image_array'], outputs=['cam/image_array_trans'])
             inputs = ['cam/image_array_trans'] + inputs[1:]


### PR DESCRIPTION
ImageAugmentation is used during training. It is needed around line 467 of complete.py where cfg.TRANSFORMATIONS is used to determine if image augmentations will be applied during training. This breaks on a RaspberryPi when trying to drive because imgaug dependency is not installed. To fix this, we should move the import of ImageAugmentation from the top of complete.py to line 467 inside the if statement where it is needed, so no attempt is made to import it unless it is needed.