### PR TITLE
989 namespace drivetrain configurations

### DIFF
--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -196,7 +196,7 @@ class LocalWebController(tornado.web.Application):
 
         # if there were changes, then send to web client
         if changes and self.loop is not None:
-            logger.info(str(changes))
+            logger.debug(str(changes))
             self.loop.add_callback(lambda: self.update_wsclients(changes))
 
         return self.angle, self.throttle, self.mode, self.recording

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -76,34 +76,44 @@ DRIVE_TRAIN_TYPE = "PWM_STEERING_THROTTLE"
 # Uses a PwmPin for steering (servo) and a second PwmPin for throttle (ESC)
 # Base PWM Frequence is presumed to be 60hz; use PWM_xxxx_SCALE to adjust pulse with for non-standard PWM frequencies
 #
-PWM_STEERING_PIN = "PCA9685.1:40.1"  # PWM output pin for steering servo
-PWM_STEERING_SCALE = 1.0   # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
-PWM_STEERING_INVERTED = False  # True if hardware requires an inverted PWM pulse
-PWM_THROTTLE_PIN = "PCA9685.1:40.0"  # PWM output pin for ESC
-PWM_THROTTLE_SCALE = 1.0   # used to compensate for PWM frequence differences from 60hz; NOT for increasing/limiting speed
-PWM_THROTTLE_INVERTED = False  # True if hardware requires an inverted PWM pulse
+PWM_STEERING_THROTTLE = {
+    "PWM_STEERING_PIN": "PCA9685.1:40.1",   # PWM output pin for steering servo
+    "PWM_STEERING_SCALE": 1.0,              # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
+    "PWM_STEERING_INVERTED": False,         # True if hardware requires an inverted PWM pulse
+    "PWM_THROTTLE_PIN": "PCA9685.1:40.0",   # PWM output pin for ESC
+    "PWM_THROTTLE_SCALE": 1.0,              # used to compensate for PWM frequence differences from 60hz; NOT for increasing/limiting speed
+    "PWM_THROTTLE_INVERTED": False,         # True if hardware requires an inverted PWM pulse
+    "STEERING_LEFT_PWM": 460,               #pwm value for full left steering
+    "STEERING_RIGHT_PWM": 290,              #pwm value for full right steering
+    "THROTTLE_FORWARD_PWM": 500,            #pwm value for max forward throttle
+    "THROTTLE_STOPPED_PWM": 370,            #pwm value for no movement
+    "THROTTLE_REVERSE_PWM": 220,            #pwm value for max reverse throttle
+}
 
+#
+# I2C_SERVO (deprecated in favor of PWM_STEERING_THROTTLE0
+#
+I2C_SERVO = {
+    "STEERING_CHANNEL": 1,            #(deprecated) channel on the 9685 pwm board 0-15
+    "STEERING_LEFT_PWM": 460,         #pwm value for full left steering
+    "STEERING_RIGHT_PWM": 290,        #pwm value for full right steering
+    "THROTTLE_CHANNEL": 0,            #(deprecated) channel on the 9685 pwm board 0-15
+    "THROTTLE_FORWARD_PWM": 500,      #pwm value for max forward throttle
+    "THROTTLE_STOPPED_PWM": 370,      #pwm value for no movement
+    "THROTTLE_REVERSE_PWM": 220,      #pwm value for max reverse throttle
+}
 
