### PR TITLE
Change AI throttle Multiplier on the joystick

### DIFF
--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -822,6 +822,7 @@ class JoystickController(object):
                  throttle_scale=1.0,
                  steering_scale=1.0,
                  throttle_dir=-1.0,
+                 ai_scale = 1.0,
                  dev_fn='/dev/input/js0',
                  auto_record_on_throttle=True):
 
@@ -833,6 +834,7 @@ class JoystickController(object):
         self.last_throttle_axis_val = 0
         self.throttle_scale = throttle_scale
         self.steering_scale = steering_scale
+        self.ai_scale = ai_scale
         self.throttle_dir = throttle_dir
         self.recording = False
         self.constant_throttle = False
@@ -1044,6 +1046,22 @@ class JoystickController(object):
 
         print('throttle_scale:', self.throttle_scale)
 
+    def increase_ai_throttle(self):
+        '''
+        increase AI throttle scale setting
+        '''
+        self.ai_scale = round(min(2.0, self.ai_scale + 0.01), 3)
+
+        print('AI scale :', self.ai_scale)
+
+    def decrease_ai_throttle(self):
+        '''
+        decrrease AI throttle scale setting
+        '''
+        self.ai_scale =  round(max(0.0, self.ai_scale - 0.01), 2)
+
+        print('AI Scale:', self.ai_scale)
+
 
     def toggle_constant_throttle(self):
         '''
@@ -1193,6 +1211,8 @@ class PS3JoystickController(JoystickController):
             'cross' : self.emergency_stop,
             'dpad_up' : self.increase_max_throttle,
             'dpad_down' : self.decrease_max_throttle,
+            'dpad_left' : self.decrease_ai_throttle,
+            'dpad_right' : self.increase_ai_throttle,
             'start' : self.toggle_constant_throttle,
             "R1" : self.chaos_monkey_on_right,
             "L1" : self.chaos_monkey_on_left,
@@ -1681,6 +1701,7 @@ def get_js_controller(cfg):
     ctr = cont_class(throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
                                 throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
                                 steering_scale=cfg.JOYSTICK_STEERING_SCALE,
+                                ai_scale = cfg.AI_THROTTLE_MULT,
                                 auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE,
                                 dev_fn=cfg.JOYSTICK_DEVICE_FILE)
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -210,6 +210,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
                 throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
                 throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
                 steering_scale=cfg.JOYSTICK_STEERING_SCALE,
+                ai_scale = cfg.AI_THROTTLE_MULT,
                 auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
                 ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)          
             elif cfg.CONTROLLER_TYPE == "MM1":
@@ -488,6 +489,9 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         def run(self, mode,
                     user_angle, user_throttle,
                     pilot_angle, pilot_throttle):
+
+            mul = ctr.ai_scale
+
             if mode == 'user':
                 return user_angle, user_throttle
 
@@ -496,7 +500,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
 
             else:
                 return pilot_angle if pilot_angle else 0.0, \
-                       pilot_throttle * cfg.AI_THROTTLE_MULT \
+                       pilot_throttle * mul \
                            if pilot_throttle else 0.0
 
     V.add(DriveMode(),


### PR DESCRIPTION
Changing AI throttle multiplier on the joystick while running the model instead of changing it on the config file everytime.

Currently the function has been mapped only to the PS3 joystick dpad left and dpad right buttons as they were  not being used, but can be mapped to other joysticks if there are unused buttons.