### PR TITLE
921 tachometer odometer kinematics parts

### DIFF
--- a/arduino/mono_encoder/mono_encoder.ino
+++ b/arduino/mono_encoder/mono_encoder.ino
@@ -1,0 +1,213 @@
+/* 
+ * mono_encoder.ino
+ * 
+ * Read a single-channel encoder,
+ * debounce the input.  Ticks 
+ * are counted for each transition
+ * from open-to-closed and closed-to-open.
+ * 
+ * For example, a 20 slot optical rotary encoder
+ * will have be 40 ticks per revolution.
+ * 
+ * Implements the r/p/c command protocol 
+ * for on-demand sending of encoder value
+ * and continuous sending with provided delay.
+ * See the comment in the loop below for details.
+ * 
+ * Sends the encoder ticks and a timestamp
+ * as a comma delimited pair: ticks,timeMs
+ *
+ */
+#include <Arduino.h>
+ 
+#define ENCODER_PIN   (7)          // input pin for first encoder
+#define ENCODER_2_PIN (9)          // input pin for second encoder
+#define POLL_DELAY_MICROS (100UL)  // microseconds between polls
+
+//
+// state for an encoder pin
+//
+struct EncoderState {
+  int pin;                     // gpio pin number
+  long ticks;                  // current tick count
+  uint16_t readings;           // history of last 16 readings
+  uint16_t transition;         // value of last 16 readings for next stable state transition 
+  unsigned long pollAtMicros;  // time of next poll
+};
+
+// list of encoders
+EncoderState encoders[2] = {
+  {ENCODER_PIN, 0L, 0, 0x8000, 0UL},
+  #ifdef ENCODER_2_PIN
+    {ENCODER_2_PIN, 0L, 0, 0x8000, 0UL},
+  #endif
+};
+
+#define ENCODER_COUNT (sizeof(encoders) / sizeof(EncoderState))
+
+boolean continuous = false; // true to send continuously, false to only send on demand
+unsigned long sendAtMs = 0; // next send time in continuous mode
+unsigned long delayMs = 0;  // time between sends in continuous mode
+
+
+
+//
+// Poll the encoder and increment ticks
+// on stable transitions.
+//
+// The method debounces noisy inputs,
+// looking for stable transitions from
+// open-to-closed and closed-to-open by polling
+// the encoder pin and building a 16 bit value.
+// We start by looking for a stable closed-to-open 
+// transition, which will be a 1 followed by 15 zeroes.
+// Then we change to look for the open-to-closed transition,
+// which is a zero reading followed by 15 ones.
+//
+// Given a polling delay of 100 microseconds, the 
+// minimum time for a stable reading is 
+// 100 microseconds * 16 bits = 1.6 milliseconds.
+// That then would allow for a maximum read rate of
+// 1000 / 1.6 = 625 ticks per second.
+// For high resolution encoders, that may be too slow.
+// In that case, reduce the POLL_DELAY_MICROS to 
+// suit your encoder and use case.
+//
+void pollEncoder(EncoderState &encoder) {
+  unsigned long nowMicros = micros();
+  if (nowMicros >= encoder.pollAtMicros) {
+    //
+    // shift state left and add new reading
+    //
+    encoder.readings = (encoder.readings << 1) | digitalRead(encoder.pin);
+
+    //
+    // if readings match target transition
+    // then count the ticks and 
+    // start looking for the next target transion
+    //
+    if (encoder.readings == encoder.transition) {
+      encoder.ticks += 1;
+      encoder.transition = ~encoder.transition;  // invert transition
+    }
+
+    encoder.pollAtMicros = nowMicros + POLL_DELAY_MICROS;
+  }
+}
+void pollEncoders() {
+  for(int i = 0; i < ENCODER_COUNT; i += 1) {
+    pollEncoder(encoders[i]);
+  }
+}
+
+//
+// reset tick counters to zero
+//
+void resetEncoders() {
+  for(int i = 0; i < ENCODER_COUNT; i += 1) {
+    encoders[i].ticks = 0;
+  }
+}
+
+
+//
+// write ticks to serial port
+// as a string tuple with ticks and tickMs separate by a comma
+//
+//   "{ticks},{ticksMs}"
+//
+void writeTicks(unsigned long ticksMs) {
+  Serial.print(encoders[0].ticks);
+  Serial.print(',');
+  Serial.print(ticksMs);
+  for(int i = 1; i < ENCODER_COUNT; i += 1) {
+    Serial.print(";");
+    Serial.print(encoders[i].ticks);
+    Serial.print(',');
+    Serial.print(ticksMs);
+  }
+  Serial.println("");
+}
+
+
+void setup() {
+  // set all encoder pins to inputs
+  for(int i = 0; i < ENCODER_COUNT; i += 1) {
+    pinMode(encoders[i].pin, INPUT);
+  }
+  Serial.begin(115200);
+}
+
+
+void loop() {
+  //
+  // poll each encoder's ticks
+  //
+  pollEncoders();
+  unsigned long ticksMs = millis();
+
+  //
+  // commands are send one per line (ending in '\n')
+  // 'r' command resets position to zero
+  // 'p' command sends position immediately
+  // 'c' command starts/stops continuous mode
+  //     - if it is followed by an integer,
+  //       then use this as the delay in ms
+  //       between readings.
+  //     - if it is not followed by an integer
+  //       then stop continuous mode
+  //
+  if (Serial.available() > 0) {
+    String newcommand = Serial.readStringUntil('\n');
+    newcommand.trim();
+
+    if (newcommand == "r") {
+      //
+      // reset tick counters to zero
+      //
+      resetEncoders();
+    }
+    else if (newcommand == "p") {
+      //
+      // send current ticks immediately
+      //
+      writeTicks(ticksMs);
+    }
+    else if (newcommand.startsWith("c")) {
+      //
+      // continous mode start or stop
+      //
+      if (1 == newcommand.length()) {
+        //
+        // stop continuous mode
+        //
+        continuous = false;
+      } else {
+        //
+        // convert characters after 'c' to an integer
+        // and use this as the delay in milliseconds
+        //
+        String intString = newcommand.substring(1);
+        if (isDigit(intString.charAt(0))) {
+          delayMs = (unsigned long)intString.toInt();
+          continuous = true;
+        }
+      }
+    } else {
+      // unknown command
+    }
+  }
+    
+  //
+  // we are in continuous mode, 
+  // then send the ticks when
+  // the delay expires
+  //
+  if (continuous) {
+    if (ticksMs >= sendAtMs) {
+      sendAtMs = ticksMs + delayMs;
+      writeTicks(ticksMs);
+    }
+  }
+}
+

--- a/arduino/quadrature_encoder/quadrature_encoder.ino
+++ b/arduino/quadrature_encoder/quadrature_encoder.ino
@@ -1,0 +1,193 @@
+#include <Encoder.h>
+
+/* 
+ * mono_encoder.ino
+ * 
+/* 
+ * Based on teensy Encoder Library Basic Example
+ * http://www.pjrc.com/teensy/td_libs_Encoder.html
+ * 
+ * Adds command for on-demand sending of encoder value
+ * and continuous sending with provided delay.
+ * Returns timestamp along with encoder ticks.
+ *
+ * Implements the r/p/c command protocol 
+ * for on-demand sending of encoder value
+ * and continuous sending with provided delay.
+ * See the comment in the loop below for details.
+ * 
+ * Sends the encoder ticks and a timestamp
+ * as a comma delimited pair: ticks,timeMs
+ *
+ */
+#include <Arduino.h>
+#include <Encoder.h>
+
+#define ENCODER_CLK_PIN   (7)      // clock input pin for first encoder
+#define ENCODER_DT_PIN    (8)      // data input pin for first encoder
+#define ENCODER_2_CLK_PIN (9)      // clock input pin for second encoder
+#define ENCODER_2_DT_PIN  (10)     // data input pin for second encoder
+#define POLL_DELAY_MICROS (100UL)  // microseconds between polls
+
+//
+// state for an encoder pin
+//
+struct EncoderState {
+  Encoder *encoder;            // quadrature encoder instance
+  long ticks;                  // current tick count
+};
+
+// list of encoders
+EncoderState encoders[2] = {
+  {new Encoder(ENCODER_DT_PIN, ENCODER_CLK_PIN), 0L},
+  #ifdef ENCODER_2_CLK_PIN
+    {new Encoder(ENCODER_2_DT_PIN, ENCODER_2_CLK_PIN), 0L},
+  #endif
+};
+
+#define ENCODER_COUNT (sizeof(encoders) / sizeof(EncoderState))
+
+boolean continuous = false; // true to send continuously, false to only send on demand
+unsigned long sendAtMs = 0; // next send time in continuous mode
+unsigned long delayMs = 0;  // time between sends in continuous mode
+
+
+
+//
+// Poll the encoder and increment ticks
+// on stable transitions.
+//
+// The method debounces noisy inputs,
+// looking for stable transitions from
+// open-to-closed and closed-to-open by polling
+// the encoder pin and building a 16 bit value.
+// We start by looking for a stable closed-to-open 
+// transition, which will be a 1 followed by 15 zeroes.
+// Then we change to look for the open-to-closed transition,
+// which is a zero reading followed by 15 ones.
+//
+// Given a polling delay of 100 microseconds, the 
+// minimum time for a stable reading is 
+// 100 microseconds * 16 bits = 1.6 milliseconds.
+// That then would allow for a maximum read rate of
+// 1000 / 1.6 = 625 ticks per second.
+// For high resolution encoders, that may be too slow.
+// In that case, reduce the POLL_DELAY_MICROS to 
+// suit your encoder and use case.
+//
+void pollEncoder(EncoderState &encoder) {
+  encoder.ticks = encoder.encoder->read();
+}
+void pollEncoders() {
+  for(int i = 0; i < ENCODER_COUNT; i += 1) {
+    pollEncoder(encoders[i]);
+  }
+}
+
+//
+// reset tick counters to zero
+//
+void resetEncoders() {
+  for(int i = 0; i < ENCODER_COUNT; i += 1) {
+    encoders[i].encoder->write(0);
+    encoders[i].ticks = 0;
+  }
+}
+
+
+//
+// write ticks to serial port
+// as a string tuple with ticks and tickMs separate by a comma
+//
+//   "{ticks},{ticksMs}"
+//
+void writeTicks(unsigned long ticksMs) {
+  Serial.print(encoders[0].ticks);
+  Serial.print(',');
+  Serial.print(ticksMs);
+  for(int i = 1; i < ENCODER_COUNT; i += 1) {
+    Serial.print(";");
+    Serial.print(encoders[i].ticks);
+    Serial.print(',');
+    Serial.print(ticksMs);
+  }
+  Serial.println("");
+}
+
+
+void setup() {
+  Serial.begin(115200);
+}
+
+
+void loop() {
+  //
+  // poll each encoder's ticks
+  //
+  pollEncoders();
+  unsigned long ticksMs = millis();
+
+  //
+  // commands are send one per line (ending in '\n')
+  // 'r' command resets position to zero
+  // 'p' command sends position immediately
+  // 'c' command starts/stops continuous mode
+  //     - if it is followed by an integer,
+  //       then use this as the delay in ms
+  //       between readings.
+  //     - if it is not followed by an integer
+  //       then stop continuous mode
+  //
+  if (Serial.available() > 0) {
+    String newcommand = Serial.readStringUntil('\n');
+    newcommand.trim();
+
+    if (newcommand == "r") {
+      //
+      // reset tick counters to zero
+      //
+      resetEncoders();
+    }
+    else if (newcommand == "p") {
+      //
+      // send current ticks immediately
+      //
+      writeTicks(ticksMs);
+    }
+    else if (newcommand.startsWith("c")) {
+      //
+      // continous mode start or stop
+      //
+      if (1 == newcommand.length()) {
+        //
+        // stop continuous mode
+        //
+        continuous = false;
+      } else {
+        //
+        // convert characters after 'c' to an integer
+        // and use this as the delay in milliseconds
+        //
+        String intString = newcommand.substring(1);
+        if (isDigit(intString.charAt(0))) {
+          delayMs = (unsigned long)intString.toInt();
+          continuous = true;
+        }
+      }
+    } else {
+      // unknown command
+    }
+  }
+    
+  //
+  // we are in continuous mode, 
+  // then send the ticks when
+  // the delay expires
+  //
+  if (continuous) {
+    if (ticksMs >= sendAtMs) {
+      sendAtMs = ticksMs + delayMs;
+      writeTicks(ticksMs);
+    }
+  }
+}

--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -748,44 +748,6 @@ class L298N_HBridge_3pin(object):
         self.pin_backward.stop()
 
 
-class TwoWheelSteeringThrottle(object):
-    """
-    Modify individual differential drive wheel throttles
-    in order to implemeht steering.
-    """
-
-    def run(self, throttle:float, steering:float) -> Tuple[float, float]:
-        """
-        :param throttle:float throttle value in range -1 to 1,
-                        where 1 is full forward and -1 is full backwards.
-        :param steering:float steering value in range -1 to 1,
-                        where -1 is full left and 1 is full right.
-        :return: tuple of left motor and right motor throttle values in range -1 to 1
-                 where 1 is full forward and -1 is full backwards.
-        """
-        if throttle > 1 or throttle < -1:
-            logger.warn( f"throttle is {throttle}, but it must be between 1(forward) and -1(reverse)")
-        if steering > 1 or steering < -1:
-            logger.warn( f"steering is {steering}, but it must be between 1(right) and -1(left)")
-
-        from donkeycar.utils import clamp
-        throttle = clamp(throttle, -1, 1)
-        steering = clamp(steering, -1, 1)
-
-        left_motor_speed = throttle
-        right_motor_speed = throttle
- 
-        if steering < 0:
-            left_motor_speed *= (1.0 - (-steering))
-        elif steering > 0:
-            right_motor_speed *= (1.0 - steering)
-
-        return left_motor_speed, right_motor_speed
-
-    def shutdown(self) -> None:
-        pass
-
-
 class L298N_HBridge_2pin(object):
     """
     Motor controlled with an 'mini' L298N hbridge using 2 PwmPins,

--- a/donkeycar/parts/controller.py
+++ b/donkeycar/parts/controller.py
@@ -12,6 +12,34 @@ from prettytable import PrettyTable
 from donkeycar.parts.web_controller.web import LocalWebController
 from donkeycar.parts.web_controller.web import WebFpv
 
+class MockController:
+    """
+    Mock controller that outputs a constant steering and throttle
+    use cfg.MOCK_JOYSTICK_STEERING and cfg.MOCK_JOYSTICK_THROTTLE
+    to set the constant values.
+    """
+    def __init__(self, steering=0.0, throttle=0.0):
+        self.steering = steering
+        self.throttle = throttle
+        self.mode = None
+        self.recording = None
+
+    def update(self):
+        pass
+
+    def run(self, img_arr=None, mode=None, recording=None):
+        #
+        # enforce defaults if they are not none.
+        #
+        if mode is not None:
+            self.mode = mode
+        if recording is not None:
+            self.recording = recording
+
+        return self.steering, self.throttle, self.mode, self.recording
+
+    def run_threaded(self, img_arr=None, mode=None, recording=None):
+        return self.run(img_arr, mode, recording)
 
 class Joystick(object):
     '''

--- a/donkeycar/parts/encoder.py
+++ b/donkeycar/parts/encoder.py
@@ -1,8 +1,11 @@
 """