-#STEERING FOR PWM_STEERING_THROTTLE (and deprecated I2C_SERVO)
-STEERING_CHANNEL = 1            #(deprecated) channel on the 9685 pwm board 0-15
-STEERING_LEFT_PWM = 460         #pwm value for full left steering
-STEERING_RIGHT_PWM = 290        #pwm value for full right steering
-
-#STEERING FOR PWM_STEERING_THROTTLE (and deprecated PIGPIO_PWM OUTPUT)
-STEERING_PWM_PIN = 13           #(deprecated) Pin numbering according to Broadcom numbers
-STEERING_PWM_FREQ = 50          #Frequency for PWM
-STEERING_PWM_INVERTED = False   #If PWM needs to be inverted
-
-#THROTTLE FOR PWM_STEERING_THROTTLE (and deprecated I2C_SERVO)
-THROTTLE_CHANNEL = 0            #(deprecated) channel on the 9685 pwm board 0-15
-THROTTLE_FORWARD_PWM = 500      #pwm value for max forward throttle
-THROTTLE_STOPPED_PWM = 370      #pwm value for no movement
-THROTTLE_REVERSE_PWM = 220      #pwm value for max reverse throttle
-
-#THROTTLE FOR PWM_STEERING_THROTTLE (and deprecated PIGPIO_PWM OUTPUT)
-THROTTLE_PWM_PIN = 18           #(deprecated) Pin numbering according to Broadcom numbers
-THROTTLE_PWM_FREQ = 50          #Frequency for PWM
-THROTTLE_PWM_INVERTED = False   #If PWM needs to be inverted
+#
+# PIGPIO_PWM (deprecated in favor of PWM_STEERING_THROTTLE)
+#
+PIGPIO_PWM = {
+    "STEERING_PWM_PIN": 13,           #(deprecated) Pin numbering according to Broadcom numbers
+    "STEERING_PWM_FREQ": 50,          #Frequency for PWM
+    "STEERING_PWM_INVERTED": False,   #If PWM needs to be inverted
+    "THROTTLE_PWM_PIN": 18,           #(deprecated) Pin numbering according to Broadcom numbers
+    "THROTTLE_PWM_FREQ": 50,          #Frequency for PWM
+    "THROTTLE_PWM_INVERTED": False,   #If PWM needs to be inverted
+}
 
 #
 # SERVO_HBRIDGE_2PIN
@@ -135,13 +145,15 @@ THROTTLE_PWM_INVERTED = False   #If PWM needs to be inverted
 # - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
 #   although it is discouraged to mix RPI_GPIO and PIGPIO.
 #
-HBRIDGE_2PIN_DUTY_FWD = "RPI_GPIO.BOARD.18"  # provides forward duty cycle to motor
-HBRIDGE_2PIN_DUTY_BWD = "RPI_GPIO.BOARD.16"  # provides reverse duty cycle to motor
-PWM_STEERING_PIN = "RPI_GPIO.BOARD.33"       # provides servo pulse to steering servo
-PWM_STEERING_SCALE = 1.0        # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
-PWM_STEERING_INVERTED = False   # True if hardware requires an inverted PWM pulse
-STEERING_LEFT_PWM = 460         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
-STEERING_RIGHT_PWM = 290        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+SERVO_HBRIDGE_2PIN = {
+    "FWD_DUTY_PIN": "RPI_GPIO.BOARD.18",  # provides forward duty cycle to motor
+    "BWD_DUTY_PIN": "RPI_GPIO.BOARD.16",  # provides reverse duty cycle to motor
+    "PWM_STEERING_PIN": "RPI_GPIO.BOARD.33",       # provides servo pulse to steering servo
+    "PWM_STEERING_SCALE": 1.0,        # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
+    "PWM_STEERING_INVERTED": False,   # True if hardware requires an inverted PWM pulse
+    "STEERING_LEFT_PWM": 460,         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+    "STEERING_RIGHT_PWM": 290,        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+}
 
 #
 # SERVO_HBRIDGE_3PIN
@@ -177,14 +189,42 @@ STEERING_RIGHT_PWM = 290        # pwm value for full right steering (use `donkey
 # - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
 #   although it is discouraged to mix RPI_GPIO and PIGPIO.
 #
