### PR TITLE
961 protect from empty camera image

### DIFF
--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -231,7 +231,7 @@ class CSICamera(BaseCamera):
     def poll_camera(self):
         import cv2
         self.ret , frame = self.camera.read()
-        if frame:
+        if frame is not None:
             self.frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
     def run(self):

--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -79,7 +79,7 @@ class PiCamera(BaseCamera):
 
 
 class Webcam(BaseCamera):
-    def __init__(self, image_w=160, image_h=120, image_d=3, framerate = 20, iCam = 0):
+    def __init__(self, image_w=160, image_h=120, image_d=3, framerate = 20, camera_index = 0):
         #
         # pygame is not installed by default.  
         # Installation on RaspberryPi (with env activated):
@@ -87,51 +87,74 @@ class Webcam(BaseCamera):
         # sudo apt-get install libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
         # pip install pygame
         #
-        import pygame
-        import pygame.camera
-
         super().__init__()
-        resolution = (image_w, image_h)
-        pygame.init()
-        pygame.camera.init()
-        l = pygame.camera.list_cameras()
-        print('cameras', l)
-        self.cam = pygame.camera.Camera(l[iCam], resolution, "RGB")
-        self.resolution = resolution
-        self.cam.start()
+        self.cam = None
         self.framerate = framerate
 
         # initialize variable used to indicate
         # if the thread should be stopped
         self.frame = None
-        self.on = True
         self.image_d = image_d
+        self.image_w = image_w
+        self.image_h = image_h
 
-        print('WebcamVideoStream loaded.. .warming camera')
+        self.init_camera(image_w, image_h, image_d, camera_index)
+        self.on = True
 
-        time.sleep(2)
+    def init_camera(self, image_w, image_h, image_d, camera_index=0):
+        try:
+            import pygame
+            import pygame.camera
+        except ModuleNotFoundError as e:
+            print("Unabled to import pygame.  Try installing it:")
+            print("    sudo apt-get install libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0")
+            print("    pip install pygame")
+            raise e
+
+        print('Opening Webcam...')
+
+        self.resolution = (image_w, image_h)
+        pygame.init()
+        pygame.camera.init()
+        l = pygame.camera.list_cameras()
+        print('cameras', l)
+        try:
+            self.cam = pygame.camera.Camera(l[camera_index], self.resolution, "RGB")
+            self.cam.start()
+
+            print('CSICamera opened.. .warming camera')
+            warming_time = time.time() + 5  # quick after 5 seconds
+            while self.frame is None and time.time() < warming_time:
+                print(".", end="")
+                self.run()
+                time.sleep(0.2)
+            print("")
+
+            if self.frame is None:
+                raise RuntimeError("Unable to start Webcam.")
+        except:
+            raise RuntimeError("Unable to open Webcam.")
+
+    def run(self):
+        import pygame.image
+        if self.cam.query_image():
+            snapshot = self.cam.get_image()
+            snapshot1 = pygame.transform.scale(snapshot, self.resolution)
+            self.frame = pygame.surfarray.pixels3d(pygame.transform.rotate(pygame.transform.flip(snapshot1, True, False), 90))
+            if self.image_d == 1:
+                self.frame = rgb2gray(self.frame)
+        return self.frame
 
     def update(self):
         from datetime import datetime, timedelta
-        import pygame.image
         while self.on:
             start = datetime.now()
-
-            if self.cam.query_image():
-                # snapshot = self.cam.get_image()
-                # self.frame = list(pygame.image.tostring(snapshot, "RGB", False))
-                snapshot = self.cam.get_image()
-                snapshot1 = pygame.transform.scale(snapshot, self.resolution)
-                self.frame = pygame.surfarray.pixels3d(pygame.transform.rotate(pygame.transform.flip(snapshot1, True, False), 90))
-                if self.image_d == 1:
-                    self.frame = rgb2gray(self.frame)
-
+            self.run()
             stop = datetime.now()
             s = 1 / self.framerate - (stop - start).total_seconds()
             if s > 0:
                 time.sleep(s)
 
-        self.cam.stop()
 
     def run_threaded(self):
         return self.frame
@@ -139,7 +162,10 @@ class Webcam(BaseCamera):
     def shutdown(self):
         # indicate that the thread should be stopped
         self.on = False
-        print('stopping Webcam')
+        if self.cam:
+            print('stopping Webcam')
+            self.cam.stop()
+            self.cam = None
         time.sleep(.5)
 
 

--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -14,7 +14,7 @@ class PiCamera(BaseCamera):
     def __init__(self, image_w=160, image_h=120, image_d=3, framerate=20, vflip=False, hflip=False):
         from picamera.array import PiRGBArray
         from picamera import PiCamera
-        
+
         resolution = (image_w, image_h)
         # initialize the camera and stream
         self.camera = PiCamera() #PiCamera gets resolution (height, width)
