### PR TITLE
Fix torch imports for rpi

### DIFF
--- a/donkeycar/parts/interpreter.py
+++ b/donkeycar/parts/interpreter.py
@@ -5,7 +5,6 @@ import numpy as np
 from typing import Union, Sequence, List
 
 import tensorflow as tf
-import torch
 from tensorflow import keras
 
 from tensorflow.python.framework.convert_to_constants import \
@@ -171,6 +170,7 @@ class KerasInterpreter(Interpreter):
     def summary(self) -> str:
         return self.model.summary()
 
+
 class FastAIInterpreter(Interpreter):
 
     def __init__(self):
@@ -206,7 +206,7 @@ class FastAIInterpreter(Interpreter):
 
     def predict(self, img_arr: np.ndarray, other_arr: np.ndarray) \
             -> Sequence[Union[float, np.ndarray]]:
-
+        import torch
         inputs = torch.unsqueeze(img_arr, 0)
         if other_arr is not None:
             #other_arr = np.expand_dims(other_arr, axis=0)
@@ -214,6 +214,7 @@ class FastAIInterpreter(Interpreter):
         return self.invoke(inputs)
 
     def load(self, model_path: str) -> None:
+        import torch
         logger.info(f'Loading model {model_path}')
         if torch.cuda.is_available():
             logger.info("using cuda for torch inference")
@@ -227,6 +228,7 @@ class FastAIInterpreter(Interpreter):
 
     def summary(self) -> str:
         return self.model
+
 
 class TfLite(Interpreter):
     """

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -439,8 +439,6 @@ def get_model_by_type(model_type: str, cfg: 'Config') -> Union['KerasPilot', 'Fa
     from donkeycar.parts.interpreter import KerasInterpreter, TfLite, TensorRT, \
         FastAIInterpreter
 
-    from donkeycar.parts.fastai import FastAILinear
-
     if model_type is None:
         model_type = cfg.DEFAULT_MODEL_TYPE
     logger.info(f'get_model_by_type: model type is: {model_type}')
@@ -455,6 +453,7 @@ def get_model_by_type(model_type: str, cfg: 'Config') -> Union['KerasPilot', 'Fa
         interpreter = FastAIInterpreter()
         used_model_type = model_type.replace('fastai_', '')
         if used_model_type == "linear":
+            from donkeycar.parts.fastai import FastAILinear
             return FastAILinear(interpreter=interpreter, input_shape=input_shape)
     else:
         interpreter = KerasInterpreter()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.7",
+      version="4.3.8",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
# Fix pytorch import issue created in #986

There is an issue with the RPi version after merging of #986. The `pytorch` imports are not moved into the corresponding classes / functions, such now pytorch becomes a dependency when running code, like loading a model. This is non-wanted behaviour, because on RPi we don't install pytorch by default, and causes the `manage.py drive --model ` to fail. This fix moves the imports into the relevant classes/functions and fixes the issue.