-HBRIDGE_3PIN_FWD = "RPI_GPIO.BOARD.18"   # ttl pin, high enables motor forward 
-HBRIDGE_3PIN_BWD = "RPI_GPIO.BOARD.16"   # ttl pin, highenables motor reverse
-HBRIDGE_3PIN_DUTY = "RPI_GPIO.BOARD.35"  # provides duty cycle to motor
-PWM_STEERING_PIN = "RPI_GPIO.BOARD.33"   # provides servo pulse to steering servo
-PWM_STEERING_SCALE = 1.0        # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
-PWM_STEERING_INVERTED = False   # True if hardware requires an inverted PWM pulse
-STEERING_LEFT_PWM = 460         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
-STEERING_RIGHT_PWM = 290        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+SERVO_HBRIDGE_3PIN = {
+    "FWD_PIN": "RPI_GPIO.BOARD.18",   # ttl pin, high enables motor forward
+    "BWD_PIN": "RPI_GPIO.BOARD.16",   # ttl pin, high enables motor reverse
+    "DUTY_PIN": "RPI_GPIO.BOARD.35",  # provides duty cycle to motor
+    "PWM_STEERING_PIN": "RPI_GPIO.BOARD.33",   # provides servo pulse to steering servo
+    "PWM_STEERING_SCALE": 1.0,        # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
+    "PWM_STEERING_INVERTED": False,   # True if hardware requires an inverted PWM pulse
+    "STEERING_LEFT_PWM": 460,         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+    "STEERING_RIGHT_PWM": 290,        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+}
+
+#
+# DRIVETRAIN_TYPE == "SERVO_HBRIDGE_PWM" (deprecated in favor of SERVO_HBRIDGE_2PIN)
+# - configures a steering servo and an HBridge in 2pin mode (2 pwm pins)
+# - Uses ServoBlaster library, which is NOT installed by default, so
+#   you will need to install it to make this work.
+# - Servo takes a standard servo PWM pulse between 1 millisecond (fully reverse)
+#   and 2 milliseconds (full forward) with 1.5ms being neutral.
+# - the motor is controlled by two pwm pins,
+#   one for forward and one for backward (reverse).
+# - the pwm pins produce a duty cycle from 0 (completely LOW)
+#   to 1 (100% completely high), which is proportional to the
+#   amount of power delivered to the motor.
+# - in forward mode, the reverse pwm is 0 duty_cycle,
+#   in backward mode, the forward pwm is 0 duty cycle.
+# - both pwms are 0 duty cycle (LOW) to 'detach' motor and
+#   and glide to a stop.
+# - both pwms are full duty cycle (100% HIGH) to brake
+#
+SERVO_HBRIDGE_PWM = {
+    "HBRIDGE_PIN_FWD": 18,  # provides forward duty cycle to motor
+    "HBRIDGE_PIN_BWD": 16,  # provides reverse duty cycle to motor
+    "STEERING_CHANNEL": 0,  # PCA 9685 channel for steering control
+    "STEERING_LEFT_PWM": 460,         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+    "STEERING_RIGHT_PWM": 290,        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+}
 
 #
 # DC_STEER_THROTTLE with one motor as steering, one as drive
@@ -206,10 +246,12 @@ STEERING_RIGHT_PWM = 290        # pwm value for full right steering (use `donkey
 # - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
 #   although it is discouraged to mix RPI_GPIO and PIGPIO.
 #
-HBRIDGE_PIN_LEFT = "RPI_GPIO.BOARD.18"   # pwm pin produces duty cycle for steering left
-HBRIDGE_PIN_RIGHT = "RPI_GPIO.BOARD.16"  # pwm pin produces duty cycle for steering right
-HBRIDGE_PIN_FWD = "RPI_GPIO.BOARD.15"    # pwm pin produces duty cycle for forward drive
-HBRIDGE_PIN_BWD = "RPI_GPIO.BOARD.13"    # pwm pin produces duty cycle for reverse drive
+DC_STEER_THROTTLE = {
+    "LEFT_DUTY_PIN": "RPI_GPIO.BOARD.18",   # pwm pin produces duty cycle for steering left
+    "RIGHT_DUTY_PIN": "RPI_GPIO.BOARD.16",  # pwm pin produces duty cycle for steering right
+    "FWD_DUTY_PIN": "RPI_GPIO.BOARD.15",    # pwm pin produces duty cycle for forward drive
+    "BWD_DUTY_PIN": "RPI_GPIO.BOARD.13",    # pwm pin produces duty cycle for reverse drive
+}
 
 #
 # DC_TWO_WHEEL pin configuration