@@ -81,7 +81,7 @@ class PiCamera(BaseCamera):
 class Webcam(BaseCamera):
     def __init__(self, image_w=160, image_h=120, image_d=3, framerate = 20, camera_index = 0):
         #
-        # pygame is not installed by default.  
+        # pygame is not installed by default.
         # Installation on RaspberryPi (with env activated):
         #
         # sudo apt-get install libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
@@ -188,27 +188,29 @@ class CSICamera(BaseCamera):
         '''
         self.w = image_w
         self.h = image_h
-        self.running = True
-        self.frame = None
         self.flip_method = gstreamer_flip
         self.capture_width = capture_width
         self.capture_height = capture_height
         self.framerate = framerate
+        self.frame = None
         self.init_camera()
+        self.running = True
 
     def init_camera(self):
+        import cv2
+
         # initialize the camera and stream
         self.camera = cv2.VideoCapture(
             self.gstreamer_pipeline(
-                capture_width =self.capture_width,
-                capture_height =self.capture_height,
+                capture_width=self.capture_width,
+                capture_height=self.capture_height,
                 output_width=self.w,
                 output_height=self.h,
                 framerate=self.framerate,
                 flip_method=self.flip_method),
             cv2.CAP_GSTREAMER)
 
-        if self.camera.isOpened():
+        if self.camera and self.camera.isOpened():
             print('CSICamera opened.. .warming camera')
             warming_time = time.time() + 5  # quick after 5 seconds
             while self.frame is None and time.time() < warming_time:
@@ -221,7 +223,7 @@ class CSICamera(BaseCamera):
                 raise RuntimeError("Unable to start CSICamera.")
         else:
             raise RuntimeError("Unable to open CSICamera.")
-        
+
     def update(self):
         while self.running:
             self.poll_camera()
@@ -229,7 +231,8 @@ class CSICamera(BaseCamera):
     def poll_camera(self):
         import cv2
         self.ret , frame = self.camera.read()
-        self.frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        if frame:
+            self.frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
     def run(self):
         self.poll_camera()

--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -80,6 +80,13 @@ class PiCamera(BaseCamera):
 
 class Webcam(BaseCamera):
     def __init__(self, image_w=160, image_h=120, image_d=3, framerate = 20, iCam = 0):
+        #
+        # pygame is not installed by default.  
+        # Installation on RaspberryPi (with env activated):
+        #
+        # sudo apt-get install libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
+        # pip install pygame
+        #
         import pygame
         import pygame.camera
 

--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -51,13 +51,14 @@ class PiCamera(BaseCamera):
     def run(self):
         # grab the frame from the stream and clear the stream in
         # preparation for the next frame
-        if self.stream:
+        if self.stream is not None:
             f = next(self.stream)
-            frame = f.array
-            self.rawCapture.truncate(0)
-            if self.image_d == 1:
-                frame = rgb2gray(frame)
-            self.frame = frame
+            if f is not None:
+                self.frame = f.array
+                self.rawCapture.truncate(0)
+                if self.image_d == 1:
+                    self.frame = rgb2gray(self.frame)
+
         return self.frame
 
     def update(self):
@@ -139,10 +140,12 @@ class Webcam(BaseCamera):
         import pygame.image
         if self.cam.query_image():
             snapshot = self.cam.get_image()
-            snapshot1 = pygame.transform.scale(snapshot, self.resolution)
-            self.frame = pygame.surfarray.pixels3d(pygame.transform.rotate(pygame.transform.flip(snapshot1, True, False), 90))
-            if self.image_d == 1:
-                self.frame = rgb2gray(self.frame)
+            if snapshot is not None:
+                snapshot1 = pygame.transform.scale(snapshot, self.resolution)
+                self.frame = pygame.surfarray.pixels3d(pygame.transform.rotate(pygame.transform.flip(snapshot1, True, False), 90))
+                if self.image_d == 1:
+                    self.frame = rgb2gray(frame)
+
         return self.frame
 
     def update(self):

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -32,6 +32,7 @@ IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
 CAMERA_FRAMERATE = DRIVE_LOOP_HZ
 CAMERA_VFLIP = False
 CAMERA_HFLIP = False
+CAMERA_INDEX = 0  # used for 'WEBCAM' when there is more than one camera connected 
 # For CSIC camera - If the camera is mounted in a rotated position, changing the below parameter will correct the output frame orientation
 CSIC_CAM_GSTREAMER_FLIP_PARM = 0 # (0 => none , 4 => Flip horizontally, 6 => Flip vertically)
 

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -32,7 +32,7 @@ IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
 CAMERA_FRAMERATE = DRIVE_LOOP_HZ
 CAMERA_VFLIP = False
 CAMERA_HFLIP = False
-CAMERA_INDEX = 0  # used for 'WEBCAM' when there is more than one camera connected 
+CAMERA_INDEX = 0  # used for 'WEBCAM' and 'CVCAM' when there is more than one camera connected 
 # For CSIC camera - If the camera is mounted in a rotated position, changing the below parameter will correct the output frame orientation
 CSIC_CAM_GSTREAMER_FLIP_PARM = 0 # (0 => none , 4 => Flip horizontally, 6 => Flip vertically)
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -141,7 +141,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             cam = PiCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE, vflip=cfg.CAMERA_VFLIP, hflip=cfg.CAMERA_HFLIP)
         elif cfg.CAMERA_TYPE == "WEBCAM":
             from donkeycar.parts.camera import Webcam
-            cam = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+            cam = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, camera_index=cfg.CAMERA_INDEX)
         elif cfg.CAMERA_TYPE == "CVCAM":
             from donkeycar.parts.cv import CvCam
             cam = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -144,7 +144,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             cam = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, camera_index=cfg.CAMERA_INDEX)
         elif cfg.CAMERA_TYPE == "CVCAM":
             from donkeycar.parts.cv import CvCam
-            cam = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+            cam = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam=cfg.CAMERA_INDEX)
         elif cfg.CAMERA_TYPE == "CSIC":
             from donkeycar.parts.camera import CSICamera
             cam = CSICamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE, 

--- a/donkeycar/templates/cv_control.py
+++ b/donkeycar/templates/cv_control.py
@@ -53,7 +53,6 @@ class LineFollower:
         input: cam_image, an RGB numpy array
         output: index of max color, value of cumulative color at that index, and mask of pixels in range 
         '''
