### PR TITLE
clamp differential drive throttle and steering

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -764,9 +764,13 @@ class TwoWheelSteeringThrottle(object):
                  where 1 is full forward and -1 is full backwards.
         """
         if throttle > 1 or throttle < -1:
-            raise ValueError( "throttle must be between 1(forward) and -1(reverse)")
+            logger.warn( f"throttle is {throttle}, but it must be between 1(forward) and -1(reverse)")
         if steering > 1 or steering < -1:
-            raise ValueError( "steering must be between 1(right) and -1(left)")
+            logger.warn( f"steering is {steering}, but it must be between 1(right) and -1(left)")
+
+        from donkeycar.utils import clamp
+        throttle = clamp(throttle, -1, 1)
+        steering = clamp(steering, -1, 1)
 
         left_motor_speed = throttle
         right_motor_speed = throttle


### PR DESCRIPTION
- the throttle and steering passed to TwoWheelSteeringThrottle where just a 3/1000 over 1, but where triggering the check against a max of 1.
- this caused the differential drive cars to fail when trying to run the linear model.
- this commit simply clamps out of range values to the allowed range of -1 to 1 inclusive.

See @Rushil  issue in discord https://discordapp.com/channels/662098530411741184/671604367706554388/932156905818828861