@@ -240,11 +282,12 @@ HBRIDGE_PIN_BWD = "RPI_GPIO.BOARD.13"    # pwm pin produces duty cycle for rever
 # - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
 #   although it is discouraged to mix RPI_GPIO and PIGPIO.
 #
-HBRIDGE_PIN_LEFT_FWD = "RPI_GPIO.BOARD.18"  # pwm pin produces duty cycle for left wheel forward 
-HBRIDGE_PIN_LEFT_BWD = "RPI_GPIO.BOARD.16"  # pwm pin produces duty cycle for left wheel reverse
-HBRIDGE_PIN_RIGHT_FWD = "RPI_GPIO.BOARD.15" # pwm pin produces duty cycle for right wheel forward
-HBRIDGE_PIN_RIGHT_BWD = "RPI_GPIO.BOARD.13" # pwm pin produces duty cycle for right wheel reverse
-
+DC_TWO_WHEEL = {
+    "LEFT_FWD_DUTY_PIN": "RPI_GPIO.BOARD.18",  # pwm pin produces duty cycle for left wheel forward
+    "LEFT_BWD_DUTY_PIN": "RPI_GPIO.BOARD.16",  # pwm pin produces duty cycle for left wheel reverse
+    "RIGHT_FWD_DUTY_PIN": "RPI_GPIO.BOARD.15", # pwm pin produces duty cycle for right wheel forward
+    "RIGHT_BWD_DUTY_PIN": "RPI_GPIO.BOARD.13", # pwm pin produces duty cycle for right wheel reverse
+}
 
 #
 # DC_TWO_WHEEL_L298N pin configuration
@@ -279,13 +322,15 @@ HBRIDGE_PIN_RIGHT_BWD = "RPI_GPIO.BOARD.13" # pwm pin produces duty cycle for ri
 # - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
 #   although it is discouraged to mix RPI_GPIO and PIGPIO.
 #
