### PR TITLE
Fix passing of tub metadata

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -848,8 +848,9 @@ if __name__ == '__main__':
     if args['drive']:
         model_type = args['--type']
         camera_type = args['--camera']
+        meta_kv = [tuple(s.split(':')) for s in args['--meta']]
         drive(cfg, model_path=args['--model'], use_joystick=args['--js'],
               model_type=model_type, camera_type=camera_type,
-              meta=args['--meta'])
+              meta=meta_kv)
     elif args['train']:
         print('Use python train.py instead.\n')

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.17",
+      version="4.3.18",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
# Template complete.py does not support passing tub metadata

According to the docopt string, the complete template should allow to read tub metadata as 
```
--meta=foo:bar --meta=baz:44
```
but it doesn't. This change fixes it.