-
         # take a horizontal slice of the image
         iSlice = self.scan_y
         scan_line = cam_img[iSlice : iSlice + self.scan_height, :, :]
@@ -77,6 +76,9 @@ class LineFollower:
         input: cam_image, an RGB numpy array
         output: steering, throttle, and recording flag
         '''
+        if cam_img is None:
+            return 0, 0, False
+
         max_yellow, confidense, mask = self.get_i_color(cam_img)
         conf_thresh = 0.001
         

--- a/donkeycar/templates/cv_control.py
+++ b/donkeycar/templates/cv_control.py
@@ -2,7 +2,7 @@
 """
 
 Usage:
-    manage.py --name=your_name
+    manage.py --name=your_name [--debug]
 
 
 Options:
@@ -29,7 +29,8 @@ class LineFollower:
     to guid a PID controller which seeks to maintain the max yellow at the same point
     in the image.
     '''
-    def __init__(self):
+    def __init__(self, debug=False):
+        self.debug = debug
         self.scan_y = 60   # num pixels from the top to start horiz scan
         self.scan_height = 10 # num pixels high to grab from horiz scan
         self.color_thr_low = np.asarray((0, 50, 50)) # hsv dark yellow
@@ -89,7 +90,7 @@ class LineFollower:
 
             # this is the target of our steering PID controller
             self.pid_st.setpoint = self.target_pixel
-
+	
         elif confidense > conf_thresh:
             # invoke the controller with the current yellow line position
             # get the new steering value as it chases the ideal
@@ -105,7 +106,8 @@ class LineFollower:
 
 
         # show some diagnostics
-        self.debug_display(cam_img, mask, max_yellow, confidense)
+        if self.debug:
+            self.debug_display(cam_img, mask, max_yellow, confidense)
 
         return self.steering, self.throttle, self.recording
 
@@ -171,7 +173,7 @@ def drive(cfg, args):
     V.add(cam, inputs=inputs, outputs=['cam/image_array'], threaded=True)
         
     #Controller
-    V.add(LineFollower(), 
+    V.add(LineFollower(bool(args['--debug'])), 
           inputs=['cam/image_array'],
           outputs=['steering', 'throttle', 'recording'])
 


### PR DESCRIPTION
This PR addresses [Issue 961](https://github.com/autorope/donkeycar/issues/961) and a little more.  Basically our cameras could return None images if they did not start correctly.  The warmup was just a sleep(2) and no check was actually made to know that the camera started.  This could result in hard to understand downstream errors.  

- This PR fixes the 'PICAM', 'CSIC' and 'WEBCAM' camera drivers to check the the camera starts and is returning non-None images at initialization time so any camera initialization issue is caught early and with a clear error message.
- There are other camera configurations that have NOT been addressed by this PR, but should be looked at in a future PR; 'V4L' and 'CVCAM'.
- this PR also addresses the originally reported bug directly by protecting cv_control.py template from a None image. 
- In addition it makes the debug window optional; it can be turned on with a command line  argument.  This was done because the cv_control.py template could not be used in a headless OS because it tried to open a window.
- In addition it adds a CAMERA_INDEX configuration value that can be used to choose the camera index in the 'WEBCAM' and 'CVCAM' configurations when there is more than one camera connected.
