### PR TITLE
963 Install Jetson.GPIO on [nano]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(name='donkeycar',
               'Adafruit_PCA9685',
               'adafruit-circuitpython-lis3dh',
               'adafruit-circuitpython-ssd1306',
-              'RPi.GPIO'
+              'Jetson.GPIO'
           ],
           'pc': [
               'matplotlib',


### PR DESCRIPTION
- it was incorrectly installing the raspberry pi only library RPi.GPIO
- this caused issues where RPi.GPIO was imported.  This is because Jetson.GPIO, which is the Nvidia version of that library, creates an alias for RPi.GPIO so that code that uses RPi.GPIO will work on the nano but ONLY if it does NOT import RPi.GPIO
- Now we install Jetson.GPIO for the nano.