+Deprecated in favor on donkeycar.parts.Tachometer and donkeycar.parts.Odometer.
+
 Encoders and odometry
 """
 
 from datetime import datetime
+from donkeycar.utilities.deprecated import deprecated
 import re
 import time
 
@@ -18,6 +21,7 @@ import time
 
 # This samples the odometer at 10HZ and does a moving average over the past ten readings to derive a velocity
 
+@deprecated("Deprecated in favor donkeycar.parts.tachometer.Tachometer(SerialEncoder)")
 class ArduinoEncoder(object):
     def __init__(self, mm_per_tick=0.0000599, debug=False):
         import serial
@@ -60,6 +64,8 @@ class ArduinoEncoder(object):
         self.on = False
         time.sleep(.5)
 
+
+@deprecated("Deprecated as unused")
 class AStarSpeed:
     def __init__(self):
         from donkeycar.parts.teensy import TeensyRCin
@@ -118,6 +124,7 @@ class AStarSpeed:
         time.sleep(.5)
 
 
+@deprecated("Deprecated in favor of donkeycar.parts.tachometer.Tachometer(GpioEncoder)")
 class RotaryEncoder():
     def __init__(self, mm_per_tick=0.306096, pin=13, poll_delay=0.0166, debug=False):
         import pigpio

--- a/donkeycar/parts/kinematics.py
+++ b/donkeycar/parts/kinematics.py
@@ -1,0 +1,592 @@
+import logging
+import math
+import time
+from typing import Tuple
+
+from donkeycar.utils import compare_to, sign, is_number_type, clamp
+
+logger = logging.getLogger(__name__)
+
+
+def limit_angle(angle:float):
+    """
+    limit angle between 0..2pi
+    """
+    return math.atan2(math.sin(angle), math.cos(angle));
+
+
+class Pose2D:
+    def __init__(self, x:float=0.0, y:float=0.0, angle:float=0.0) -> None:
+        self.x = x
+        self.y = y
+        self.angle = angle
+
+
+class Bicycle:
+    """
+    Bicycle forward kinematics for a car-like vehicle (Ackerman steering)
+    takes the steering angle in radians and output of the odometer 
+    and turns those into:
+    - forward distance and velocity,
+    - pose; angle aligned (x,y) position and orientation in radians
+    - pose velocity; change in angle aligned position and orientation per second
+    @param wheel_base: distance between the front and back wheels
+
+    NOTE: this version uses the point midway between the rear wheels
+          as the point of reference.
+    see https://thef1clan.com/2020/09/21/vehicle-dynamics-the-kinematic-bicycle-model/
+    """
+    def __init__(self, wheel_base:float, debug=False):
+        self.wheel_base:float = wheel_base
+        self.debug = debug
+        self.timestamp:float = 0
+        self.forward_distance:float = 0
+        self.forward_velocity:float = 0
+        self.pose = Pose2D()
+        self.pose_velocity = Pose2D()
+        self.running:bool = True
+
+    def run(self, forward_distance:float, steering_angle:float, timestamp:float=None) -> Tuple[float, float, float, float, float, float, float, float, float]:
+        """
+        params
+            forward_distance: distance the reference point has travelled
+            steering_angle: angle in radians of the front 'wheel' from forward.
+                            In this case left is positive, right is negative,
+                            and directly forward is zero.
+            timestamp: time of distance readings or None to use current time
+        returns
+            distance
+            velocity
+            x is horizontal position of point midway between wheels
+            y is vertical position of point midway between wheels
+            angle is orientation in radians around point midway between wheels
+            x' is the horizontal velocity
+            y' is the vertical velocity
+            angle' is the angular velocity
+            timestamp
+
+        """
+        if timestamp is None:
+            timestamp = time.time()
+
+        steering_angle = limit_angle(steering_angle)
+
+        if self.running:
+            if 0 == self.timestamp:
+                self.timestamp = timestamp
+                self.forward_distance = forward_distance
+                self.forward_velocity=0
+                self.pose = Pose2D()
+                self.pose_velocity = Pose2D()
+                self.timestamp = timestamp
+            elif timestamp > self.timestamp:
+                #
+                # changes from last run
+                #
+                delta_time = timestamp - self.timestamp
+                delta_distance = forward_distance - self.forward_distance
+                forward_velocity = delta_distance / delta_time
+
+                #
+                # new velocities
+                #
+                angle_velocity = bicycle_angular_velocity(self.wheel_base, forward_velocity, steering_angle)
+                delta_angle = angle_velocity * delta_time
+                estimated_angle = limit_angle(self.pose.angle + delta_angle / 2)
+                x_velocity = forward_velocity * math.cos(estimated_angle)
+                y_velocity = forward_velocity * math.sin(estimated_angle)
+
+                #
+                # new position and orientation
+                #
+                x = self.pose.x + x_velocity * delta_time
+                y = self.pose.y + y_velocity * delta_time
+                angle = limit_angle(self.pose.angle + delta_angle)
+
+                #
+                # update pose and velocities
+                #
+                self.pose.x = x
+                self.pose.y = y
+                self.pose.angle = angle
+                self.pose_velocity.x = x_velocity
+                self.pose_velocity.y = y_velocity
+                self.pose_velocity.angle = angle_velocity
+
+                #
+                # update odometry
+                #
+                self.forward_distance = forward_distance
+                self.forward_velocity = forward_velocity
+
+                self.timestamp = timestamp
+
+                return (
+                    self.forward_distance,
+                    self.forward_velocity, 
+                    self.pose.x, self.pose.y, self.pose.angle, 
+                    self.pose_velocity.x, self.pose_velocity.y, self.pose_velocity.angle, 
+                    self.timestamp
+                )
+
+        return (0, 0, 0, 0, 0, 0, 0, 0, self.timestamp)
+
+    def shutdown(self):
+        self.running = False
+
+
+class InverseBicycle:
+    """
+    Bicycle inverse kinematics for a car-like vehicle (Ackerman steering)
+    takes the forward velocity and the angular velocity in radians/second
+    and converts these to:
+    - forward velocity (pass through),
+    - steering angle in radians
+    @param wheel_base: distance between the front and back wheels
+
+    NOTE: this version uses the point midway between the rear wheels
+          as the point of reference.
+    see https://thef1clan.com/2020/09/21/vehicle-dynamics-the-kinematic-bicycle-model/
+    """
+    def __init__(self, wheel_base:float, debug=False):
+        self.wheel_base:float = wheel_base
+        self.debug = debug
+        self.timestamp:float = 0
+
+    def run(self, forward_velocity:float, angular_velocity:float, timestamp:float=None) -> Tuple[float, float, float]:
+        """
+        @param forward_velocity:float in meters per second
+        @param angular_velocity:float in radians per second
+        @return tuple
+                - forward_velocity:float in meters per second (basically a pass through)
+                - steering_angle:float in radians
+                - timestamp:float
+        """
+        if timestamp is None:
+            timestamp = time.time()
+
+        """
+        derivation from bicycle model:
+        angular_velocity = forward_velocity * math.tan(steering_angle) / self.wheel_base
+        math.tan(steering_angle) = angular_velocity * self.wheel_base / forward_velocity
+        steering_angle = math.atan(angular_velocity * self.wheel_base / forward_velocity)
+        """
+        steering_angle = bicycle_steering_angle(self.wheel_base, forward_velocity, angular_velocity)        
+        self.timestamp = timestamp
+
+        return (forward_velocity, steering_angle, timestamp)
+
+
+def bicycle_steering_angle(wheel_base:float, forward_velocity:float, angular_velocity:float) -> float:
+    """
+    Calculate bicycle steering for the vehicle from the angular velocity.
+    For car-like vehicles, calculate the angular velocity using 
+    the bicycle model and the measured max forward velocity and max steering angle.
+    """
+    #
+    # derivation from bicycle model:
+    # angular_velocity = forward_velocity * math.tan(steering_angle) / self.wheel_base
+    # math.tan(steering_angle) = angular_velocity * self.wheel_base / forward_velocity
+    # steering_angle = math.atan(angular_velocity * self.wheel_base / forward_velocity)
+    #
+    return math.atan(angular_velocity * wheel_base / forward_velocity)
+
+
+def bicycle_angular_velocity(wheel_base:float, forward_velocity:float, steering_angle:float) -> float:
+    """
+    Calculate angular velocity for the vehicle from the bicycle steering angle.
+    For car-like vehicles, calculate the angular velocity using 
+    the bicycle model and the measured max forward velocity and max steering angle.
+    """
+    #
+    # for car-like (bicycle model) vehicle:
+    # angular_velocity = forward_velocity / wheel_base * math.tan(steering_angle)
+    #
+    return forward_velocity / wheel_base * math.tan(steering_angle)
+
+
+class BicycleNormalizeAngularVelocity:
+    """
+    For a car-like vehicle, convert an angular velocity in radians per second
+    to a value between -1 and 1 inclusive.
+    """
+    def __init__(self, wheel_base:float, max_forward_velocity:float, max_steering_angle:float) -> None:
+        self.max_angular_velocity = bicycle_angular_velocity(wheel_base, max_forward_velocity, max_steering_angle)
+
+    def run(self, angular_velocity:float) -> float:
+        return angular_velocity / self.max_angular_velocity
+
+
+class BicycleUnnormalizeAngularVelocity:
+    """
+    For a car-like vehicle, convert a normalized angular velocity in range -1 to 1
+    into a real angular velocity in radians per second.
+    """
+    def __init__(self, wheel_base:float, max_forward_velocity:float, max_steering_angle:float) -> None:
+        self.max_angular_velocity = bicycle_angular_velocity(wheel_base, max_forward_velocity, max_steering_angle)
+
+    def run(self, normalized_angular_velocity:float) -> float:
+        if abs(normalized_angular_velocity) > 1:
+            print("Warning: normalized_angular_velocity must be between -1 and 1")
+        return normalized_angular_velocity * self.max_angular_velocity
+
+
+class Unicycle:
+    """
+    Unicycle forward kinematics takes the output of the 
+    left and right odometers and 
+    turns those into:
+    - forward distance and velocity,
+    - pose; angle aligned (x,y) position and orientation in radians
+    - pose velocity; change in angle aligned position and orientation per second
+    axle_length: distance between the two drive wheels
+    wheel_radius: radius of wheel; must be in same units as axle_length
+                  It is assumed that both wheels have the same radius
+    see http://faculty.salina.k-state.edu/tim/robotics_sg/Control/kinematics/unicycle.html
+    """
+    def __init__(self, axle_length:float, debug=False):
+        self.axle_length:float = axle_length
+        self.debug = debug
+        self.timestamp:float = 0
+        self.left_distance:float = 0
+        self.right_distance:float = 0
+        self.velocity:float = 0
+        self.pose = Pose2D()
+        self.pose_velocity = Pose2D()
+        self.running:bool = True
+
+    def run(self, left_distance:float, right_distance:float, timestamp:float=None) -> Tuple[float, float, float, float, float, float, float, float, float]:
+        """
+        params
+            left_distance: distance left wheel has travelled
+            right_distance: distance right wheel has travelled
+            timestamp: time of distance readings or None to use current time
+        returns
+            distance
+            velocity
+            x is horizontal position of point midway between wheels
+            y is vertical position of point midway between wheels
+            angle is orientation in radians around point midway between wheels
+            x' is the horizontal velocity
+            y' is the vertical velocity
+            angle' is the angular velocity
+            timestamp
+
+        """
+        if timestamp is None:
+            timestamp = time.time()
+
+        if self.running:
+            if 0 == self.timestamp:
+                self.timestamp = timestamp
+                self.left_distance = left_distance
+                self.right_distance = right_distance
+                self.velocity=0
+                self.pose = Pose2D()
+                self.pose_velocity = Pose2D()
+                self.timestamp = timestamp
+            elif timestamp > self.timestamp:
+                #
+                # changes from last run
+                #
+                delta_left_distance = left_distance - self.left_distance
+                delta_right_distance = right_distance - self.right_distance
+                delta_distance = (delta_left_distance + delta_right_distance) / 2
+                delta_angle = (delta_right_distance - delta_left_distance) / self.axle_length
+                delta_time = timestamp - self.timestamp
+
+                forward_velocity = delta_distance / delta_time
+                angle_velocity = delta_angle / delta_time
+
+                #
+                # new position and orientation
+                #
+                estimated_angle = limit_angle(self.pose.angle + delta_angle / 2)
+                x = self.pose.x + delta_distance * math.cos(estimated_angle)
+                y = self.pose.y + delta_distance * math.sin(estimated_angle)
+                angle = limit_angle(self.pose.angle + delta_angle)
+
+                #
+                # new velocities
+                #
+                self.pose_velocity.x = (x - self.pose.x) / delta_time
+                self.pose_velocity.y = (y - self.pose.y) / delta_time
+                self.pose_velocity.angle = angle_velocity
+
+                #
+                # update pose
+                #
+                self.pose.x = x
+                self.pose.y = y
+                self.pose.angle = angle
+
+                #
+                # update odometry
+                #
+                self.left_distance = left_distance
+                self.right_distance = right_distance
+                self.velocity = forward_velocity
+
+                self.timestamp = timestamp
+
+                return (
+                    (self.left_distance + self.right_distance) / 2,
+                    self.velocity, 
+                    self.pose.x, self.pose.y, self.pose.angle, 
+                    self.pose_velocity.x, self.pose_velocity.y, self.pose_velocity.angle, 
+                    self.timestamp
+                )
+
+
+        return (0, 0, 0, 0, 0, 0, 0, 0, self.timestamp)
+
+    def shutdown(self):
+        self.running = False
+
+
+class InverseUnicycle:
+    """
+    Unicycle inverse kinematics that converts forward velocity and 
+    angular orientation velocity into invidual linear wheel velocities 
+    in a differential drive robot.
+    """
+    def __init__(self, axle_length:float, wheel_radius:float, min_speed:float, max_speed:float, steering_zero:float=0.01, debug=False):
+        self.axle_length:float = axle_length
+        self.wheel_radius:float = wheel_radius
+        self.min_speed:float = min_speed
+        self.max_speed:float = max_speed
+        self.steering_zero:float = steering_zero
+        self.timestamp = 0
+        self.debug = debug
+
+        self.wheel_diameter = 2 * wheel_radius
+        self.wheel_circumference = math.pi * self.wheel_diameter
+    def run(self, forward_velocity:float, angular_velocity:float, timestamp:float=None) -> Tuple[float, float, float]:
+        """
+        Convert turning velocity in radians and forward velocity (like meters per second)
+        into left and right linear wheel speeds that result in that forward speed
+        at that turning angle
+        see http://faculty.salina.k-state.edu/tim/robotics_sg/Control/kinematics/unicycle.html#calculating-wheel-velocities
+
+        @parma forward_velocity:float in meters per second
+        @param angular_velocity:float in radians per second
+        @param timestamp:float epoch seconds or None to use current time
+        @return tuple
+                - left_wheel_velocity: in meters per second
+                - right_wheel_velocity in meters per second
+                - timestamp
+        """
+        if timestamp is None:
+            timestamp = time.time()
+
+        left_linear_speed = forward_velocity - angular_velocity * self.axle_length / 2
+        right_linear_speed = forward_velocity + angular_velocity * self.axle_length / 2
+
+        self.timestamp = timestamp
+
+        # left/right linear speeds and timestamp
+        return (left_linear_speed, right_linear_speed, timestamp)
+
+    def shutdown(self):
+        pass
+
+
+def unicycle_angular_velocity(wheel_radius:float, axle_length:float, left_velocity:float, right_velocity:float) -> float:
+    """
+    Calculate angular velocity for the unicycle vehicle.
+    For differential drive, calculate angular velocity 
+    using the unicycle model and linear wheel velocities. 
+    """
+    #
+    # since angular_velocity = wheel_radius / axle_length * (right_rotational_velocity - left_rotational_velocity)
+    # where wheel rotational velocity is in radians per second.
+    #
+    right_rotational_velocity = wheel_rotational_velocity(wheel_radius, right_velocity)
+    left_rotational_velocity = wheel_rotational_velocity(wheel_radius, left_velocity)
+    return wheel_radius / axle_length * (right_rotational_velocity - left_rotational_velocity)
+
+
+def unicycle_max_angular_velocity(wheel_radius:float, axle_length:float, max_forward_velocity:float) -> float:
+    """
+    Calculate maximum angular velocity for the vehicle, so we can convert between
+    normalized and unnormalized forms of the angular velocity.
+    For differential drive, calculate maximum angular velocity 
+    using the unicycle model and assuming one 
+    one wheel is stopped and one wheel is at max velocity.
+    """
+    #
+    # since angular_velocity = wheel_radius / axle_length * (right_rotational_velocity - left_rotational_velocity)
+    # where wheel rotational velocity is in radians per second.
+    # then if we drive the right wheel at maximum velocity and keep the left wheel stopped
+    # we get max_angular_velocity = wheel_radius / axle_length * max_forward_velocity
+    #
+    return unicycle_angular_velocity(wheel_radius, axle_length, 0, max_forward_velocity)
+
+
+class UnicycleNormalizeAngularVelocity:
+    """
+    For a differential drive vehicle, convert an angular velocity in radians per second
+    to a value between -1 and 1 inclusive.
+    """
+    def __init__(self, wheel_radius:float, axle_length:float, max_forward_velocity:float) -> None:
+        self.max_angular_velocity = unicycle_max_angular_velocity(wheel_radius, axle_length, max_forward_velocity)
+
+    def run(self, angular_velocity:float) -> float:
+        return angular_velocity / self.max_angular_velocity
+
+
+class UnicycleUnnormalizeAngularVelocity:
+    """
+    For a differential drive vehicle, convert a normalized angular velocity in range -1 to 1
+    into a real angular velocity in radians per second.
+    """
+    def __init__(self, wheel_radius:float, axle_length:float, max_forward_velocity:float) -> None:
+        self.max_angular_velocity = unicycle_max_angular_velocity(wheel_radius, axle_length, max_forward_velocity)
+
+    def run(self, normalized_angular_velocity:float) -> float:
+        if abs(normalized_angular_velocity) > 1:
+            print("Warning: normalized_angular_velocity must be between -1 and 1")
+        return normalized_angular_velocity * self.max_angular_velocity
+
+
+class NormalizeSteeringAngle:
+    """
+    Part to convert real steering angle in radians
+    to a to a normalize steering value in range -1 to 1
+    """
+    def __init__(self, max_steering_angle:float, steering_zero:float=0.0) -> None:
+        """
+        @param max_steering_angle:float measured maximum steering angle in radians
+        @param steering_zero:float value at or below which normalized steering values
+                                   are considered to be zero.
+        """
+        self.max_steering_angle = max_steering_angle
+        self.steering_zero = steering_zero
+    
+    def run(self, steering_angle) -> float:
+        if not is_number_type(steering_angle):
+            logger.error("steering angle must be a number.")
+            return 0
+
+        steering = steering_angle / self.max_steering_angle
+        if abs(steering) <= self.steering_zero:
+            return 0
+        return steering
+
+    def shutdown():
+        pass
+
+
+class UnnormalizeSteeringAngle:
+    """
+    Part to convert normalized steering in range -1 to 1
+    to a to real steering angle in radians
+    """
+    def __init__(self, max_steering_angle:float, steering_zero:float=0.0) -> None:
+        """
+        @param max_steering_angle:float measured maximum steering angle in radians
+        @param steering_zero:float value at or below which normalized steering values
+                                   are considered to be zero.
+        """
+        self.max_steering_angle = max_steering_angle
+        self.steering_zero = steering_zero
+    
+    def run(self, steering) -> float:
+        if not is_number_type(steering):
+            logger.error("steering must be a number")
+            return 0
+
+        if steering > 1 or steering < -1:
+            logger.warn(f"steering = {steering}, but must be between 1(right) and -1(left)")
+
+        steering = clamp(steering, -1, 1)
+        
+        s = sign(steering)
+        steering = abs(steering)
+        if steering <= self.steering_zero:
+            return 0
+
+        return self.max_steering_angle * steering * s
+
+    def shutdown():
+        pass
+
+
+def wheel_rotational_velocity(wheel_radius:float, speed:float) -> float:
+    """
+    Convert a forward speed to wheel rotational speed in radians per second.
+    Units like wheel_radius in meters and speed in meters per second
+    results in radians per second rotational wheel speed.
+
+    @wheel_radius:float radius of wheel in same distance units as speed
+    @speed:float speed in distance units compatible with radius
+    @return:float wheel's rotational speed in radians per second
+    """
+    return speed / wheel_radius
+
+
+def differential_steering(throttle: float, steering: float, steering_zero: float = 0.01) -> Tuple[float, float]:
+        """
+        Turn steering angle and speed/throttle into 
+        left and right wheel speeds/throttle.
+        This basically slows down one wheel by the steering value
+        while leaving the other wheel at the desired throttle.
+        So, except for the case where the steering is zero (going straight forward),
+        the effective throttle is low than the requested throttle.  
+        This is different than car-like vehicles, where the effective
+        forward throttle is not affected by the steering angle.
+        This is is NOT inverse kinematics; it is appropriate for managing throttle
+        when a user is driving the car (so the user is the controller)
+        This is the algorithm used by TwoWheelSteeringThrottle.
+
+        @Param throttle:float throttle or real speed; reverse < 0, 0 is stopped, forward > 0
+        @Param steering:float -1 to 1, -1 full left, 0 straight, 1 is full right
+        @Param steering_zero:float values abs(steering) <= steering_zero are considered zero.
+        """
+        if not is_number_type(throttle):
+            logger.error("throttle must be a number")
+            return 0, 0
+        if throttle > 1 or throttle < -1:
+            logger.warn(f"throttle = {throttle}, but must be between 1(right) and -1(left)")
+        throttle = clamp(throttle, -1, 1)
+
+        if not is_number_type(steering):
+            logger.error("steering must be a number")
+            return 0, 0
+        if steering > 1 or steering < -1:
+            logger.warn(f"steering = {steering}, but must be between 1(right) and -1(left)")
+        steering = clamp(steering, -1, 1)
+
+        left_throttle = throttle
+        right_throttle = throttle
+ 
+        if steering < -steering_zero:
+            left_throttle *= (1.0 + steering)
+        elif steering > steering_zero:
+            right_throttle *= (1.0 - steering)
+
+        return left_throttle, right_throttle        
+
+
+class TwoWheelSteeringThrottle:
+    """
+    convert throttle and steering into individual
+    wheel throttles in a differential drive robot
+    @Param steering_zero:float values abs(steering) <= steering_zero are considered zero.
+    """
+    def __init__(self, steering_zero: float = 0.01) -> None:
+        if not is_number_type(steering_zero):
+            raise ValueError("steering_zero must be a number")
+        if steering_zero > 1 or steering_zero < 0:
+            raise ValueError(f"steering_zero  {steering_zero}, but must be be between 1 and zero.")
+        self.steering_zero = steering_zero
+
+    def run(self, throttle, steering):
+        """
+        @Param throttle:float throttle or real speed; reverse < 0, 0 is stopped, forward > 0
+        @Param steering:float -1 to 1, -1 full left, 0 straight, 1 is full right
+        """
+        return differential_steering(throttle, steering, self.steering_zero)
+ 
+    def shutdown(self):
+        pass

--- a/donkeycar/parts/kinematics.py
+++ b/donkeycar/parts/kinematics.py
@@ -10,9 +10,15 @@ logger = logging.getLogger(__name__)
 
 def limit_angle(angle:float):
     """
