### PR TITLE
Fix missing import for UI and added windows support where tensorrt is not available

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/donkeycar/parts/interpreter.py
+++ b/donkeycar/parts/interpreter.py
@@ -6,7 +6,7 @@ from typing import Union, Sequence, List
 
 import tensorflow as tf
 from tensorflow import keras
-from tensorflow.python.compiler.tensorrt import trt_convert as trt
+
 from tensorflow.python.framework.convert_to_constants import \
     convert_variables_to_constants_v2 as convert_var_to_const
 from tensorflow.python.saved_model import tag_constants, signature_constants
@@ -56,6 +56,7 @@ def saved_model_to_tensor_rt(saved_path: str, tensor_rt_path: str):
         within TF now. """
     logger.info(f'Converting SavedModel {saved_path} to TensorRT'
                 f' {tensor_rt_path}')
+    from tensorflow.python.compiler.tensorrt import trt_convert as trt
 
     params = trt.DEFAULT_TRT_CONVERSION_PARAMS
     params = params._replace(max_workspace_size_bytes=(1 << 32))

--- a/install/envs/mac.yml
+++ b/install/envs/mac.yml
@@ -33,6 +33,7 @@ dependencies:
   - psutil
   - kivy=2.0.0
   - plotly
+  - pyyaml
   - pip:
     - tensorflow==2.2.0
     - git+https://github.com/autorope/keras-vis.git

--- a/install/envs/ubuntu.yml
+++ b/install/envs/ubuntu.yml
@@ -34,7 +34,8 @@ dependencies:
   - psutil
   - kivy=2.0.0
   - plotly
-  - tensorflow==2.2.0
+  - pyyaml
+  - tensorflow=2.2.0
   - pip:
     - git+https://github.com/autorope/keras-vis.git
     - simple-pid

--- a/install/envs/windows.yml
+++ b/install/envs/windows.yml
@@ -33,6 +33,7 @@ dependencies:
   - numpy
   - kivy=2.0.0
   - plotly
+  - pyyaml
   - psutil
   - pip:
     - git+https://github.com/autorope/keras-vis.git

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(name='donkeycar',
               'matplotlib',
               'imgaug',
               'kivy',
-              'pandas'
+              'pandas',
+              'pyyaml'
           ],
           'dev': [
               'pytest',


### PR DESCRIPTION
# Fix missing imports and supporting of windows where tensorrt is potentially not working
1) Two imports that are used in the UI were not correctly added to the install files
* pyyaml was missing in conda install files
* pyyaml and plotly were missing in setup.py 

2) Bumped the superlinter to v4 because of issue: https://github.com/github/super-linter/issues/2253

3) Also, moved tensorrt imports into function, so loading will not fail unless a tensorrt conversion is called. It seems windows 11 doesn't support tensorrt yet.

4) Bumped version bugfix digit