### PR TITLE
Add back support for tubhist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ setup(name='donkeycar',
           'pc': [
               'matplotlib',
               'imgaug',
-              'kivy'
+              'kivy',
+              'pandas'
           ],
           'dev': [
               'pytest',


### PR DESCRIPTION
The `donkey tubhist` command got lost when migrating to 4.x. We are bringing it back here.