-    limit angle between 0..2pi
+    limit angle to pi to -pi radians (one full circle)
     """
     return math.atan2(math.sin(angle), math.cos(angle));
+    # twopi = math.pi * 2
+    # while(angle > math.pi):
+    #     angle -= twopi
+    # while(angle < -math.pi):
+    #     angle += twopi
+    # return angle
 
 
 class Pose2D:

--- a/donkeycar/parts/logger.py
+++ b/donkeycar/parts/logger.py
@@ -1,0 +1,41 @@
+import logging
+from typing import List, Set, Dict, Tuple, Optional
+
+
+class LoggerPart:
+    """
+    Log the given values in vehicle memory.
+    """
+    def __init__(self, inputs: List[str], level: str="INFO", rate: int=0, logger=None):
+        self.inputs = inputs
+        self.rate = rate  # force output every nth update
+        self.level = logging._nameToLevel.get(level, logging.INFO)
+        self.logger = logging.getLogger(logger if logger is not None else "LoggerPart")
+
+        self.values = {}
+        self.count = 0
+        self.running = True
+
+    def run(self, *args):
+        if self.running:
+            if len(args) != len(self.inputs):
+                self.logger.error("Not enough arguments to log")
+                return
+
+            msgs = []
+            self.count = (self.count + 1) % (self.rate + 1)
+            for i in range(len(self.inputs)):
+                field = self.inputs[i]
+                value = args[i]
+                old_value = self.values.get(field)
+                if old_value != value:
+                    # always log changes
+                    msgs.append(f"{field} = {old_value} -> {value}")
+                    self.values[field] = value
+                elif self.rate and self.count >= self.rate:
+                    msgs.append(f"{field} = {value}")
+            if len(msgs) > 0:
+                self.logger.log(self.level, ", ".join(msgs))
+
+    def shutdown(self):
+        self.running = False

--- a/donkeycar/parts/odometer.py
+++ b/donkeycar/parts/odometer.py
@@ -1,0 +1,61 @@
+import time
+from typing import Tuple
+
+from donkeycar.utilities.circular_buffer import CircularBuffer
+
+
+class Odometer:
+    """
+    An Odometer takes the output of a Tachometer (revolutions) and
+    turns those into a distance and velocity.  Velocity can be
+    optionally smoothed across a given number of readings.
+    """
+    def __init__(self, distance_per_revolution:float, smoothing_count=1, debug=False):
+        self.distance_per_revolution:float = distance_per_revolution
+        self.timestamp:float = 0
+        self.revolutions:float = 0
+        self.running:bool = True
+        self.queue = CircularBuffer(smoothing_count if smoothing_count >= 1 else 1)
+        self.debug = debug
+
+    def poll(self, revolutions, timestamp):
+        if self.running:
+            if timestamp is None:
+                timestamp = time.time()
+            distance = revolutions * self.distance_per_revolution
+
+            # smooth velocity
+            velocity = 0
+            if self.queue.count > 0:
+                lastDistance, lastVelocity, lastTimestamp = self.queue.tail()
+                if timestamp > lastTimestamp:
+                    velocity = (distance - lastDistance) / (timestamp - lastTimestamp)
+
+            self.queue.enqueue((distance, velocity, timestamp))
+            if self.debug and velocity != 0:
+                print("odometry: d = {}, v = {}, ts = {}".format(distance, velocity, timestamp))
+
+    def update(self):
+        while(self.running):
+            self.poll(self.revolutions, self.timestamp)
+            time.sleep(0)  # give other threads time
+
+    def run_threaded(self, revolutions:float=0, timestamp:float=None) -> Tuple[float, float, float]:
+        if self.running:
+            self.revolutions = revolutions
+            self.timestamp = timestamp if timestamp is not None else time.time()
+
+            if self.queue.count > 0:
+                return self.queue.head()
+        return (0, 0, self.timestamp)
+
+    def run(self, revolutions:float=0, timestamp:float=None) -> Tuple[float, float, float]:
+        if self.running:
+            self.poll(revolutions, timestamp)
+
+            if self.queue.count > 0:
+                return self.queue.head()
+        return (0, 0, self.timestamp)
+
+    def shutdown(self):
+        self.running = False

--- a/donkeycar/parts/tachometer.py
+++ b/donkeycar/parts/tachometer.py
@@ -53,6 +53,33 @@ class AbstractEncoder(ABC):
         """
         return 0
 
