### PR TITLE
Update NMEA parser to handle bad chars

### DIFF
--- a/donkeycar/parts/gps.py
+++ b/donkeycar/parts/gps.py
@@ -181,7 +181,12 @@ def getGpsPosition(line, debug=False):
     nmea_msg = line[1:-3]      # msg without $ and *## checksum
     nmea_parts = nmea_msg.split(",")
     message = nmea_parts[0]
-    if (message == "GPRMC") or (message == "GNRMC"):   
+
+    if (message == "GPRMC") or (message == "GNRMC"):
+        if True or debug:
+            print()
+            print(line)
+
         #     
         # like '$GPRMC,003918.00,A,3806.92281,N,12235.64362,W,0.090,,060322,,,D*67'
         # GPRMC = Recommended minimum specific GPS/Transit data
@@ -191,6 +196,7 @@ def getGpsPosition(line, debug=False):
         calculated_checksum = calculate_nmea_checksum(line)
         if nmea_checksum != calculated_checksum:
             logger.info(f"NMEA checksum does not match: {nmea_checksum} != {calculated_checksum}")
+            return None
         
         #
         # parse against a known parser to check our parser

--- a/donkeycar/parts/gps.py
+++ b/donkeycar/parts/gps.py
@@ -183,10 +183,6 @@ def getGpsPosition(line, debug=False):
     message = nmea_parts[0]
 
     if (message == "GPRMC") or (message == "GNRMC"):
-        if True or debug:
-            print()
-            print(line)
-
         #     
         # like '$GPRMC,003918.00,A,3806.92281,N,12235.64362,W,0.090,,060322,,,D*67'
         # GPRMC = Recommended minimum specific GPS/Transit data

--- a/donkeycar/parts/gps.py
+++ b/donkeycar/parts/gps.py
@@ -57,6 +57,9 @@ class Gps:
                     return self.gps.readline().decode()
             except serial.serialutil.SerialException:
                 pass
+            except UnicodeDecodeError:
+                # the first sentence often includes mis-framed garbase
+                pass  # ignore and keep going
             finally:
                 self.lock.release()
         return None

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.14",
+      version="4.3.17",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
- it turns out that it is common for the first set of
  data returned by a gps module to include incorrectly
  framed characters that break the unicode conversion.
- This change ignores exceptions thrown by the
  unicode decoder and keeps on going until it
  can read a correctly framed line.