-HBRIDGE_L298N_PIN_LEFT_FWD = "RPI_GPIO.BOARD.16"  # TTL output pin enables left wheel forward
-HBRIDGE_L298N_PIN_LEFT_BWD = "RPI_GPIO.BOARD.18"  # TTL output pin enables left wheel reverse
-HBRIDGE_L298N_PIN_LEFT_EN = "RPI_GPIO.BOARD.22"   # PWM pin generates duty cycle for left motor speed
+DC_TWO_WHEEL_L298N = {
+    "LEFT_FWD_PIN": "RPI_GPIO.BOARD.16",        # TTL output pin enables left wheel forward
+    "LEFT_BWD_PIN": "RPI_GPIO.BOARD.18",        # TTL output pin enables left wheel reverse
+    "LEFT_EN_DUTY_PIN": "RPI_GPIO.BOARD.22",    # PWM pin generates duty cycle for left motor speed
 
-HBRIDGE_L298N_PIN_RIGHT_FWD = "RPI_GPIO.BOARD.15" # TTL output pin enables right wheel forward
-HBRIDGE_L298N_PIN_RIGHT_BWD = "RPI_GPIO.BOARD.13" # TTL output pin enables right wheel reverse
-HBRIDGE_L298N_PIN_RIGHT_EN = "RPI_GPIO.BOARD.11"  # PWM pin generates duty cycle for right wheel speed
+    "RIGHT_FWD_PIN": "RPI_GPIO.BOARD.15",       # TTL output pin enables right wheel forward
+    "RIGHT_BWD_PIN": "RPI_GPIO.BOARD.13",       # TTL output pin enables right wheel reverse
+    "RIGHT_EN_DUTY_PIN": "RPI_GPIO.BOARD.11",   # PWM pin generates duty cycle for right wheel speed
+}
 
 #ODOMETRY
 HAVE_ODOM = False                   # Do you have an odometer/encoder 

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -215,11 +215,11 @@ SERVO_HBRIDGE_3PIN = {
 #   and glide to a stop.
 # - both pwms are full duty cycle (100% HIGH) to brake
 #
-HBRIDGE_PIN_FWD = 18,       ß# provides forward duty cycle to motor
-HBRIDGE_PIN_BWD = 16,       # provides reverse duty cycle to motor
-STEERING_CHANNEL = 0,       # PCA 9685 channel for steering control
-STEERING_LEFT_PWM = 460,    # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
-STEERING_RIGHT_PWM = 290,   # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+HBRIDGE_PIN_FWD = 18       # provides forward duty cycle to motor
+HBRIDGE_PIN_BWD = 16       # provides reverse duty cycle to motor
+STEERING_CHANNEL = 0       # PCA 9685 channel for steering control
+STEERING_LEFT_PWM = 460    # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+STEERING_RIGHT_PWM = 290   # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
 
 #
 # DC_STEER_THROTTLE with one motor as steering, one as drive

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -60,10 +60,11 @@ SSD1306_RESOLUTION = 1 # 1 = 128x32; 2 = 128x64
 # "SERVO_HBRIDGE_2PIN" Servo for steering and HBridge motor driver in 2pin mode for motor
 # "SERVO_HBRIDGE_3PIN" Servo for steering and HBridge motor driver in 3pin mode for motor
 # "DC_STEER_THROTTLE" uses HBridge pwm to control one steering dc motor, and one drive wheel motor
-# "DC_TWO_WHEEL" uses HBridge in two-pin mode to control two drive motors, one on the left, and one on the right.
-# "DC_TWO_WHEEL_L298N" using HBridge in three-pin mode to control two drive motors, one of the left and one on the right.
+# "DC_TWO_WHEEL" uses HBridge in 2-pin mode to control two drive motors, one on the left, and one on the right.
+# "DC_TWO_WHEEL_L298N" using HBridge in 3-pin mode to control two drive motors, one of the left and one on the right.
 # "MOCK" no drive train.  This can be used to test other features in a test rig.
-# (deprecated) "SERVO_HBRIDGE_PWM" use ServoBlaster to output pwm control from the PiZero directly to control steering, and HBridge for a drive motor.
+# (deprecated) "SERVO_HBRIDGE_PWM" use ServoBlaster to output pwm control from the PiZero directly to control steering,
+#                                  and HBridge for a drive motor.
 # (deprecated) "PIGPIO_PWM" uses Raspberrys internal PWM
 # (deprecated) "I2C_SERVO" uses PCA9685 servo controller to control a steering servo and an ESC, as in a standard RC car
 #
@@ -91,29 +92,25 @@ PWM_STEERING_THROTTLE = {
 }
 
 #
-# I2C_SERVO (deprecated in favor of PWM_STEERING_THROTTLE0
+# I2C_SERVO (deprecated in favor of PWM_STEERING_THROTTLE)
 #
-I2C_SERVO = {
-    "STEERING_CHANNEL": 1,            #(deprecated) channel on the 9685 pwm board 0-15
-    "STEERING_LEFT_PWM": 460,         #pwm value for full left steering
-    "STEERING_RIGHT_PWM": 290,        #pwm value for full right steering
-    "THROTTLE_CHANNEL": 0,            #(deprecated) channel on the 9685 pwm board 0-15
-    "THROTTLE_FORWARD_PWM": 500,      #pwm value for max forward throttle
-    "THROTTLE_STOPPED_PWM": 370,      #pwm value for no movement
-    "THROTTLE_REVERSE_PWM": 220,      #pwm value for max reverse throttle
-}
+STEERING_CHANNEL = 1            #(deprecated) channel on the 9685 pwm board 0-15
+STEERING_LEFT_PWM = 460         #pwm value for full left steering
+STEERING_RIGHT_PWM = 290        #pwm value for full right steering
+THROTTLE_CHANNEL = 0            #(deprecated) channel on the 9685 pwm board 0-15
+THROTTLE_FORWARD_PWM = 500      #pwm value for max forward throttle
+THROTTLE_STOPPED_PWM = 370      #pwm value for no movement
+THROTTLE_REVERSE_PWM = 220      #pwm value for max reverse throttle
 
 #
 # PIGPIO_PWM (deprecated in favor of PWM_STEERING_THROTTLE)
 #
-PIGPIO_PWM = {
-    "STEERING_PWM_PIN": 13,           #(deprecated) Pin numbering according to Broadcom numbers
-    "STEERING_PWM_FREQ": 50,          #Frequency for PWM
-    "STEERING_PWM_INVERTED": False,   #If PWM needs to be inverted
-    "THROTTLE_PWM_PIN": 18,           #(deprecated) Pin numbering according to Broadcom numbers
-    "THROTTLE_PWM_FREQ": 50,          #Frequency for PWM
-    "THROTTLE_PWM_INVERTED": False,   #If PWM needs to be inverted
-}
+STEERING_PWM_PIN = 13           #(deprecated) Pin numbering according to Broadcom numbers
+STEERING_PWM_FREQ = 50          #Frequency for PWM
+STEERING_PWM_INVERTED = False   #If PWM needs to be inverted
+THROTTLE_PWM_PIN = 18           #(deprecated) Pin numbering according to Broadcom numbers
+THROTTLE_PWM_FREQ = 50          #Frequency for PWM
+THROTTLE_PWM_INVERTED = False   #If PWM needs to be inverted
 
 #
 # SERVO_HBRIDGE_2PIN
@@ -218,13 +215,11 @@ SERVO_HBRIDGE_3PIN = {
 #   and glide to a stop.
 # - both pwms are full duty cycle (100% HIGH) to brake
 #
-SERVO_HBRIDGE_PWM = {
-    "HBRIDGE_PIN_FWD": 18,  # provides forward duty cycle to motor
-    "HBRIDGE_PIN_BWD": 16,  # provides reverse duty cycle to motor
-    "STEERING_CHANNEL": 0,  # PCA 9685 channel for steering control
-    "STEERING_LEFT_PWM": 460,         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
-    "STEERING_RIGHT_PWM": 290,        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
-}
+HBRIDGE_PIN_FWD = 18,       ß# provides forward duty cycle to motor
+HBRIDGE_PIN_BWD = 16,       # provides reverse duty cycle to motor
+STEERING_CHANNEL = 0,       # PCA 9685 channel for steering control
+STEERING_LEFT_PWM = 460,    # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+STEERING_RIGHT_PWM = 290,   # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
 
 #
 # DC_STEER_THROTTLE with one motor as steering, one as drive

--- a/donkeycar/templates/cfg_path_follow.py
+++ b/donkeycar/templates/cfg_path_follow.py
@@ -29,13 +29,7 @@ WEB_INIT_MODE = "user"              # which control mode to start in. one of use
 PCA9685_I2C_ADDR = 0x40     #I2C address, use i2cdetect to validate this number
 PCA9685_I2C_BUSNUM = None   #None will auto detect, which is fine on the pi. But other platforms should specify the bus num.
 # 
-# #DRIVETRAIN
-# #These options specify which chasis and motor setup you are using. Most are using SERVO_ESC.
-# #DC_STEER_THROTTLE uses HBridge pwm to control one steering dc motor, and one drive wheel motor
-# #DC_TWO_WHEEL uses HBridge pwm to control two drive motors, one on the left, and one on the right.
-# #SERVO_HBRIDGE_PWM use ServoBlaster to output pwm control from the PiZero directly to control steering, and HBridge for a drive motor.
-DRIVE_TRAIN_TYPE = "SERVO_ESC" # SERVO_ESC|DC_STEER_THROTTLE|DC_TWO_WHEEL|SERVO_HBRIDGE_PWM
-# 
+# #DRIVETRAIN is I2C_SERVO; PCA9685 outputs PWM to steering servo and ESC
 # #STEERING
 STEERING_CHANNEL = 1            #channel on the 9685 pwm board 0-15
 STEERING_LEFT_PWM = 460         #pwm value for full left steering
@@ -46,21 +40,8 @@ THROTTLE_CHANNEL = 0            #channel on the 9685 pwm board 0-15
 THROTTLE_FORWARD_PWM = 400       #pwm value for auto mode throttle
 THROTTLE_STOPPED_PWM = 370      #pwm value for no movement
 THROTTLE_REVERSE_PWM = 220      #pwm value for max reverse throttle
-# 
-# #DC_STEER_THROTTLE with one motor as steering, one as drive
-# #these GPIO pinouts are only used for the DRIVE_TRAIN_TYPE=DC_STEER_THROTTLE
-HBRIDGE_PIN_LEFT = 18
-HBRIDGE_PIN_RIGHT = 16
-HBRIDGE_PIN_FWD = 15
-HBRIDGE_PIN_BWD = 13
-# 
-# #DC_TWO_WHEEL - with two wheels as drive, left and right.
-# #these GPIO pinouts are only used for the DRIVE_TRAIN_TYPE=DC_TWO_WHEEL
-HBRIDGE_PIN_LEFT_FWD = 18
-HBRIDGE_PIN_LEFT_BWD = 16
-HBRIDGE_PIN_RIGHT_FWD = 15
-HBRIDGE_PIN_RIGHT_BWD = 13
-# 
+
+#
 # 
 # 
 # #JOYSTICK

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -587,22 +587,21 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
 
     elif cfg.DRIVE_TRAIN_TYPE == "I2C_SERVO":
         #
-        # Thi driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
+        # This driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
         # This driver will be removed in a future release
         #
         from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
 
-        dt = cfg.I2C_SERVO
-        steering_controller = PCA9685(dt["STEERING_CHANNEL"], cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
+        steering_controller = PCA9685(cfg.STEERING_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
         steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=dt['STEERING_LEFT_PWM'],
-                                        right_pulse=dt['STEERING_RIGHT_PWM'])
+                                        left_pulse=cfg.STEERING_LEFT_PWM,
+                                        right_pulse=cfg.STEERING_RIGHT_PWM)
 
-        throttle_controller = PCA9685(dt['THROTTLE_CHANNEL'], cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
+        throttle_controller = PCA9685(cfg.THROTTLE_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
         throttle = PWMThrottle(controller=throttle_controller,
-                                        max_pulse=dt['THROTTLE_FORWARD_PWM'],
-                                        zero_pulse=dt['THROTTLE_STOPPED_PWM'],
-                                        min_pulse=dt['THROTTLE_REVERSE_PWM'])
+                                        max_pulse=cfg.THROTTLE_FORWARD_PWM,
+                                        zero_pulse=cfg.THROTTLE_STOPPED_PWM,
+                                        min_pulse=cfg.THROTTLE_REVERSE_PWM)
 
         V.add(steering, inputs=['angle'], threaded=True)
         V.add(throttle, inputs=['throttle'], threaded=True)
@@ -708,44 +707,42 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         # This driver will be removed in a future release
         #
         from donkeycar.parts.actuator import ServoBlaster, PWMSteering
-
-        dt = cfg.SERVO_HBRIDGE_PWM
-        steering_controller = ServoBlaster(dt['STEERING_CHANNEL']) #really pin
+        steering_controller = ServoBlaster(cfg.STEERING_CHANNEL) #really pin
         # PWM pulse values should be in the range of 100 to 200
-        assert(dt['STEERING_LEFT_PWM'] <= 200)
-        assert(dt['STEERING_RIGHT_PWM'] <= 200)
+        assert(cfg.STEERING_LEFT_PWM <= 200)
+        assert(cfg.STEERING_RIGHT_PWM <= 200)
         steering = PWMSteering(controller=steering_controller,
-                               left_pulse=dt['STEERING_LEFT_PWM'],
-                               right_pulse=dt['STEERING_RIGHT_PWM'])
+                               left_pulse=cfg.STEERING_LEFT_PWM,
+                               right_pulse=cfg.STEERING_RIGHT_PWM)
 
         from donkeycar.parts.actuator import Mini_HBridge_DC_Motor_PWM
-        motor = Mini_HBridge_DC_Motor_PWM(dt['HBRIDGE_PIN_FWD'], dt['HBRIDGE_PIN_BWD'])
+        motor = Mini_HBridge_DC_Motor_PWM(cfg.HBRIDGE_PIN_FWD, cfg.HBRIDGE_PIN_BWD)
 
         V.add(steering, inputs=['angle'], threaded=True)
         V.add(motor, inputs=["throttle"])
-        
+
     elif cfg.DRIVE_TRAIN_TYPE == "MM1":
         from donkeycar.parts.robohat import RoboHATDriver
         V.add(RoboHATDriver(cfg), inputs=['angle', 'throttle'])
-    
+
     elif cfg.DRIVE_TRAIN_TYPE == "PIGPIO_PWM":
         #
         # Thi driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
         # This driver will be removed in a future release
         #
         from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PiGPIO_PWM
-        
-        dt = cfg.PIGPIO_PWM
-        steering_controller = PiGPIO_PWM(dt['STEERING_PWM_PIN'], freq=dt['STEERING_PWM_FREQ'], inverted=dt['STEERING_PWM_INVERTED'])
+        steering_controller = PiGPIO_PWM(cfg.STEERING_PWM_PIN, freq=cfg.STEERING_PWM_FREQ,
+                                         inverted=cfg.STEERING_PWM_INVERTED)
         steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=dt['STEERING_LEFT_PWM'],
-                                        right_pulse=dt['STEERING_RIGHT_PWM'])
-        
-        throttle_controller = PiGPIO_PWM(dt['THROTTLE_PWM_PIN'], freq=dt['THROTTLE_PWM_FREQ'], inverted=dt['THROTTLE_PWM_INVERTED'])
+                               left_pulse=cfg.STEERING_LEFT_PWM,
+                               right_pulse=cfg.STEERING_RIGHT_PWM)
+
+        throttle_controller = PiGPIO_PWM(cfg.THROTTLE_PWM_PIN, freq=cfg.THROTTLE_PWM_FREQ,
+                                         inverted=cfg.THROTTLE_PWM_INVERTED)
         throttle = PWMThrottle(controller=throttle_controller,
-                                            max_pulse=dt['THROTTLE_FORWARD_PWM'],
-                                            zero_pulse=dt['THROTTLE_STOPPED_PWM'],
-                                            min_pulse=dt['THROTTLE_REVERSE_PWM'])
+                               max_pulse=cfg.THROTTLE_FORWARD_PWM,
+                               zero_pulse=cfg.THROTTLE_STOPPED_PWM,
+                               min_pulse=cfg.THROTTLE_REVERSE_PWM)
         V.add(steering, inputs=['angle'], threaded=True)
         V.add(throttle, inputs=['throttle'], threaded=True)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.5",
+      version="4.3.6",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
Addresses Issue https://github.com/autorope/donkeycar/issues/989

The PWM_STEERING_PIN configuration values are used in several DRIVETRAIN_TYPE configurations, each with a different default value. If you just set the DRIVETRAIN_TYPE = "PWM_STEERING_THROTTLE", but don't uncomment the PWM_STEERING_PIN value, then the default of a different drivetrain get's used.

So a workaround is to just uncomment PWM_STEERING_PIN in the PWM_STEERING_THROTTLE sections.

This fix changes the newer drivetrain configuration into python dictionaries so all configuration are namespaced.