+
+class MockEncoder(AbstractEncoder):
+    """
+    Mock encoder always counts up based on time
+    """
+    def __init__(self, ticks_per_millis=1):
+        self.ticks_per_millis = ticks_per_millis
+        self.start_millis = 0
+        self.ticks = 0
+        self.running = False
+
+    def start_ticks(self):
+        self.start_millis = time.time()
+
+    def stop_ticks(self):
+        self.start_millis = 0
+
+    def poll_ticks(self, direction:int):
+        if self.start_millis:
+            now = time.time()
+            self.ticks += (now - self.start_millis) * self.ticks_per_millis * direction
+            self.start_millis = now
+
+    def get_ticks(self, encoder_index:int=0) -> int:
+        return self.ticks
+
+
 class SerialEncoder(AbstractEncoder):
     """
     Encoder that requests tick count over serial port.

--- a/donkeycar/parts/tachometer.py
+++ b/donkeycar/parts/tachometer.py
@@ -1,0 +1,562 @@
+from abc import (ABC, abstractmethod)
+import logging
+import time
+import threading
+from typing import Tuple
+
+from donkeycar.utilities.platform import is_jetson
+from donkeycar.utilities.serial_port import SerialPort
+from donkeycar.parts.pins import InputPin, PinEdge
+
+
+logger = logging.getLogger("donkeycar.parts.tachometer")
+
+
+class AbstractEncoder(ABC):
+    """
+    Interface for an encoder.
+    To create a new encoder class, subclass from
+    AbstractEncoder and implement
+    start_ticks(), stop_ticks() and poll_ticks().
+    Tachometer() takes an encoder in it's contructor.
+    """
+    @abstractmethod
+    def start_ticks(self):
+        """Initialize the encoder"""
+        pass
+
+    @abstractmethod
+    def stop_ticks(self):
+        """release the encoder resources"""
+        pass
+
+    @abstractmethod
+    def poll_ticks(self, direction:int):
+        """
+        Update the encoder ticks
+        direction: 1 if forward, -1 if reverse, 0 if stopped.
+
+        This will request a new value from the encoder.
+        """
+        pass
+
+    @abstractmethod
+    def get_ticks(self, encoder_index:int=0) -> int:
+        """
+        Get last polled encoder ticks
+        encoder_index: zero based index of encoder.
+        return: Most recently polled encoder ticks
+
+        This will return the value from the
+        most recent call to poll_ticks().  It 
+        will not request new values from the encoder.
+        """
+        return 0
+
+class SerialEncoder(AbstractEncoder):
+    """
+    Encoder that requests tick count over serial port.
+    The other end is typically a microcontroller that 
+    is reading an encoder, which may be a single-channel
+    encoder (so ticks only increase) or a quarature encoder
+    (so ticks may increment or decrement).
+
+    Quadrature encoders can detect when the 
+    encoder is going forward, backward or stopped.
+    For such encoders, use the default direction mode, 
+    FORWARD_ONLY, and changes in tick count will correctly 
+    be summed to the current tick count.
+
+    Single channel encoders cannot encode direction;
+    their count will only ever increase.  So this part
+    can take the signed throttle value as direction and
+    use it to decide if the ticks should be incremented
+    or decremented. 
+    For vehicles that 'coast' at zero throttle, choose
+    FORWARD_BACKWARD direction mode so we continue to 
+    integrate ticks while coasting.
+    For vehicles with brakes or that otherwise stop quickly, 
+    choose FORWARD_BACKWARD_STOP direction mode 
+    so encoder noise is not integrated while stopped.
+
+    This part assumes a microcontroller connected via
+    serial port that implements the following 
+    'r/p/c' protocol:
+
+    Commands are sent to the microcontroller 
+    one per line (ending in '\n'):
+    'r' command resets position to zero
+    'p' command sends position immediately
+    'c' command starts/stops continuous mode
+        - if it is followed by an integer,
+          then use this as the delay in ms
+          between readings.
+        - if it is not followed by an integer
+          then stop continuous mode
+    
+    The microcontroller sends one reading per line.
+    Each reading includes the tick count and the time
+    that the reading was taken, separated by a comma
+    and ending in a newline.  Readings for multiple
+    encoders are separated by colons.
+
+        {ticks},{milliseconds};{ticks},{milliseconds}\n
+
+    There is an example arduino sketch that implements the
+    'r/p/c' protocol using the teensy encoder library at 
+    donkeycar/arduino/encoder/encoder.ino  The sketch
+    presumes a quadrature encoder connect to pins 2 & 3
+    of an arduino.  If you have a different microcontroller
+    or want to use different pins or if you want to
+    use a single-channel encoder, then modify that sketch.
+
+    """
+    def __init__(self, serial_port:SerialPort=None, debug=False):
+        if serial_port is None:
+            raise ValueError("serial_port must be an instance of SerialPort")
+        self.ser = serial_port
+        self.ticks = [0,0]
+        self.lasttick = [0,0]
+        self.running = False
+    
+    def start_ticks(self):
+        self.ser.start()
+        self.ser.writeln('r')  # restart the encoder to zero
+        # if self.poll_delay_secs > 0:
+        #     # start continuous mode if given non-zero delay
+        #     self.ser.writeln("c" + str(int(self.poll_delay_secs * 1000)))
+        self.ser.writeln('p')  # ask for the first ticks
+        self.running = True
+
+    def stop_ticks(self):
+        self.running = False
+        if self.ser is not None:
+            self.ser.stop()
+
+    # TODO: we need to have independent directions for each encoder,
+    #       either poll_ticks takes encoder index or we keep track of direction
+    #       for each channel. This is ok for now because the way our
+    #       differential drive works we cannot pivot in place; we just slow
+    #       down one wheel to turn, so effectively both wheels are always going
+    #       in the same direction.
+    def poll_ticks(self, direction:int):
+        """
+        read the encoder ticks
+        direction: 1 if forward, -1 if reverse, 0 if stopped.
+        return: updated encoder ticks
+        """
+        #
+        # If there are characters waiting, 
+        # then read from the serial port.
+        # Read all lines and use the last one
+        # because it has the most recent reading
+        #
+        input = ''
+        while (self.running and (self.ser.buffered() > 0)):
+            _, input = self.ser.readln()
+
+        #
+        # queue up another reading by sending the "p" command to the Arduino
+        #
+        self.ser.writeln('p')  
+
+        #
+        # if we got data, update the  ticks
+        # if we got no data, then use last ticks we read
+        #
+        # data for encoders is separated by semicolon
+        # and ticks and time for single encoder
+        # is comma separated.
+        # 
+        #  "ticks,ticksMs;ticks,ticksMs"
+        #
+        if input != '':
+            try:
+                # 
+                # split separate encoder outputs
+                # "ticks,time;ticks,time" -> ["ticks,time", "ticks,time"]
+                #
+                values = [s.strip() for s in input.split(';')]
+
+                #
+                # split tick/time pairs for each encoder
+                # ["ticks,time", "ticks,time"] -> [["ticks", "time"], ["ticks", "time"]]
+                #
+                values = [v.split(',') for v in values]
+                for i in range(len(values)):
+                    total_ticks = int((values[i][0]).strip())
+                    delta_ticks = total_ticks - self.lasttick[i]
+                    self.lasttick[i] = total_ticks
+                    self.ticks[i] += delta_ticks * direction
+                
+            except ValueError:
+                logger.error("failure parsing encoder values from serial")
+
+    def get_ticks(self, encoder_index:int=0) -> int:
+        """
+        Get last polled encoder ticks
+        encoder_index: zero based index of encoder.
+        return: Most recently polled encoder ticks
+
+        This will return the same value as the
+        most recent call to poll_ticks().  It 
+        will not request new values from the encoder.
+        """
+        return self.ticks[encoder_index] if encoder_index < len(self.ticks) else 0
+
+
+class EncoderChannel(AbstractEncoder):
+    """
+    Wrapper around SerialEncoder to pull 
+    out channel 2 as separate encoder.
+
+    This MUST be added AFTER the parent SerialEncoder,
+    so that the parent encodere gets polled before 
+    we attempt to call get_ticks() for this encoder channel.
+    """
+    def __init__(self, encoder:SerialEncoder, channel:int) -> None:
+        self.encoder = encoder
+        self.channel = channel
+        super().__init__()
+
+    def start_ticks(self):
+        if not self.encoder.running:
+            self.encoder.start_ticks()
+
+
+    def stop_ticks(self):
+        if self.encoder.running:
+            self.encoder.stop_ticks()
+
+
+    def poll_ticks(self, direction:int):
+        self.encoder.poll_ticks(direction)
+
+
+    def get_ticks(self, encoder_index:int=0) -> int:
+        return self.encoder.get_ticks(encoder_index=self.channel)
+
+
+class GpioEncoder(AbstractEncoder):
+    """
+    An single-channel encoder read using an InputPin
+    :gpio_pin: InputPin that will get the signal
+    :debounce_ns: int number of nano seconds before accepting another 
+                  encoder signal.  This is used to ignore bounces.
+    :debug: bool True to output extra logging
+    """
+    def __init__(self, gpio_pin: InputPin, debounce_ns:int=0, debug=False):
+        # validate gpio_pin
+        if gpio_pin is None:
+            raise ValueError('The encoder input pin must be a valid InputPin.')
+
+        self.debug = debug
+        self.counter = 0
+        self._cb_counter = 0
+        self.direction = 0
+        self.pin = gpio_pin
+        self.debounce_ns:int = debounce_ns
+        self.debounce_time:int = 0
+        if self.debounce_ns > 0:
+            logger.warn("GpioEncoder debounce_ns will be ignored.")
+        self.lock = threading.Lock()
+
+
+    def _cb(self):
+        """
+        Callback routine called by GPIO when a tick is detected
+        :pin_number: int the pin number that generated the interrupt.
+        :pin_state: int the state of the pin
+        """
+        self._cb_counter += 1
+        if self.lock.acquire(blocking=False):
+            try:
+                self.counter += self._cb_counter * self.direction
+                self._cb_counter = 0
+            finally:
+                self.lock.release()
+            
+    def start_ticks(self):
+        # configure GPIO pin
+        self.pin.start(on_input=lambda: self._cb(), edge=PinEdge.RISING)
+
+
+    def poll_ticks(self, direction:int):  
+        """
+        read the encoder ticks
+        direction: 1 if forward, -1 if reverse, 0 if stopped.
+        return: updated encoder ticks
+        """
+        with self.lock:
+            self.direction = direction
+
+
+    def stop_ticks(self):
+        self.pin.stop()          
+
+    def get_ticks(self, encoder_index:int=0) -> int:
+        """
+        Get last polled encoder ticks
+        encoder_index: zero based index of encoder.
+        return: Most recently polled encoder ticks
+
+        This will return the same value as the
+        most recent call to poll_ticks().  It 
+        will not request new values from the encoder.
+        """
+        with self.lock:
+            return self.counter if encoder_index == 0 else 0
+
+
+def sign(value) -> int:
+    if value > 0: return 1
+    if value < 0: return -1
+    return 0
+
+
+class TachometerMode:
+    FORWARD_ONLY = 1          # only sum ticks (ticks may be signed)
+    FORWARD_REVERSE = 2       # subtract ticks if throttle is negative
+    FORWARD_REVERSE_STOP = 3  # ignore ticks if throttle is zero
+    
+
+class Tachometer:
+    """
+    Tachometer converts encoder ticks to revolutions
+    and supports modifying direction based on
+    throttle input.
+    encoder is an instance of an encoder class
+    derived from AbstactEncoder.  
+    config is ticks per revolution,
+    input is throttle value (used to set direction),
+    output is current number of revolutions and timestamp
+    note: if you just want raw encoder output, use 
+          ticks_per_revolution=1
+    """
+
+    def __init__(self, 
+        encoder:AbstractEncoder, 
+        ticks_per_revolution:float=1, 
+        direction_mode=TachometerMode.FORWARD_ONLY, 
+        poll_delay_secs:float=0.01, 
+        debug=False):
+        
+        if encoder is None:
+            raise ValueError("encoder must be an instance of AbstractEncoder")
+        self.encoder = encoder
+        self.running:bool = False
+        self.ticks_per_revolution:float = ticks_per_revolution
+        self.direction_mode = direction_mode
+        self.ticks:int = 0
+        self.direction:int = 1  # default to forward ticks
+        self.timestamp:float = 0
+        self.throttle = 0.0
+        self.debug = debug
+        self.poll_delay_secs = poll_delay_secs
+        self.encoder.start_ticks()
+        self.running = True
+
+    def poll(self, throttle, timestamp):
+        """
+        throttle:  positive means forward
+                   negative means backward
+                   zero means stopped
+        timestamp: the timestamp to apply to the tick reading
+                   or None to use the current time
+        """
+        if self.running:
+            # if a timestamp if provided, use it
+            if timestamp is None:
+                timestamp = time.time()
+
+            # set direction flag based on direction mode
+            if throttle is not None:
+                if TachometerMode.FORWARD_REVERSE == self.direction_mode:
+                    # if throttle is zero, leave direction alone to model 'coasting'
+                    if throttle != 0:
+                        self.direction = sign(throttle)
+                elif TachometerMode.FORWARD_REVERSE_STOP == self.direction_mode:
+                    self.direction = sign(throttle)
+
+            lastTicks = self.ticks
+            self.timestamp = timestamp
+            self.encoder.poll_ticks(self.direction)
+            self.ticks = self.encoder.get_ticks()
+            if self.debug and self.ticks != lastTicks:
+                logger.info("tachometer: t = {}, r = {}, ts = {}".format(self.ticks, self.ticks / self.ticks_per_revolution, timestamp))
+
+    def update(self):
+        """
+        throttle: sign of throttle is use used to determine direction.
+        timestamp: timestamp for update or None to use current time.
+                   This is useful for creating deterministic tests.
+        """
+        while(self.running):
+            self.poll(self.throttle, self.timestamp)
+            time.sleep(self.poll_delay_secs)  # give other threads time
+
+    def run_threaded(self, throttle:float=0.0, timestamp:float=None) -> Tuple[float, float]:
+        if self.running:
+            thisTimestamp = self.timestamp
+            thisRevolutions = self.ticks / self.ticks_per_revolution
+
+            # update throttle for next poll()
+            self.throttle = throttle
+            self.timestamp = timestamp
+
+            # return (revolutions, timestamp)
+            return (thisRevolutions, thisTimestamp)
+        return (0, self.timestamp)
+
+    def run(self, throttle:float=1.0, timestamp:float=None) -> Tuple[float, float]:
+        if self.running:
+            # update throttle for next poll()
+            self.throttle = throttle
+            self.timestamp = timestamp
+            self.poll(throttle, timestamp)
+
+            # return (revolutions, timestamp)
+            return (self.ticks / self.ticks_per_revolution, self.timestamp)
+        return (0, self.timestamp)
+
+    def shutdown(self):
+        self.running = False
+        self.encoder.stop_ticks()
+
+
+if __name__ == "__main__":
+    import argparse
+    from threading import Thread
+    import sys
+    import time
+    from donkeycar.parts.pins import input_pin_by_id
+
+    # parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--rate", type=float, default=20,
+                        help = "Number of readings per second")
+    parser.add_argument("-n", "--number", type=int, default=40,
+                        help = "Number of readings to collect")
+    parser.add_argument("-ppr", "--pulses-per-revolution", type=int, required=True, 
+                        help="Pulses per revolution of output shaft")
+    parser.add_argument("-d", "--direction-mode", type=int, default=1, 
+                        help="1=FORWARD_ONLY, 2=FORWARD_REVERSE, 3=FORWARD_REVERSE_STOP")
+    parser.add_argument("-s", "--serial-port", type=str, default=None,
+                        help="serial-port to open, like '/dev/ttyACM0'")
+    parser.add_argument("-b", "--baud-rate", type=int, default=115200, 
+                        help="Serial port baud rate")
+    parser.add_argument("-e", "--encoder-index", type=int, default=0,
+                        help="Serial encoder index (0 based) if more than one encoder")
+    parser.add_argument("-p", "--pin", type=str, default=None,
+                        help="pin specifier for encoder InputPin, like 'RPI_GPIO.BCM.22'")  # noqa
+    parser.add_argument("-dbc", "--debounce-ns", type=int, default=100,
+                        help="debounce delay in nanoseconds for reading gpio pin")  # noqa
+    parser.add_argument("-db", "--debug", action='store_true', help = "show debug output")
+    parser.add_argument("-t", "--threaded", action='store_true', help = "run in threaded mode")
+
+    # Read arguments from command line
+    args = parser.parse_args()
+    
+    help = []
+    if args.rate < 1:
+        help.append("-r/--rate: must be >= 1.")
+        
+    if args.number < 1:
+        help.append("-n/--number: must be >= 1.")
+        
+    if args.direction_mode < 1 and args.direction_mode > 3:
+        help.append("-d/--direction-mode must be 1, 2, or")
+
+    if args.pulses_per_revolution <= 0:
+        help.append("-ppr/--pulses-per-revolution must be > 0")
+        
+    if args.serial_port is None and args.pin is None:
+        help.append("either -s/--serial_port or -p/--pin must be passed")
+
+    if args.serial_port is not None and args.pin is not None:
+        help.append("only one of -s/--serial_port or -p/--pin must be passed")
+
+    if args.serial_port is not None and len(args.serial_port) == 0:
+        help.append("-s/--serial-port not be empty if passed")
+      
+    if args.baud_rate <= 0:
+        help.append("-b/--baud-rate must be > 0")
+        
+    if args.pin is not None and args.pin == "":
+        help.append("-p/--pin must be non-empty if passed")
+
+    if args.debounce_ns < 0:
+        help.append("-dbc/--debounce-ns must be greater than zero")
+                
+    if len(help) > 0:
+        parser.print_help()
+        for h in help:
+            print("  " + h)
+        sys.exit(1)
+        
+    update_thread = None
+    serial_port = None
+    tachometer = None
+    
+    try:
+        scan_count = 0
+        seconds_per_scan = 1.0 / args.rate
+        scan_time = time.time() + seconds_per_scan
+
+        #
+        # construct a tachometer part of the correct type
+        #
+        if args.serial_port is not None:
+            serial_port = SerialPort(args.serial_port, args.baud_rate)
+            tachometer = Tachometer(
+                encoder=EncoderChannel(SerialEncoder(serial_port=serial_port, debug=args.debug), args.encoder_index),
+                ticks_per_revolution=args.pulses_per_revolution, 
+                direction_mode=args.direction_mode, 
+                poll_delay_secs=1/(args.rate*2), 
+                debug=args.debug)
+        if args.pin is not None:
+            tachometer = Tachometer(
+                encoder=GpioEncoder(gpio_pin=input_pin_by_id(args.pin), debounce_ns=args.debounce_ns, debug=args.debug),
+                ticks_per_revolution=args.pulses_per_revolution, 
+                direction_mode=args.direction_mode,
+                debug=args.debug)
+        
+        #
+        # start the threaded part
+        # and a threaded window to show plot
+        #
+        if args.threaded:
+            update_thread = Thread(target=tachometer.update, args=())
+            update_thread.start()
+        
+        while scan_count < args.number:
+            start_time = time.time()
+
+            # emit the scan
+            scan_count += 1
+
+            # get most recent scan and plot it
+            if args.threaded:
+                measurements = tachometer.run_threaded()
+            else:
+                measurements = tachometer.run()
+
+            print(measurements)
+                                    
+            # yield time to background threads
+            sleep_time = seconds_per_scan - (time.time() - start_time)
+            if sleep_time > 0.0:
+                time.sleep(sleep_time)
+            else:
+                time.sleep(0)  # yield time to other threads
+
+    except KeyboardInterrupt:
+        print('Stopping early.')
+    except Exception as e:
+        print(e)
+        exit(1)
+    finally:
+        if tachometer is not None:
+            tachometer.shutdown()
+        if update_thread is not None:
+            update_thread.join()  # wait for thread to end

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -20,6 +20,19 @@ CAR_PATH = PACKAGE_PATH = os.path.dirname(os.path.realpath(__file__))
 DATA_PATH = os.path.join(CAR_PATH, 'data')
 MODELS_PATH = os.path.join(CAR_PATH, 'models')
 
+#
+# MEASURED ROBOT PROPERTIES
+# - measure your own vehicle and update these
+# - these are used by kinematics for pose estimation
+#
+AXLE_LENGTH = 0.03     # length of axle; distance between left and right wheels in meters
+WHEEL_BASE = 0.1       # distance between front and back wheels in meters
+WHEEL_RADIUS = 0.0315  # radius of wheel in meters
+WHEEL_CIRCUMFERENCE = 2 * WHEEL_RADIUS * 3.141592653589793
+MIN_THROTTLE = 0.1     # throttle (0 to 1.0) that corresponds to MIN_SPEED, throttle below which car stalls
+MAX_STEERING_ANGLE = 3.141592653589793 / 4  # for car-like robot; maximum steering angle in radians (corresponding to tire angle at steering == -1)
+
+
 #VEHICLE
 DRIVE_LOOP_HZ = 20      # the vehicle loop will pause if faster than this speed.
 MAX_LOOPS = None        # the vehicle loop can abort after this many iterations, when given a positive integer.
@@ -327,12 +340,51 @@ DC_TWO_WHEEL_L298N = {
     "RIGHT_EN_DUTY_PIN": "RPI_GPIO.BOARD.11",   # PWM pin generates duty cycle for right wheel speed
 }
 
-#ODOMETRY
-HAVE_ODOM = False                   # Do you have an odometer/encoder 
-ENCODER_TYPE = 'GPIO'            # What kind of encoder? GPIO|Arduino|Astar 
-MM_PER_TICK = 12.7625               # How much travel with a single tick, in mm. Roll you car a meter and divide total ticks measured by 1,000
-ODOM_PIN = 13                        # if using GPIO, which GPIO board mode pin to use as input
-ODOM_DEBUG = False                  # Write out values on vel and distance as it runs
+#
+# ODOMETRY
+#
+HAVE_ODOM = False               # Do you have an odometer/encoder
+HAVE_ODOM_2 = False             # Do you have a second odometer/encoder as in a differential drive robot.
+                                # In this case, the 'first' encoder is the left wheel encoder and
+                                # the second encoder is the right wheel encoder.
+ENCODER_TYPE = 'GPIO'           # What kind of encoder? GPIO|arduino.
+                                # - 'GPIO' refers to direct connect of a single-channel encoder to an RPi/Jetson GPIO header pin.
+                                #   Set ODOM_PIN to the gpio pin, based on board numbering.
+                                # - 'arduino' generically refers to any microcontroller connected over a serial port.
+                                #   Set ODOM_SERIAL to the serial port that connects the microcontroller.
+                                #   See 'arduino/encoder/encoder.ino' for an Arduino sketch that implements both a continuous and
+                                #    on demand protocol for sending readings from the microcontroller to the host.
+ENCODER_PPR = 20                # encoder's pulses (ticks) per revolution of encoder shaft.
+ENCODER_DEBOUNCE_NS = 0         # nanoseconds to wait before integrating subsequence encoder pulses.
+                                # For encoders with noisy transitions, this can be used to reject extra interrupts caused by noise.
+                                # If necessary, the exact value can be determined using an oscilliscope or logic analyzer or
+                                # simply by experimenting with various values.
+FORWARD_ONLY = 1
+FORWARD_REVERSE = 2
+FORWARD_REVERSE_STOP = 3
+TACHOMETER_MODE=FORWARD_ONLY    # FORWARD_ONLY, FORWARD_REVERSE or FORWARD_REVERSE_STOP
+                                # For dual channel quadrature encoders, 'FORWARD_ONLY' is always the correct mode.
+                                # For single-channel encoders, the tachometer mode depends upon the application.
+                                # - FORWARD_ONLY always increments ticks; effectively assuming the car is always moving forward
+                                #   and always has a positive throttle. This is best for racing on wide open circuits where
+                                #   the car is always under throttle and where we are not trying to model driving backwards or stopping.
+                                # - FORWARD_REVERSE uses the throttle value to decide if the car is moving forward or reverse
+                                #   increments or decrements ticks accordingly.  In the case of a zero throttle, ticks will be
+                                #   incremented or decremented based on the last non-zero throttle; effectively modelling 'coasting'.
+                                #   This can work well in situations where the car will be making progress even when the throttle
+                                #   drops to zero.  For instance, in a race situatino where the car may coast to slow down but not
+                                #   actually stop.
+                                # - FORWARD_REVERSE_STOP uses the throttle value to decide if the car is moving forward or reverse or stopped.
+                                #   This works well for a slower moving robot in situations where the robot is changing direction; for instance4
+                                #   when doing SLAM, the robot will explore the room slowly and may need to backup.
+MM_PER_TICK = 12.7625           # How much travel with a single encoder tick, in mm. Roll you car a meter and divide total ticks measured by 1,000
+ODOM_SERIAL = '/dev/ttyACM0'    # serial port when ENCODER_TYPE is 'arduino'
+ODOM_SERIAL_BAUDRATE = 115200   # baud rate for serial port encoder
+ODOM_PIN = "RPI_GPIO.BCM.22"    # BCM.22 == BOARD.15 # if using ENCODER_TYPE=GPIO, which GPIO board mode pin to use as input
+ODOM_PIN_2 = "RPI_GPIO.BCM.18"  # BCM.18 == BOARD.13 # GPIO for second encoder in differential drivetrains
+ODOM_SMOOTHING = 1              # number of odometer readings to use when calculating velocity
+ODOM_DEBUG = False              # Write out values on vel and distance as it runs
+
 
 # #LIDAR
 USE_LIDAR = False

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -347,7 +347,7 @@ HAVE_ODOM = False               # Do you have an odometer/encoder
 HAVE_ODOM_2 = False             # Do you have a second odometer/encoder as in a differential drive robot.
                                 # In this case, the 'first' encoder is the left wheel encoder and
                                 # the second encoder is the right wheel encoder.
-ENCODER_TYPE = 'GPIO'           # What kind of encoder? GPIO|arduino.
+ENCODER_TYPE = 'GPIO'           # What kind of encoder? GPIO|arduino|mock.
                                 # - 'GPIO' refers to direct connect of a single-channel encoder to an RPi/Jetson GPIO header pin.
                                 #   Set ODOM_PIN to the gpio pin, based on board numbering.
                                 # - 'arduino' generically refers to any microcontroller connected over a serial port.
@@ -463,13 +463,15 @@ USE_JOYSTICK_AS_DEFAULT = False      #when starting the manage.py, when True, wi
 JOYSTICK_MAX_THROTTLE = 0.5         #this scalar is multiplied with the -1 to 1 throttle value to limit the maximum throttle. This can help if you drop the controller or just don't need the full speed available.
 JOYSTICK_STEERING_SCALE = 1.0       #some people want a steering that is less sensitve. This scalar is multiplied with the steering -1 to 1. It can be negative to reverse dir.
 AUTO_RECORD_ON_THROTTLE = True      #if true, we will record whenever throttle is not zero. if false, you must manually toggle recording with some other trigger. Usually circle button on joystick.
-CONTROLLER_TYPE = 'xbox'            #(ps3|ps4|xbox|pigpio_rc|nimbus|wiiu|F710|rc3|MM1|custom) custom will run the my_joystick.py controller written by the `donkey createjs` command
+CONTROLLER_TYPE = 'xbox'            #(ps3|ps4|xbox|pigpio_rc|nimbus|wiiu|F710|rc3|MM1|custom|mock) custom will run the my_joystick.py controller written by the `donkey createjs` command
 USE_NETWORKED_JS = False            #should we listen for remote joystick control over the network?
 NETWORK_JS_SERVER_IP = None         #when listening for network joystick control, which ip is serving this information
 JOYSTICK_DEADZONE = 0.01            # when non zero, this is the smallest throttle before recording triggered.
 JOYSTICK_THROTTLE_DIR = -1.0         # use -1.0 to flip forward/backward, use 1.0 to use joystick's natural forward/backward
 USE_FPV = False                     # send camera data to FPV webserver
 JOYSTICK_DEVICE_FILE = "/dev/input/js0" # this is the unix file use to access the joystick.
+MOCK_JOYSTICK_STEERING = 0.0
+MOCK_JOYSTICK_THROTTLE = 0.0
 
 #For the categorical model, this limits the upper bound of the learned throttle
 #it's very IMPORTANT that this value is matched from the training PC config.py and the robot.py

--- a/donkeycar/tests/test_circular_buffer.py
+++ b/donkeycar/tests/test_circular_buffer.py
@@ -1,0 +1,124 @@
+import unittest
+import pytest
+
+from donkeycar.utilities.circular_buffer import CircularBuffer
+
+class TestCircularBuffer(unittest.TestCase):
+
+    def test_circular_buffer_queue(self):
+        """
+        enqueue items to head
+        dequeue items from tail
+        """
+        queue:CircularBuffer = CircularBuffer(3, defaultValue="out-of-range")
+        self.assertEqual(3, queue.capacity)
+        self.assertEqual(0, queue.count)
+
+        queue.enqueue(0)
+        self.assertEqual(1, queue.count)
+        self.assertEqual(0, queue.head())
+        self.assertEqual(0, queue.tail())
+
+        queue.enqueue(1)
+        self.assertEqual(2, queue.count)
+        self.assertEqual(1, queue.head())
+        self.assertEqual(0, queue.tail())
+
+        queue.enqueue(2)
+        self.assertEqual(3, queue.count)
+        self.assertEqual(2, queue.head())
+        self.assertEqual(0, queue.tail())
+
+        queue.enqueue(3)
+        self.assertEqual(3, queue.count)
+        self.assertEqual(3, queue.head())
+        self.assertEqual(1, queue.tail())
+
+        self.assertEqual(1, queue.dequeue())
+        self.assertEqual(2, queue.count)
+        self.assertEqual(3, queue.head())
+        self.assertEqual(2, queue.tail())
+
+        self.assertEqual(2, queue.dequeue())
+        self.assertEqual(1, queue.count)
+        self.assertEqual(3, queue.head())
+        self.assertEqual(3, queue.tail())
+
+        self.assertEqual(3, queue.dequeue())
+        self.assertEqual(0, queue.count)
+        self.assertEqual("out-of-range", queue.head())
+        self.assertEqual("out-of-range", queue.tail())
+
+        self.assertEqual("out-of-range", queue.dequeue())
+
+    def test_circular_buffer_stack(self):
+        """
+        push items to head
+        pop items from head
+        """
+        stack:CircularBuffer = CircularBuffer(2, defaultValue="out-of-range")
+        self.assertEqual(2, stack.capacity)
+        self.assertEqual(0, stack.count)
+        self.assertEqual("out-of-range", stack.pop())
+
+        stack.push(0)
+        self.assertEqual(1, stack.count)
+        self.assertEqual(0, stack.head())
+        self.assertEqual(0, stack.tail())
+
+        stack.push(1)
+        self.assertEqual(2, stack.count)
+        self.assertEqual(1, stack.head())
+        self.assertEqual(0, stack.tail())
+
+        # pushing onto a full stack raises exception
+        try:
+            stack.push(2)
+            self.fail("should have thrown exception")
+        except IndexError:
+            # nothing should have changed
+            self.assertEqual(2, stack.count)
+            self.assertEqual(1, stack.head())
+            self.assertEqual(0, stack.tail())
+
+        self.assertEqual(1, stack.pop())
+        self.assertEqual(1, stack.count)
+        self.assertEqual(0, stack.head())
+        self.assertEqual(0, stack.tail())
+
+        self.assertEqual(0, stack.pop())
+        self.assertEqual(0, stack.count)
+        self.assertEqual("out-of-range", stack.head())
+        self.assertEqual("out-of-range", stack.tail())
+
+        # popping from empty stack returns default
+        self.assertEqual("out-of-range", stack.pop())
+
+    def test_circular_buffer_array(self):
+        """
+        append items to tail
+        set/get items by index
+        """
+        array:CircularBuffer = CircularBuffer(2, defaultValue="out-of-range")
+        self.assertEqual(2, array.capacity)
+        self.assertEqual(0, array.count)
+        self.assertEqual("out-of-range", array.get(0))
+
+        array.append(0)
+        self.assertEqual(1, array.count)
+        self.assertEqual(0, array.head())
+        self.assertEqual(0, array.tail())
+        self.assertEqual(0, array.get(0))
+        self.assertEqual("out-of-range", array.get(1))
+
+        array.append(1)
+        self.assertEqual(2, array.count)
+        self.assertEqual(0, array.head())
+        self.assertEqual(1, array.tail())
+        self.assertEqual(0, array.get(0))
+        self.assertEqual(1, array.get(1))
+        self.assertEqual("out-of-range", array.get(2))
+
+        for i in range(array.count):
+            array.set(i, array.count-i)
+            self.assertEqual(array.count-i, array.get(i))

--- a/donkeycar/tests/test_kinematics.py
+++ b/donkeycar/tests/test_kinematics.py
@@ -1,0 +1,429 @@
+import math
+import unittest
+
+from donkeycar.parts.kinematics import Bicycle, InverseBicycle, InverseUnicycle, bicycle_angular_velocity, limit_angle
+from donkeycar.parts.kinematics import BicycleNormalizeAngularVelocity, BicycleUnnormalizeAngularVelocity
+from donkeycar.parts.kinematics import Unicycle, unicycle_angular_velocity, unicycle_max_angular_velocity
+from donkeycar.parts.kinematics import UnicycleNormalizeAngularVelocity, UnicycleUnnormalizeAngularVelocity
+from donkeycar.parts.kinematics import NormalizeSteeringAngle, UnnormalizeSteeringAngle
+from donkeycar.parts.kinematics import differential_steering
+from donkeycar.utils import sign
+
+#
+# python -m unittest donkeycar/tests/test_kinematics.py
+#
+class TestBicycle(unittest.TestCase):
+
+    def test_forward(self):
+        bicycle = Bicycle(1)
+
+        bicycle.run(0, 0, 1)
+        self.assertEqual(0, bicycle.forward_distance)
+        self.assertEqual(0, bicycle.forward_velocity)
+        self.assertEqual(1, bicycle.timestamp)
+        self.assertEqual(0, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(0, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+        bicycle.run(1, 0, 2)
+        self.assertEqual(1, bicycle.forward_distance)
+        self.assertEqual(1, bicycle.forward_velocity)
+        self.assertEqual(2, bicycle.timestamp)
+        self.assertEqual(1, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(1, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+        bicycle.run(10, 0, 3)
+        self.assertEqual(10, bicycle.forward_distance)
+        self.assertEqual(9, bicycle.forward_velocity)
+        self.assertEqual(3, bicycle.timestamp)
+        self.assertEqual(10, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(9, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+    def test_reverse(self):
+        bicycle = Bicycle(1)
+
+        bicycle.run(0, 0, 1)
+        self.assertEqual(0, bicycle.forward_distance)
+        self.assertEqual(0, bicycle.forward_velocity)
+        self.assertEqual(1, bicycle.timestamp)
+        self.assertEqual(0, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(0, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+        bicycle.run(-1, 0, 2)
+        self.assertEqual(-1, bicycle.forward_distance)
+        self.assertEqual(-1, bicycle.forward_velocity)
+        self.assertEqual(2, bicycle.timestamp)
+        self.assertEqual(-1, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(-1, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+        bicycle.run(-10, 0, 3)
+        self.assertEqual(-10, bicycle.forward_distance)
+        self.assertEqual(-9, bicycle.forward_velocity)
+        self.assertEqual(3, bicycle.timestamp)
+        self.assertEqual(-10, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(-9, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+    def test_forward_reverse(self):
+        bicycle = Bicycle(1)
+
+        bicycle.run(0, 0, 1)
+        self.assertEqual(0, bicycle.forward_distance)
+        self.assertEqual(0, bicycle.forward_velocity)
+        self.assertEqual(1, bicycle.timestamp)
+        self.assertEqual(0, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(0, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+        bicycle.run(1, 0, 2)
+        self.assertEqual(1, bicycle.forward_distance)
+        self.assertEqual(1, bicycle.forward_velocity)
+        self.assertEqual(2, bicycle.timestamp)
+        self.assertEqual(1, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(1, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+        bicycle.run(-1, 0, 3)
+        self.assertEqual(-1, bicycle.forward_distance)
+        self.assertEqual(-2, bicycle.forward_velocity)
+        self.assertEqual(3, bicycle.timestamp)
+        self.assertEqual(-1, bicycle.pose.x)
+        self.assertEqual(0, bicycle.pose.y)
+        self.assertEqual(0, bicycle.pose.angle)
+        self.assertEqual(-2, bicycle.pose_velocity.x)
+        self.assertEqual(0, bicycle.pose_velocity.y)
+        self.assertEqual(0, bicycle.pose_velocity.angle)
+
+    def do_90degree_turn(self, steering_angle):
+        turn_direction = sign(steering_angle)
+        steering_angle = limit_angle(steering_angle)
+
+        wheel_base = 0.5  
+        bicycle = Bicycle(wheel_base)  # wheel base is 1/2 meter
+
+
+        #
+        # turn an 1/4 of circle while wheel is turned 22.5 degrees.
+        # do this at 20 hertz, like the vehicle loop
+        #
+        # calculate length of circle's perimeter
+        # see [Rear-axle reference point](https://thef1clan.com/2020/09/21/vehicle-dynamics-the-kinematic-bicycle-model/)
+        #
+        R = abs(wheel_base / math.tan(steering_angle))  # Radius of turn
+        C = 2 * math.pi * R                             # Circumference of turn
+
+        turn_distance = C / 4  # drive the 90 degrees of perimeter
+        turn_steps = math.floor(turn_distance * 200)  # 200 odometry readings per meter
+        steps_per_second = 20
+        time_per_step = 1 / steps_per_second  # 20 odometry readings per second
+        print()
+        print("X,Y,A")
+        for i in range(turn_steps):
+            distance, velocity, pose_x, pose_y, pose_angle, pose_velocity_x, pose_velocity_y, pose_velocity_angle, timestamp = bicycle.run(turn_distance * (i+1) / turn_steps, steering_angle, 1 + time_per_step * (i + 1))
+            print(pose_x, pose_y, pose_angle, sep=",")
+        self.assertAlmostEqual(turn_distance, bicycle.forward_distance, 3)
+        self.assertAlmostEqual(1 + turn_steps * time_per_step, bicycle.timestamp, 3)
+        self.assertLessEqual((R - pose_x) / R, 0.005)  # final error less than 0.5%
+        self.assertLessEqual((turn_direction * R - pose_y) / R, 0.005)  # final error less than 0.5%
+        self.assertLessEqual(((turn_direction * math.pi / 2) - pose_angle) / (math.pi / 2), 0.005)
+
+
+    def test_turn_left(self):
+        # 22.5 degrees steering angle
+        self.do_90degree_turn(steering_angle = math.pi / 8)
+
+    def test_turn_right(self):
+        # 22.5 degrees steering angle
+        self.do_90degree_turn(steering_angle = -math.pi / 8)
+
+
+class TestUnicycle(unittest.TestCase):
+
+    def test_forward(self):
+        unicycle = Unicycle(1)
+
+        unicycle.run(0, 0, 1)
+        self.assertEqual(0, unicycle.left_distance)
+        self.assertEqual(0, unicycle.right_distance)
+        self.assertEqual(1, unicycle.timestamp)
+        self.assertEqual(0, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(0, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        unicycle.run(1, 1, 2)
+        self.assertEqual(1, unicycle.left_distance)
+        self.assertEqual(1, unicycle.right_distance)
+        self.assertEqual(2, unicycle.timestamp)
+        self.assertEqual(1, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(1, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        unicycle.run(10, 10, 3)
+        self.assertEqual(10, unicycle.left_distance)
+        self.assertEqual(10, unicycle.right_distance)
+        self.assertEqual(3, unicycle.timestamp)
+        self.assertEqual(10, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(9, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+    def test_reverse(self):
+        unicycle = Unicycle(1)
+
+        unicycle.run(0, 0, 1)
+        self.assertEqual(0, unicycle.left_distance)
+        self.assertEqual(0, unicycle.right_distance)
+        self.assertEqual(1, unicycle.timestamp)
+        self.assertEqual(0, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(0, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        unicycle.run(-1, -1, 2)
+        self.assertEqual(-1, unicycle.left_distance)
+        self.assertEqual(-1, unicycle.right_distance)
+        self.assertEqual(2, unicycle.timestamp)
+        self.assertEqual(-1, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(-1, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        unicycle.run(-10, -10, 3)
+        self.assertEqual(-10, unicycle.left_distance)
+        self.assertEqual(-10, unicycle.right_distance)
+        self.assertEqual(3, unicycle.timestamp)
+        self.assertEqual(-10, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(-9, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+
+    def test_forward_reverse(self):
+        unicycle = Unicycle(1)
+
+        unicycle.run(0, 0, 1)
+        self.assertEqual(0, unicycle.left_distance)
+        self.assertEqual(0, unicycle.right_distance)
+        self.assertEqual(1, unicycle.timestamp)
+        self.assertEqual(0, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(0, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        unicycle.run(1, 1, 2)
+        self.assertEqual(1, unicycle.left_distance)
+        self.assertEqual(1, unicycle.right_distance)
+        self.assertEqual(2, unicycle.timestamp)
+        self.assertEqual(1, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(1, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        unicycle.run(-1, -1, 3)
+        self.assertEqual(-1, unicycle.left_distance)
+        self.assertEqual(-1, unicycle.right_distance)
+        self.assertEqual(3, unicycle.timestamp)
+        self.assertEqual(-1, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(-2, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+    def test_turn_left(self):
+        unicycle = Unicycle(1)
+
+        unicycle.run(0, 0, 1)
+        self.assertEqual(0, unicycle.left_distance)
+        self.assertEqual(0, unicycle.right_distance)
+        self.assertEqual(1, unicycle.timestamp)
+        self.assertEqual(0, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(0, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        #
+        # turn left 90 degrees, pivoting on left wheel.
+        # pivot on a non-moving wheel creates a circle
+        # with a radius equal to the axle-length.
+        # do this at 20 hertz, like the vehicle loop
+        #
+        turn_distance = math.pi / 2
+        turn_steps = 20
+        steps_per_second = 20
+        time_per_step = 1 / steps_per_second  # 20 hertz
+        for i in range(turn_steps):
+            distance, velocity, pose_x, pose_y, pose_angle, pose_velocity_x, pose_velocity_y, pose_velocity_angle, timestamp = unicycle.run(0, turn_distance * (i+1) / turn_steps, 1 + time_per_step * (i + 1))
+        self.assertEqual(0, unicycle.left_distance)
+        self.assertEqual(turn_distance, unicycle.right_distance)
+        self.assertEqual(1 + turn_steps * time_per_step, unicycle.timestamp)
+        self.assertAlmostEqual(0.5, pose_x, 3)
+        self.assertAlmostEqual(0.5, pose_y, 3)
+        self.assertAlmostEqual(math.pi / 2, pose_angle, 3)
+
+    def test_turn_right(self):
+        unicycle = Unicycle(1)
+
+        unicycle.run(0, 0, 1)
+        self.assertEqual(0, unicycle.left_distance)
+        self.assertEqual(0, unicycle.right_distance)
+        self.assertEqual(1, unicycle.timestamp)
+        self.assertEqual(0, unicycle.pose.x)
+        self.assertEqual(0, unicycle.pose.y)
+        self.assertEqual(0, unicycle.pose.angle)
+        self.assertEqual(0, unicycle.pose_velocity.x)
+        self.assertEqual(0, unicycle.pose_velocity.y)
+        self.assertEqual(0, unicycle.pose_velocity.angle)
+
+        #
+        # turn right 180 degrees, pivoting on right wheel.
+        # pivot on a non-moving wheel creates a circle
+        # with a radius equal to the axle-length.
+        # do this at 20 hertz, like the vehicle loop
+        #
+        turn_distance = math.pi / 2
+        turn_steps = 20
+        steps_per_second = 20
+        time_per_step = 1 / steps_per_second  # 20 hertz
+        for i in range(turn_steps):
+            distance, velocity, pose_x, pose_y, pose_angle, pose_velocity_x, pose_velocity_y, pose_velocity_angle, timestamp = unicycle.run(turn_distance * (i+1) / turn_steps, 0, 1 + time_per_step * (i + 1))
+        self.assertEqual(0, unicycle.right_distance)
+        self.assertEqual(turn_distance, unicycle.left_distance)
+        self.assertEqual(1 + turn_steps * time_per_step, unicycle.timestamp)
+        self.assertAlmostEqual(0.5, pose_x, 3)
+        self.assertAlmostEqual(-0.5, pose_y, 3)
+        self.assertAlmostEqual(-math.pi / 2, pose_angle, 3)
+
+
+class TestInverseBicycle(unittest.TestCase):
+    def test_inverse_bicycle(self):
+        wheel_base = 0.5
+        steering_angle = math.pi / 8
+        angular_velocity = bicycle_angular_velocity(wheel_base, 1, steering_angle)
+        inverse = InverseBicycle(wheel_base)
+        forward_velocity, inverse_steering_angle, _ = inverse.run(1, angular_velocity)
+        self.assertAlmostEqual(forward_velocity, 1, 3)
+        self.assertAlmostEqual(inverse_steering_angle, steering_angle, 3)
+
+
+class TestInverseUnicycle(unittest.TestCase):
+    def test_inverse_unicycle(self):
+        axle_length = 0.3
+        wheel_radius = 0.01
+        angular_velocity = unicycle_angular_velocity(wheel_radius, axle_length, 0.5, 1.5)
+        inverse = InverseUnicycle(axle_length, wheel_radius, 0.01, 10, 0)
+        left_velocity, right_velocity, _ = inverse.run(1, angular_velocity)
+        self.assertAlmostEqual(left_velocity, 0.5, 3)
+        self.assertAlmostEqual(right_velocity, 1.5, 3)
+
+
+class TestBicycleNormalizeAngularVelocity(unittest.TestCase):
+    def test_normalize(self):
+        wheel_base = 0.5
+        max_forward_velocity = 10
+        max_steering_angle = math.pi / 6
+        max_angular_velocity = bicycle_angular_velocity(wheel_base, max_forward_velocity, max_steering_angle)
+        normalize = BicycleNormalizeAngularVelocity(wheel_base, max_forward_velocity, max_steering_angle)        
+        unnormalize = BicycleUnnormalizeAngularVelocity(wheel_base, max_forward_velocity, max_steering_angle)
+
+        angular_velocity = normalize.run(max_angular_velocity / 2)
+        self.assertAlmostEqual(angular_velocity, 0.5, 3)
+        angular_velocity = unnormalize.run(angular_velocity)
+        self.assertAlmostEqual(angular_velocity, max_angular_velocity / 2, 3)
+
+
+class TestUnicycleNormalizeAngularVelocity(unittest.TestCase):
+    def test_normalize(self):
+        wheel_radius = 0.01
+        axle_length = 0.1
+        max_forward_velocity = 10
+        max_angular_velocity = unicycle_max_angular_velocity(wheel_radius, axle_length, max_forward_velocity)
+        normalize = UnicycleNormalizeAngularVelocity(wheel_radius, axle_length, max_forward_velocity)        
+        unnormalize = UnicycleUnnormalizeAngularVelocity(wheel_radius, axle_length, max_forward_velocity)
+
+        angular_velocity = normalize.run(max_angular_velocity / 2)
+        self.assertAlmostEqual(angular_velocity, 0.5, 3)
+        angular_velocity = unnormalize.run(angular_velocity)
+        self.assertAlmostEqual(angular_velocity, max_angular_velocity / 2, 3)
+
+
+class TestNormalizeSteeringAngle(unittest.TestCase):
+    def test_normalize(self):
+        max_steering_angle = math.pi / 6
+        normalize = NormalizeSteeringAngle(max_steering_angle)        
+        unnormalize = UnnormalizeSteeringAngle(max_steering_angle)
+
+        steering_angle = normalize.run(max_steering_angle / 2)
+        self.assertAlmostEqual(steering_angle, 0.5, 3)
+        steering_angle = unnormalize.run(steering_angle)
+        self.assertAlmostEqual(steering_angle, max_steering_angle / 2, 3)
+
+
+class TestTwoWheelSteeringThrottle(unittest.TestCase):
+    def test_differential_steering(self):
+        # Straight within steering_zero tolerance
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, 0.0, 0.0))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, 0.05, 0.10))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, 0.10, 0.10))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, -0.05, 0.10))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, -0.10, 0.10))
+
+        # left
+        self.assertEqual((0.9, 1.0), differential_steering(1.0, -0.10, 0.0))
+        self.assertEqual((0.8, 1.0), differential_steering(1.0, -0.20, 0.0))
+        self.assertEqual((0.45, 0.5), differential_steering(0.5, -0.10, 0.0))
+        self.assertEqual((0.40, 0.5), differential_steering(0.5, -0.20, 0.0))
+
+        # right
+        self.assertEqual((1.0, 0.9), differential_steering(1.0, 0.10, 0.0))
+        self.assertEqual((1.0, 0.8), differential_steering(1.0, 0.20, 0.0))
+        self.assertEqual((0.5, 0.45), differential_steering(0.5, 0.10, 0.0))
+        self.assertEqual((0.5, 0.40), differential_steering(0.5, 0.20, 0.0))

--- a/donkeycar/tests/test_odometer.py
+++ b/donkeycar/tests/test_odometer.py
@@ -1,0 +1,29 @@
+
+import unittest
+import time
+
+from donkeycar.parts.odometer import Odometer
+
+class TestOdometer(unittest.TestCase):
+    
+    def test_odometer(self):
+        odometer = Odometer(0.2)         # 0.2 meters per revolution
+
+        ts = time.time()                                     # initial time
+        distance, velocity, timestamp = odometer.run(1, ts)  # first reading is one revolution
+        self.assertEqual(ts, timestamp)
+        self.assertEqual(0.2, distance)                      # distance travelled is 0.2 meters
+        self.assertEqual(0, velocity)                        # zero velocity until we get two distances
+
+        ts += 1                                              # add one second
+        distance, velocity, timestamp = odometer.run(2, ts)  # total of 2 revolutions
+        self.assertEqual(ts, timestamp)
+        self.assertEqual(0.4, distance)                      # 0.4 meters travelled
+        self.assertEqual(0.2, velocity)                      # 0.2 meters per second since last update
+
+        ts += 1                                              # add one second
+        distance, velocity, timestamp = odometer.run(2, ts)  # don't move
+        self.assertEqual(ts, timestamp)
+        self.assertEqual(0.4, distance)                      # still at 0.4 meters travelled
+        self.assertEqual(0, velocity)                        # 0 meter per second in last interval
+

--- a/donkeycar/tests/test_tachometer.py
+++ b/donkeycar/tests/test_tachometer.py
@@ -23,7 +23,8 @@ class MockEncoder(AbstractEncoder):
         assert((1==direction) or (0==direction) or (-1==direction))
         self.ticks += direction
         return self.ticks
-
+    def get_ticks(self, encoder_index:int=0) -> int:
+        return self.ticks
 
 class MockTachometer(Tachometer):
     def __init__(self, ticks_per_revolution: float, direction_mode, debug=False):

--- a/donkeycar/tests/test_tachometer.py
+++ b/donkeycar/tests/test_tachometer.py
@@ -1,0 +1,145 @@
+import time
+from typing import Tuple
+import unittest
+
+from donkeycar.parts.tachometer import Tachometer
+from donkeycar.parts.tachometer import AbstractEncoder
+from donkeycar.parts.tachometer import TachometerMode
+from donkeycar.utilities.serial_port import SerialPort
+
+
+class MockEncoder(AbstractEncoder):
+    def __init__(self) -> None:
+        self.ticks = 0
+        super().__init__()
+    def start_ticks(self):
+        pass
+    def stop_ticks(self):
+        pass
+    def poll_ticks(self, direction: int) -> int:
+        """
+        add a tick based on direction
+        """
+        assert((1==direction) or (0==direction) or (-1==direction))
+        self.ticks += direction
+        return self.ticks
+
+
+class MockTachometer(Tachometer):
+    def __init__(self, ticks_per_revolution: float, direction_mode, debug=False):
+        super().__init__(MockEncoder(), ticks_per_revolution=ticks_per_revolution, direction_mode=direction_mode, poll_delay_secs=0, debug=debug)
+
+
+class TestTachometer(unittest.TestCase):
+    
+    def test_tachometer_forward_only(self):
+        #
+        # FORWARD_ONLY mode will ignore throttle
+        # and just increase revolutions
+        #
+        tachometer = MockTachometer(
+            ticks_per_revolution=10, 
+            direction_mode=TachometerMode.FORWARD_ONLY)
+
+        ts = time.time()
+        revolutions, timestamp = tachometer.run(throttle=1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.1, revolutions, 4)
+
+        ts += 1  # add one second and one revolution
+        revolutions, timestamp = tachometer.run(throttle=1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.2, revolutions, 4)
+
+        ts += 1  # add one second, but stopped
+        revolutions, timestamp = tachometer.run(throttle=0, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.3, revolutions, 4)
+
+        ts += 1  # add one second and reverse one revolution
+        revolutions, timestamp = tachometer.run(throttle=-1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.4, revolutions, 4) 
+
+        ts += 1  # add one second, but stopped and coasting
+        revolutions, timestamp = tachometer.run(throttle=0, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.5, revolutions, 4)
+
+
+    def test_tachometer_forward_reverse(self):
+        #
+        # FORWARD_REVERSE mode will ignore zero throttle
+        # and continue changing revolutions in the
+        # current direction.  So if direction was
+        # forward, then throttle=0 will continue forward,
+        # if direction was reverse then throttle=0
+        # will continue in reverse.
+        #
+        tachometer = MockTachometer(
+            ticks_per_revolution=10, 
+            direction_mode=TachometerMode.FORWARD_REVERSE)
+
+        ts = time.time()
+        revolutions, timestamp = tachometer.run(throttle=1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.1, revolutions, 4)
+
+        ts += 1  # add one second and one revolution
+        revolutions, timestamp = tachometer.run(throttle=1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.2, revolutions, 4)
+
+        ts += 1  # add one second, but stopped
+        revolutions, timestamp = tachometer.run(throttle=0, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.3, revolutions, 4)
+
+        ts += 1  # add one second and reverse one revolution
+        revolutions, timestamp = tachometer.run(throttle=-1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.2, revolutions, 4) 
+
+        ts += 1  # add one second, but stopped and coasting
+        revolutions, timestamp = tachometer.run(throttle=0, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.1, revolutions, 4)
+
+
+    def test_tachometer_forward_reverse_stop(self):
+        #
+        # FORWARD_REVERSE_STOP mode will honor the
+        # throttle completely; 
+        # positive throttle being forward, increasing revolutions
+        # negative throttle being reverse, decreasing revolutions
+        # zero throttle being stopped; no change in revolutions
+        #
+        tachometer = MockTachometer(
+            ticks_per_revolution=10, 
+            direction_mode=TachometerMode.FORWARD_REVERSE_STOP)
+
+        ts = time.time()
+        revolutions, timestamp = tachometer.run(throttle=1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.1, revolutions, 4)
+
+        ts += 1  # add one second and one revolution
+        revolutions, timestamp = tachometer.run(throttle=1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.2, revolutions, 4)
+
+        ts += 1  # add one second, but stopped
+        revolutions, timestamp = tachometer.run(throttle=0, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.2, revolutions, 4)
+
+        ts += 1  # add one second and reverse one revolution
+        revolutions, timestamp = tachometer.run(throttle=-1, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.1, revolutions, 4) 
+
+        ts += 1  # add one second, but stopped
+        revolutions, timestamp = tachometer.run(throttle=0, timestamp=ts)
+        self.assertEqual(ts, timestamp)
+        self.assertAlmostEqual(0.1, revolutions, 4)
+

--- a/donkeycar/utilities/circular_buffer.py
+++ b/donkeycar/utilities/circular_buffer.py
@@ -1,0 +1,143 @@
+
+class CircularBuffer:
+    """
+    Fixed capacity circular buffer that can be used as
+    a queue, stack or array
+    """
+    def __init__(self, capacity:int, defaultValue=None) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be greater than zero")
+        self.defaultValue = defaultValue
+        self.buffer:list = [None] * capacity
+        self.capacity:int = capacity
+        self.count:int = 0
+        self.tailIndex:int = 0
+
+    def head(self):
+        """
+        Non-destructive get of the entry at the head (index count-1)
+        return: if list is not empty, the head (most recently pushed/enqueued) entry.
+                if list is empty, the default value provided in the constructor                
+        """
+        if self.count > 0:
+            return self.buffer[(self.tailIndex + self.count - 1) % self.capacity]
+        return self.defaultValue
+
+    def tail(self):
+        """
+        Non-destructive get of the entry at the tail (index 0)
+        return: if list is not empty, the tail (least recently pushed/enqueued) entry.
+                if list is empty, the default value provided in the constructor
+        """
+        if self.count > 0:
+            return self.buffer[self.tailIndex]
+        return self.defaultValue
+
+    def enqueue(self, value):
+        """
+        Push a value onto the head of the buffer.  
+        If the buffer is full, then the value 
+        at the tail is dropped to make room.
+        """
+        if self.count < self.capacity:
+            self.count += 1
+        else:
+            # drop entry at the tail
+            self.tailIndex = (self.tailIndex + 1) % self.capacity
+
+        # write value at head
+        self.buffer[(self.tailIndex + self.count - 1) % self.capacity] = value    
+
+    def dequeue(self):
+        """
+        Remove value at tail of list and return it
+        return: if list not empty, value at tail
+                if list empty, the default value
+        """
+        theValue = self.tail()
+        if self.count > 0:
+            self.count -= 1
+            self.tailIndex = (self.tailIndex + 1) % self.capacity
+        return theValue
+
+    def push(self, value):
+        """
+        Push a value onto the head of the buffer.  
+        If the buffer is full, then a IndexError
+        is raised.
+        """
+        if self.count >= self.capacity:
+            raise IndexError("Attempt to push to a full buffer")
+
+        self.enqueue(value)
+
+    def pop(self):
+        """
+        Remove value at head of list and return it
+        return: if list not empty, the value at head 
+                if list empty, the default value
+        """
+        theValue = self.head()
+        if self.count > 0:
+            self.count -= 1
+        return theValue
+
+    def append(self, value):
+        """
+        append a value to the tail (index count-1) of the buffer.
+        If the buffer is at capacity, then this
+        will raise an IndexError.
+        """
+        if self.count >= self.capacity:
+            raise IndexError("Attempt to append to a full buffer")
+
+        # make space a tail for the value
+        self.count += 1
+        self.tailIndex = (self.tailIndex - 1) % self.capacity
+        self.buffer[self.tailIndex] = value
+
+
+    def get(self, i:int):
+        """
+        Get value at given index where
+        head is index 0 and tail is is index count-1;
+        i: index from 0 to count-1 (head is zero)
+        return: value at index
+                or the default value if index is out of range
+        """
+        if (i >= 0) and (i < self.count):
+            return self.buffer[(self.tailIndex + (self.count + i - 1)) % self.capacity]
+
+        return self.defaultValue
+
+    def set(self, i:int, value):
+        """
+        Set value at given index where
+        head is index 0 and tail is is index count-1;
+        """
+        if (i >= 0) and (i < self.count):
+            self.buffer[(self.tailIndex + (self.count + i - 1)) % self.capacity] = value
+            return
+        raise IndexError("buffer index is out of range")
+
+    def truncateTo(self, count):
+        """
+        Truncate the list to the given number of values.
+        If the given number is greater than or equal to
+        the current count(), then nothing is changed.
+        If the given number is less than the 
+        current count(), then elements are dropped
+        from the tail to resize to the given number.
+        The capactity of the queue is not changed.
+
+        So to drop all entries except the head:
+         truncateTo(1)        
+
+        count: the desired number of elements to
+               leave in the queue (maximum)
+        """
+        if count < 0 or count > self.capacity:
+            raise ValueError("count is out of range")
+        self.count = count
+        self.tailIndex = (self.tailIndex + count) % self.capacity
+

--- a/donkeycar/utilities/platform.py
+++ b/donkeycar/utilities/platform.py
@@ -1,0 +1,57 @@
+import os
+import platform
+
+#
+# functions to query hardware and os
+#
+
+
+def is_mac():
+    """
+    True if running on MacOs
+    """
+    return "Darwin" == platform.system()
+
+
+def is_windows():
+    """
+    True if running on Windows operating system.
+    """
+    return "Windows" == platform.system()
+
+
+def is_linux():
+    """
+    True for any linux OS
+    """
+    return "Linux" == platform.system()
+
+
+# TODO: create is_raspberrypi() - true if running on raspberrypi
+
+
+#
+# read tegra chip id if it exists.
+#
+def _read_chip_id() -> str:
+    """
+    Read the tegra chip id.
+    On non-tegra platforms this will be blank.
+    """
+    try:
+        with open("/sys/module/tegra_fuse/parameters/tegra_chip_id", "r") as f:
+            return next(f)
+    except FileNotFoundError:
+        pass
+    return ""
+
+_chip_id = None
+
+def is_jetson() -> bool:
+    """
+    Determine if platform is a jetson
+    """
+    global _chip_id
+    if _chip_id is None:
+        _chip_id = _read_chip_id()
+    return _chip_id != ""

--- a/donkeycar/utilities/platform.py
+++ b/donkeycar/utilities/platform.py
@@ -1,3 +1,4 @@
+import io
 import os
 import platform
 
@@ -27,8 +28,25 @@ def is_linux():
     return "Linux" == platform.system()
 
 
-# TODO: create is_raspberrypi() - true if running on raspberrypi
+_is_raspberrypi = None  # latch value
 
+
+def is_raspberrypi():
+    """
+    True if running on raspberry_pi hardware.
+    NOTE: this does not tell you anything about the operating system.
+          Use is_linux() and is_windows() to distinguish possible os
+          differences.
+    """
+    global _is_raspberrypi
+    if _is_raspberrypi is None:
+        _is_raspberrypi = False
+        try:
+            with io.open('/sys/firmware/devicetree/base/model', 'r') as m:
+                _is_raspberrypi = 'raspberry pi' in m.read().lower()
+        except Exception:
+            pass
+    return _is_raspberrypi
 
 #
 # read tegra chip id if it exists.
@@ -45,7 +63,9 @@ def _read_chip_id() -> str:
         pass
     return ""
 
+
 _chip_id = None
+
 
 def is_jetson() -> bool:
     """

