### PR TITLE
Install imgaug also on the robot and not only the pc, so the donkey c…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.4",
+      version="4.3.5",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,7 @@ setup(name='donkeycar',
           'progress',
           'typing_extensions',
           'pyfiglet',
-          'psutil',
-          'imgaug'
+          'psutil'
       ],
       extras_require={
           'pi': [
@@ -60,6 +59,7 @@ setup(name='donkeycar',
               'adafruit-circuitpython-ssd1306',
               'RPi.GPIO',
               'pyserial',
+              'imgaug'
           ],
           'nano': [
               'Adafruit_PCA9685',
@@ -73,7 +73,8 @@ setup(name='donkeycar',
               'kivy',
               'pandas',
               'pyyaml',
-              'plotly'
+              'plotly',
+              'imgaug'
           ],
           'dev': [
               'pytest',

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name='donkeycar',
           'typing_extensions',
           'pyfiglet',
           'psutil',
+          'imgaug'
       ],
       extras_require={
           'pi': [
@@ -69,7 +70,6 @@ setup(name='donkeycar',
           ],
           'pc': [
               'matplotlib',
-              'imgaug',
               'kivy',
               'pandas',
               'pyyaml',


### PR DESCRIPTION
Install `imgaug` also on the robot and not only the pc, so the donkey car can use CROP without any additional manual installation. Also added a None type check in the augmentation part. I checked on RPi that this is working.