### PR TITLE
Fix pandas import error on RPi

### DIFF
--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -16,7 +16,6 @@ import sys
 import time
 
 import numpy as np
-import pandas as pd
 from PIL import Image
 
 
@@ -100,7 +99,9 @@ class Tub(object):
         return max(index)
 
     def update_df(self):
-        df = pd.DataFrame([self.get_json_record(i) for i in self.get_index(shuffled=False)])
+        import pandas as pd
+        df = pd.DataFrame([self.get_json_record(i)
+                           for i in self.get_index(shuffled=False)])
         self.df = df
 
     def get_df(self):
@@ -344,7 +345,6 @@ class Tub(object):
         except:
             pass
 
-
     def write_exclude(self):
         if 0 == len(self.exclude):
             # If the exclude set is empty don't leave an empty file around.
@@ -353,7 +353,6 @@ class Tub(object):
         else:
             with open(self.exclude_path, 'w') as f:
                 json.dump(list(self.exclude), f)
-
 
 
 class TubWriter(Tub):
@@ -535,6 +534,8 @@ class TubTimeStacker(TubImageStacker):
 
 class TubGroup(Tub):
     def __init__(self, tub_paths):
+        import pandas as pd
+
         tub_paths = self.resolve_tub_paths(tub_paths)
         print('TubGroup:tubpaths:', tub_paths)
         tubs = [Tub(path) for path in tub_paths]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.15",
+      version="4.3.16",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
# RPi pandas import error when using auto generated tubs

When using `AUTO_CREATE_NEW_TUB = True`, we import the legacy `datastore.py` module for the `TubHandler` class. However, that module specifies a `pandas` import at module level. We don't install `pandas` on RPi by default to keep the python package smaller. This behaviour has been reported in #1010.

This is fixed by:

* Move the pandas import from module level into the `Tub` and `TubGroup` classes as otherwise we have an import error on RPi when the config `AUTO_CREATE_NEW_TUB` is set to True.

* Bump the version.