--- a/donkeycar/utilities/serial_port.py
+++ b/donkeycar/utilities/serial_port.py
@@ -1,0 +1,134 @@
+import logging
+from typing import Tuple
+import serial
+import serial.tools.list_ports
+
+
+logger = logging.getLogger(__name__)
+
+
+class SerialPort:
+    """
+    Wrapper for serial port connect/read/write.
+    Use this rather than raw pyserial api.
+    It provides a layer that automatically 
+    catches exceptions and encodes/decodes
+    between bytes and str.  
+    It also provides a layer of indirection 
+    so that we can mock this for testing.
+    """
+    def __init__(self, port:str='/dev/ttyACM0', baudrate:int=115200):
+        self.port = port
+        self.baudrate = baudrate
+        self.ser = None
+
+    def start(self):
+        for item in serial.tools.list_ports.comports():
+            logger.info(item)  # list all the serial ports
+        self.ser = serial.Serial(self.port, self.baudrate, 8, 'N', 1, timeout=0.1)
+        logger.debug("Opened serial port " + self.ser.name)
+
+    def stop(self):
+        if self.ser is not None:
+            sp = self.ser
+            self.ser = None
+            sp.close()
+
+    def buffered(self) -> int:
+        """
+        return: the number of buffered characters
+        """
+        if self.ser is None or not self.ser.is_open:
+            return 0
+
+        try:
+            return self.ser.in_waiting
+        except serial.serialutil.SerialException:
+            return 0
+
+
+    def readBytes(self, count:int=0) -> Tuple[bool, bytes]:
+        """
+        if there are characters waiting, 
+        then read them from the serial port
+        bytes: number of bytes to read 
+        return: tuple of
+                bool: True if count bytes were available to read, 
+                      false if not enough bytes were avaiable
+                bytes: string string if count bytes read (may be blank), 
+                       blank if count bytes are not available
+        """
+        if self.ser is None or not self.ser.is_open:
+            return (False, b'')
+
+        try:
+            input = ''
+            waiting = self.buffered()
+            if (waiting >= count):   # read the serial port and see if there's any data there
+                input = self.ser.read(count)
+            return ((waiting > 0), input)
+        except (serial.serialutil.SerialException, TypeError):
+            logger.warn("failed reading bytes from serial port")
+            return (False, b'')
+
+    def read(self, count:int=0) -> Tuple[bool, str]:
+        """
+        if there are characters waiting, 
+        then read them from the serial port
+        bytes: number of bytes to read 
+        return: tuple of
+                bool: True if count bytes were available to read, 
+                      false if not enough bytes were avaiable
+                str: ascii string if count bytes read (may be blank), 
+                     blank if count bytes are not available
+        """
+        ok, bytestring = self.readBytes(count)
+        return (ok, bytestring.decode('ascii'))
+
+    def readln(self) -> Tuple[bool, str]:
+        """
+        if there are characters waiting, 
+        then read a line from the serial port.
+        This will block until end-of-line can be read.
+        The end-of-line is included in the return value.
+        return: tuple of
+                bool: True if line was read, false if not
+                str: line if read (may be blank), 
+                     blank if not read
+        """
+        if self.ser is None or not self.ser.is_open:
+            return (False, "")
+
+        try:
+            input = ''
+            waiting = self.buffered()
+            if (waiting > 0):   # read the serial port and see if there's any data there
+                buffer = self.ser.readline()
+                input = buffer.decode('ascii')
+            return ((waiting > 0), input)
+        except (serial.serialutil.SerialException, TypeError):
+            logger.warn("failed reading line from serial port")
+            return (False, "")
+
+    def writeBytes(self, value:bytes):
+        """
+        write byte string to serial port
+        """
+        if self.ser is not None and self.ser.is_open:
+            try:
+                self.ser.write(value)  
+            except (serial.serialutil.SerialException, TypeError):
+                logger.warn("Can't write to serial port")
+
+    def write(self, value:str):
+        """
+        write string to serial port
+        """
+        self.writeBytes(value.encode())
+
+    def writeln(self, value:str):
+        """
+        write line to serial port
+        """
+        self.write(value + '\n')
+

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -372,10 +372,36 @@ def throttle(input_value):
 OTHER
 '''
 
+def is_number_type(i):
+    return type(i) == int or type(i) == float;
+
+
+def sign(x):
+    if x > 0:
+        return 1
+    if x < 0:
+        return -1
+    return 0
+
+
+def compare_to(
+    value:float,      # IN : value to compare
+    toValue:float,    # IN : value to compare with tolerance
+    tolerance:float): # IN : non-negative tolerance
+                      # RET: 1 if value > toValue + tolerance
+                      #      -1 if value < toValue - tolerance
+                      #      otherwise zero
+    if (toValue - value) > tolerance:
+        return -1
+    if (value - toValue) > tolerance:
+        return 1
+    return 0
+
 
 def map_frange(x, X_min, X_max, Y_min, Y_max):
     '''
     Linear mapping between two ranges of values
