### PR TITLE
Set LOG_LEVEL environment variable to set log level

### DIFF
--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pyfiglet import Figlet
 import logging
@@ -5,7 +6,8 @@ from pkg_resources import get_distribution
 
 __version__ = get_distribution('donkeycar').version
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper())
+
 f = Figlet(font='speed')
 
 


### PR DESCRIPTION
Minor change to allow the root logger level to be set with an environment variable.  This makes it easy to run a different log level without changing code or configuration.

```python
LOG_LEVEL=DEBUG python manage.py drive
```
