### PR TITLE
Added 4WD for DC Motor with L298N Configuration

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -656,6 +656,36 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         V.add(left_motor, inputs=['left_motor_speed'])
         V.add(right_motor, inputs=['right_motor_speed'])
 
+    elif cfg.DRIVE_TRAIN_TYPE == "DC_FOUR_WHEEL_L298N":
+        dt = cfg.DC_FOUR_WHEEL_L298N
+        left_back_motor = actuator.L298N_HBridge_3pin(
+            pins.output_pin_by_id(dt['LEFT_BACK_FWD_PIN']),
+            pins.output_pin_by_id(dt['LEFT_BACK_BWD_PIN']),
+            pins.pwm_pin_by_id(dt['LEFT_BACK_EN_DUTY_PIN']))
+        right_back_motor = actuator.L298N_HBridge_3pin(
+            pins.output_pin_by_id(dt['RIGHT_BACK_FWD_PIN']),
+            pins.output_pin_by_id(dt['RIGHT_BACK_BWD_PIN']),
+            pins.pwm_pin_by_id(dt['RIGHT_BACK_EN_DUTY_PIN']))
+        left_front_motor = actuator.L298N_HBridge_3pin(
+            pins.output_pin_by_id(dt['LEFT_FRONT_FWD_PIN']),
+            pins.output_pin_by_id(dt['LEFT_FRONT_BWD_PIN']),
+            pins.pwm_pin_by_id(dt['LEFT_FRONT_EN_DUTY_PIN']))
+        right_front_motor = actuator.L298N_HBridge_3pin(
+            pins.output_pin_by_id(dt['RIGHT_FRONT_FWD_PIN']),
+            pins.output_pin_by_id(dt['RIGHT_FRONT_BWD_PIN']),
+            pins.pwm_pin_by_id(dt['RIGHT_FRONT_EN_DUTY_PIN']))
+
+        two_wheel_control = actuator.TwoWheelSteeringThrottle()
+
+        V.add(two_wheel_control,
+                inputs=['throttle', 'angle'],
+                outputs=['left_motor_speed', 'right_motor_speed'])
+
+        V.add(left_back_motor, inputs=['left_motor_speed'])
+        V.add(left_front_motor, inputs=['left_motor_speed'])
+        V.add(right_back_motor, inputs=['right_motor_speed'])
+        V.add(right_front_motor, inputs=['right_motor_speed'])
+
     elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_2PIN":
         #
         # Servo for steering and HBridge motor driver in 2pin mode for motor


### PR DESCRIPTION
4 DC Motors controlled by 2 L298N motor controllers is one of the easiest and cheapest configurations to build. For example, in this build, I simply stuck the motors and screwed the motor controllers on a wooden plank. On the other side, I stuck a raspberry pi, a battery and a voltage converter (using double sided tape, **not** glue). I know the end result doesn't look pretty but it works. 

![IMG_0422](https://user-images.githubusercontent.com/7254326/172775553-844f8f37-a7ae-456f-a3b2-39c6cc82b9a9.JPG)
![IMG_0421](https://user-images.githubusercontent.com/7254326/172775562-82cf4121-db2e-411c-a19b-5a82170678e6.JPG)

With this teeny-tiny contribution, new users will be able to build the cheapest RC car and be able to use it  with the rest of donkey car awesomeness right of the bat. If you guys think this is useful and would like me to improve the commit, please let me know. I'm willing to spend time documenting this (wherever the right place is).  
 