+    map from x range to y range
     '''
     X_range = X_max - X_min
     Y_range = Y_max - Y_min

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='donkeycar',
           'progress',
           'typing_extensions',
           'pyfiglet',
+          'pyserial',
           'psutil'
       ],
       extras_require={
@@ -58,7 +59,6 @@ setup(name='donkeycar',
               'adafruit-circuitpython-lis3dh',
               'adafruit-circuitpython-ssd1306',
               'RPi.GPIO',
-              'pyserial',
               'imgaug'
           ],
           'nano': [
@@ -66,7 +66,6 @@ setup(name='donkeycar',
               'adafruit-circuitpython-lis3dh',
               'adafruit-circuitpython-ssd1306',
               'Jetson.GPIO',
-              'pyserial',
           ],
           'pc': [
               'matplotlib',


### PR DESCRIPTION
Add new encoder, tachometer, odometer and kinematics parts
- the encoder/tachometer/odometer break up the these concerns into separate layers so we can avoid hoisting all that functionality into each separate encoder.
    - encoders simply count ticks
    - tachometers take ticks and output revolutions 
    - odometers take revolutions and output distance and velocity
- We support either one odometer for car-like vehicles or two encoders/odometers for differential robots.
- the kinematics are used to estimate the vehicle pose (x, y, heading).  This will eventually be used in two ways
   - we can use this as a source of pose in the path_follow template.  TBD in a separate pull request.
   - we can use this, along with closed loop speed control, to implement a velocity based neural network model.  TBD in a separate pull request.
- car-like vehicles uses bicycle kinematics
- differential drive vehicles uses unicycle kinematics

All of these parts have been run-tested for a few months in another branch using a highly modified path_follow.py.  That branch has a lot of changes, so I've created this pull request just for the encoder/odometer/kinematics pipeline.  Future pull requests will 1) add changes to path_follow to bring it up to snuff with the complete template 2) add closed-loop speed control and a velocity-based neural network model.

This is draft because I still need to test it on track.