### PR TITLE
1022 add programable buttons to webui

### DIFF
--- a/donkeycar/memory.py
+++ b/donkeycar/memory.py
@@ -14,13 +14,14 @@ class Memory:
         self.d = {}
     
     def __setitem__(self, key, value):
-        if type(key) is not tuple:
-            print('tuples')
-            key = (key,)
-            value=(value,)
-        
-        for i, k in enumerate(key):
-            self.d[k] = value[i]
+        if type(key) is str:
+            self.d[key] = value
+        else:
+            if type(key) is not tuple:
+                key = tuple(key)
+                value = tuple(key)
+            for i, k in enumerate(key):
+                self.d[k] = value[i]
         
     def __getitem__(self, key):
         if type(key) is tuple:

--- a/donkeycar/parts/explode.py
+++ b/donkeycar/parts/explode.py
@@ -1,0 +1,15 @@
+#
+# part that executes a no-arg method when a button is clicked
+#
+
+
+class UnzipDict:
+    def __init__(self, prefix):
+        """
+        Break a map into key/value pairs and write
+        them to the output memory
+        """
+    def run(self, key_values):
+        if type(key_values) is dict:
+            return tuple(key_values.values())
+        return ()

--- a/donkeycar/parts/explode.py
+++ b/donkeycar/parts/explode.py
@@ -3,13 +3,20 @@
 #
 
 
-class UnzipDict:
-    def __init__(self, prefix):
+class ExplodeDict:
+    def __init__(self, memory, output_prefix = ""):
         """
         Break a map into key/value pairs and write
-        them to the output memory
+        them to the output memory, optionally
+        prefixing the key on output.
+        Basically, take a dictionary and write
+        it to the output.
         """
+        self.memory = memory
+        self.prefix = output_prefix
+
     def run(self, key_values):
         if type(key_values) is dict:
-            return tuple(key_values.values())
-        return ()
+            for key in key_values:
+                self.memory[self.prefix + key] = key_values[key]
+        return None

--- a/donkeycar/parts/explode.py
+++ b/donkeycar/parts/explode.py
@@ -17,6 +17,6 @@ class ExplodeDict:
 
     def run(self, key_values):
         if type(key_values) is dict:
-            for key in key_values:
-                self.memory[self.prefix + key] = key_values[key]
+            for key, value in key_values.items():
+                self.memory[self.prefix + key] = value
         return None

--- a/donkeycar/parts/web_controller/templates/base.html
+++ b/donkeycar/parts/web_controller/templates/base.html
@@ -32,12 +32,6 @@
   <div class="container-fluid">
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
       <a class="navbar-brand" href="/">Donkey</a>
     </div>
 

--- a/donkeycar/parts/web_controller/templates/static/main.js
+++ b/donkeycar/parts/web_controller/templates/static/main.js
@@ -1,26 +1,34 @@
 var driveHandler = new function() {
     //functions used to drive the vehicle. 
 
-    var state = {'tele': {
-                          "user": {
-                                  'angle': 0,
-                                  'throttle': 0,
-                                  },
-                          "pilot": {
-                                  'angle': 0,
-                                  'throttle': 0,
-                                  }
-                          },
-                  'brakeOn': true,
-                  'recording': false,
-                  'driveMode': "user",
-                  'pilot': 'None',
-                  'session': 'None',
-                  'lag': 0,
-                  'controlMode': 'joystick',
-                  'maxThrottle' : 1,
-                  'throttleMode' : 'user',
-                  }
+    var state = {
+        'tele': {
+            "user": {
+                'angle': 0,
+                'throttle': 0,
+            },
+            "pilot": {
+                'angle': 0,
+                'throttle': 0,
+            }
+        },
+        'brakeOn': true,
+        'recording': false,
+        'driveMode': "user",
+        'pilot': 'None',
+        'session': 'None',
+        'lag': 0,
+        'controlMode': 'joystick',
+        'maxThrottle' : 1,
+        'throttleMode' : 'user',
+        'buttons': {
+            "w1": false,  // boolean; true is 'down' or pushed, false is 'up' or not pushed
+            "w2": false,
+            "w3": false,
+            "w4": false,
+            "w5": false,
+        }
+    }
 
     var joystick_options = {}
     var joystickLoopRunning=false;
@@ -152,12 +160,16 @@ var driveHandler = new function() {
           joystickLoopRunning = true;
           console.log('joystick mode');
           joystickLoop();
-        } else if (this.value == 'tilt' && deviceHasOrientation) {
+        } else {
           joystickLoopRunning = false;
+        }
+
+        if (deviceHasOrientation && this.value == 'tilt') {
           state.controlMode = "tilt";
           console.log('tilt mode')
-        } else if (this.value == 'gamepad' && hasGamepad) {
-          joystickLoopRunning = false;
+        }
+
+        if (hasGamepad && this.value == 'gamepad') {
           state.controlMode = "gamepad";
           console.log('gamepad mode')
           gamePadLoop();
@@ -165,6 +177,17 @@ var driveHandler = new function() {
         updateUI();
       });
 
+      // programmable buttons
+      $('#button_bar > button').mousedown(function() {
+        console.log(`${$(this).attr('id')} mousedown`);
+        state.buttons[$(this).attr('id')] = true;
+        postDrive(["buttons"]); // write it back to the server
+      });
+      $('#button_bar > button').mouseup(function() {
+        console.log(`${$(this).attr('id')} mouseup`);
+        state.buttons[$(this).attr('id')] = false;
+        postDrive(["buttons"]); // write it back to the server
+      });
     };
 
 
@@ -296,7 +319,7 @@ var driveHandler = new function() {
       //drawLine(state.tele.user.angle, state.tele.user.throttle)
     };
 
-    const ALL_POST_FIELDS = ['angle', 'throttle', 'drive_mode', 'recording'];
+    const ALL_POST_FIELDS = ['angle', 'throttle', 'drive_mode', 'recording', 'buttons'];
 
     //
     // Set any changed properties to the server
@@ -315,12 +338,14 @@ var driveHandler = new function() {
                 case 'throttle': data['throttle'] = state.tele.user.throttle; break;
                 case 'drive_mode': data['drive_mode'] = state.driveMode; break;
                 case 'recording': data['recording'] = state.recording; break;
+                case 'buttons': data['buttons'] = state.buttons; break;
                 default: console.log(`Unexpected post field: '${field}'`); break;
             }
         });
         if(data) {
-            console.log(`Posting ${data}`);
-            socket.send(JSON.stringify(data))
+            let json_data = JSON.stringify(data);
+            console.log(`Posting ${json_data}`);
+            socket.send(json_data)
             updateUI()
         }
     };

--- a/donkeycar/parts/web_controller/templates/static/main.js
+++ b/donkeycar/parts/web_controller/templates/static/main.js
@@ -40,10 +40,14 @@ var driveHandler = new function() {
 
       setBindings()
 
+      joystick_element = document.getElementById('joystick_container');
       joystick_options = {
-        zone: document.getElementById('joystick_container'),  // active zone
+        zone: joystick_element,  // active zone
+        mode: 'dynamic',
+        size: 200,
         color: '#668AED',
-        size: 350,
+        dynamicPage: true,
+        follow: true,
       };
 
       var manager = nipplejs.create(joystick_options);
@@ -272,17 +276,21 @@ var driveHandler = new function() {
       }
 
       if (state.controlMode == "joystick") {
-        $('#joystick-column').show();
-        $('#tilt-toggle').removeClass("active");
+        $('#joystick_outer').show();
         $('#joystick-toggle').addClass("active");
         $('#joystick').attr("checked", "checked")
-        $('#tilt').removeAttr("checked")
-      } else if (state.controlMode == "tilt") {
-        $('#joystick-column').hide();
+      } else {
+        $('#joystick_outer').hide();
         $('#joystick-toggle').removeClass("active");
-        $('#tilt-toggle').addClass("active");
         $('#joystick').removeAttr("checked");
+      }
+
+      if (state.controlMode == "tilt") {
+        $('#tilt-toggle').addClass("active");
         $('#tilt').attr("checked", "checked");
+      } else {
+        $('#tilt-toggle').removeClass("active");
+        $('#tilt').removeAttr("checked")
       }
 
       //drawLine(state.tele.user.angle, state.tele.user.throttle)

--- a/donkeycar/parts/web_controller/templates/static/style.css
+++ b/donkeycar/parts/web_controller/templates/static/style.css
@@ -5,13 +5,20 @@
 		bottom:100; 
 		right:0;*/
 		width:100%; 
-		height:40%;
+		height:0;
 		 
 	}
 	
 	#joystick-padding {
 		height:220px;
 	}
+}
+
+/* override bootstrap */
+.form-control {
+    display: inline;
+    width: auto;
+    padding: 0.25em 0.25em
 }
 
 #controls-column {
@@ -21,16 +28,21 @@
 	margin-top:10px;
 }
 .group-label {
-	width:100%;
+	width:auto;
+}
+
+#control-bars > div {
+    display: inline;
 }
 
 /* this setting is too large on iPhone5s */
 #control-bars .progress {
-	width: 40%;
+	width: 15%;
 }
 
 #control-bars .glyphicon {
-	margin-right: 3px;
+    margin-left: 1.5em;
+	margin-right: 0.5em;
 }
 
 #control-bars .progress.negative {
@@ -40,6 +52,7 @@
 }
 
 #control-bars .progress.positive {
+	float: left;
 	border-top-left-radius: 0px;
 	border-bottom-left-radius: 0px;
 }
@@ -54,8 +67,9 @@
 
 #joystick_container {
 	text-align: center;
-	height: 335px;
-	padding-top: 155px;
+	width: 100%;
+	height: 17em;
+	padding-top: 8em;
 	border-color: #bce8f1;
 	background-color: #d9edf7;
 }

--- a/donkeycar/parts/web_controller/templates/static/style.css
+++ b/donkeycar/parts/web_controller/templates/static/style.css
@@ -15,10 +15,19 @@
 }
 
 /* override bootstrap */
+form {
+    margin-bottom: 0.5em;
+}
 .form-control {
     display: inline;
     width: auto;
     padding: 0.25em 0.25em
+}
+
+#button_bar button {
+    display: inline-block;
+    padding-left: 1.5em;
+    padding-right: 1.5em;
 }
 
 #controls-column {

--- a/donkeycar/parts/web_controller/templates/vehicle.html
+++ b/donkeycar/parts/web_controller/templates/vehicle.html
@@ -18,6 +18,15 @@
             </button>
         </form>
 
+        <!-- programmable buttons -->
+        <form id="button_bar">
+          <button type="button" id="w1" class="btn btn-info">1</button>
+          <button type="button" id="w2" class="btn btn-info">2</button>
+          <button type="button" id="w3" class="btn btn-info">3</button>
+          <button type="button" id="w4" class="btn btn-info">4</button>
+          <button type="button" id="w5" class="btn btn-info">5</button>
+        </form>
+
         <!-- video -->
         <div class="thumbnail">
           <img id='mpeg-image', class='img-responsive' src="/video"/> </img>
@@ -54,7 +63,7 @@
       </div> <!-- end video column -->
 
       <div id="joystick-column"  class="col-md-6">
-        <div style="text-align:center;color:rgb(255, 27, 65);display:inline-block">Caution: If a Physical Joystick is Used, It overides the Web Controller.</div>
+        <div style="text-align:center;color:rgb(255, 27, 65);display:inline-block">Note: physical game controller overrides web control.</div>
         <!-- virtual joystick -->
         <div id="joystick_outer" class="thumbnail">
           <div id="joystick_container">

--- a/donkeycar/parts/web_controller/templates/vehicle.html
+++ b/donkeycar/parts/web_controller/templates/vehicle.html
@@ -1,21 +1,69 @@
 {% extends "base.html" %}
 {% block content %}
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-  
   <div class="container">
-    <div class="row"> 
-      <div class="col-md-12">
-        <div class="page-header">
+    <div class="row">
+
+      <div class="col-md-6">
+        <!-- pilot mode/recording -->
+        <form>
+            <label>(M)ode</label>
+            <select id="mode_select" class="form-control"  style="display: inline">
+              <option value="user">(U)ser</option>
+              <option value="local">Full (A)uto</option>
+              <option value="local_angle">Auto (S)teer</option>
+            </select>
+            <button type="button" id="record_button" class="btn btn-info" >
+              Start (R)ecording
+            </button>
+        </form>
+
+        <!-- video -->
+        <div class="thumbnail">
+          <img id='mpeg-image', class='img-responsive' src="/video"/> </img>
         </div>
+
+        <!-- steering/throttle meters -->
+        <div id="control-bars">
+          <div>
+            <span class="glyphicon glyphicon-resize-horizontal pull-left"></span>
+            <div class="progress negative">
+              <div id="angle-bar-backward" class="progress-bar progress-bar-warning pull-right" role="progressbar" style="width: 0%;">
+              </div>
+            </div>
+
+            <div class="progress positive">
+              <div id="angle-bar-forward" class="progress-bar progress-bar-info" role="progressbar" style="width: 0%;">
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <span class="glyphicon glyphicon-resize-vertical pull-left"></span>
+            <div class="progress negative">
+              <div id="throttle-bar-backward" class="progress-bar progress-bar-danger pull-right" role="progressbar" style="width: 0%;">
+              </div>
+            </div>
+
+            <div class="progress positive">
+              <div id="throttle-bar-forward" class="progress-bar progress-bar-success" role="progressbar" style="width: 0%;">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div> <!-- end video column -->
+
+      <div id="joystick-column"  class="col-md-6">
+        <div style="text-align:center;color:rgb(255, 27, 65);display:inline-block">Caution: If a Physical Joystick is Used, It overides the Web Controller.</div>
+        <!-- virtual joystick -->
+        <div id="joystick_outer" class="thumbnail">
+          <div id="joystick_container">
+            <p>Click/touch to use joystick.</p>
+          </div>
+        </div>
+
         <div class="form-inline">
-          <div class="form-group">
-            <label class="group-label">
-              Control Mode Help
-              <a data-toggle="modal" class="btn btn-primary btn-xs" data-target="#aboutControlModes">
-                <span class="glyphicon glyphicon-info-sign"></span>
-              </a>
-            </label>
-            <br/>
+          <div>
             <div class="btn-group" data-toggle="buttons">
               <label class="btn btn-primary" id="joystick-toggle">
                 <input type="radio" name="controlMode" id="joystick" autocomplete="off" value="joystick"> Joystick
@@ -27,101 +75,32 @@
                 <input type="radio" name="controlMode" id="tilt" autocomplete="off" value="tilt">Device Tilt
               </label>
             </div>
+            <label class="group-label" style="display: inline">
+              <a data-toggle="modal" class="btn btn-primary btn-xs" data-target="#aboutControlModes">
+                <span class="glyphicon glyphicon-info-sign"></span>
+              </a>
+            </label>
           </div>
-          <div class="form-group" style="max-width:30%;">
-            <label class="group-label">Max Throttle</label><br/>
-            <div class="form-group">
-              <select id="max_throttle_select" class="form-control">
-                <option disabled selected> Select Max Throttle </option>
-                {% for t in [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 100] %}
-                  <option value="{{ t / 100.0 }}">{{ t }}%</option>
-                {% end %}
-              </select>
-            </div>
-          </div>
-          <div class="form-group" style="max-width:30%;">
-            <label class="group-label">Throttle Mode</label><br/>
-            <div class="form-group">
-              <select id="throttle_mode_select" class="form-control">
-                <option value="user" selected>User</option>
-                <option value="constant">Constant (Selected Max)</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <hr>
 
-    <div class="row">
-      <div class="col-xs-4 col-sm-2 col-md-2">
-        <div id="control-bars">
-          <label class="group-label">Angle &amp; Throttle</label>
+          <br/>
           <div>
-            <span class="glyphicon glyphicon-resize-horizontal pull-left"></span>
-            <div class="progress negative">
-              <div id="angle-bar-backward" class="progress-bar progress-bar-warning pull-right" role="progressbar" style="width: 0%;">
-              </div>
-            </div>
-            
-            <div class="progress positive">
-              <div id="angle-bar-forward" class="progress-bar progress-bar-info" role="progressbar" style="width: 0%;">
-              </div>
-            </div>
-          </div>
-          
-          <div>
-            <span class="glyphicon glyphicon-resize-vertical pull-left"></span>
-            <div class="progress negative">
-              <div id="throttle-bar-backward" class="progress-bar progress-bar-danger pull-right" role="progressbar" style="width: 0%;">
-              </div>
-            </div>
-            
-            <div class="progress positive">
-              <div id="throttle-bar-forward" class="progress-bar progress-bar-success" role="progressbar" style="width: 0%;">
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <form>
-          <label>Pilot Mode [m]</label>
-          <div class="form-group">
-            <select id="mode_select" class="form-control">
-              <option disabled selected> Select Mode [m]</option>
-              <option value="user">User [u]</option>
-              <option value="local">Full Auto [a]</option>
-              <option value="local_angle">Auto Steering [s]</option>
+            <label class="group-label" style="display: inline">Throttle:</label>
+            <select id="throttle_mode_select" class="form-control" style="display: inline">
+              <option value="user" selected>Maximum</option>
+              <option value="constant">Constant</option>
+            </select>
+            <select id="max_throttle_select" class="form-control" style="display: inline">
+              {% for t in [100, 95, 90, 85, 80, 75, 70, 60, 50, 40, 30, 20, 10] %}
+                <option value="{{ t / 100.0 }}">{{ t }}%</option>
+              {% end %}
             </select>
           </div>
-          <div class="form-group">
-            <button type="button" id="record_button" class="btn btn-info btn-block">
-              Start Recording [r]
-            </button>
-          </div>
-        </form>
-      </div>
-      
-      <div class="col-xs-8 col-sm-5 col-md-5"><!-- center column -->
-        <div class="thumbnail">
-          <img id='mpeg-image', class='img-responsive' src="/video"/> </img>
         </div>
-      </div><!-- end center column -->
+      </div> <!-- end joystick-column -->
+      <div id="joystick-padding"></div>
+    </div> <!-- END row -->
+  </div> <!-- END page Container -->
 
-      <div id="joystick-column" class="col-xs-10 col-sm-5 col-md-5"> 
-        <div class="thumbnail">
-          <div id="joystick_container">
-            <p>Click/touch to use joystick.</p>
-          </div>
-        </div><!-- end right col -->
-      </div><!-- end right col -->
-    </div>
-    <div class="row">
-      <p  style="text-align:center;color:rgb(255, 27, 65)">Caution: If a Physical Joystick is Used, It overides the Web Controller.</p>
-    </div>
-    <div id="joystick-padding"></div>
-    
-  </div> <!-- END Container -->
   <footer class="footer" id="vehicle_footer">
     <div class="container">
       <div class="row">

--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -202,8 +202,8 @@ class LocalWebController(tornado.web.Application):
         #
         buttons = self.buttons
         self.buttons = {}
-        for button in buttons:
-            if buttons[button]:
+        for button, pressed in buttons.items():
+            if pressed:
                 self.buttons[button] = False
 
         # if there were changes, then send to web client

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -30,6 +30,8 @@ from donkeycar.parts.throttle_filter import ThrottleFilter
 from donkeycar.parts.behavior import BehaviorPart
 from donkeycar.parts.file_watcher import FileWatcher
 from donkeycar.parts.launch import AiLaunch
+from donkeycar.parts.explode import ExplodeDict
+from donkeycar.parts.transform import Lambda
 from donkeycar.utils import *
 
 logger = logging.getLogger(__name__)
@@ -199,9 +201,24 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     
     V.add(ctr,
         inputs=['cam/image_array', 'tub/num_records', 'user/mode', 'recording'],
-        outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
+        outputs=['user/angle', 'user/throttle', 'user/mode', 'recording', 'web/buttons'],
         threaded=True)
-        
+
+    #
+    # explode the buttons into their own key/values in memory
+    #
+    V.add(ExplodeDict(V.mem, "web/"), inputs=['web/buttons'])
+
+    #
+    # adding a button handler is just adding a part with a run_condition
+    # set to the button's name, so it runs when button is pressed.
+    #
+    V.add(Lambda(lambda v: print(f"web/w1 clicked")), inputs=["web/w1"], run_condition="web/w1")
+    V.add(Lambda(lambda v: print(f"web/w2 clicked")), inputs=["web/w2"], run_condition="web/w2")
+    V.add(Lambda(lambda v: print(f"web/w3 clicked")), inputs=["web/w3"], run_condition="web/w3")
+    V.add(Lambda(lambda v: print(f"web/w4 clicked")), inputs=["web/w4"], run_condition="web/w4")
+    V.add(Lambda(lambda v: print(f"web/w5 clicked")), inputs=["web/w5"], run_condition="web/w5")
+
     if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
         #modify max_throttle closer to 1.0 to have more power
         #modify steering_scale lower than 1.0 to have less responsive steering

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.19",
+      version="4.3.20",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
Issue https://github.com/autorope/donkeycar/issues/1022

This PR adds 5 general purpose buttons to the webui.  Presses of these buttons can be processed by other donkeycar parts as input values.
- reformatted webui layout into a 2 column layout that works better on a phone.  This is in anticipation of using the phone while using an RC controller we we can get similar functionality to a game controller.
- Also added code to hide the virtual joystick if it is not being used (if gamepad is being used).
- Add 5 buttons to the ui
- When a button is pressed the pressed state is sent to the donkeycar, which then latches the value.
- The latched value is then written into vehicle memory.
- Parts can detect button presses as input values and respond to them.

I've added code into the complete.py template that shows how to process the button presses.  That is just there to test.  Eventually we can decide if we want to add standard behavior to these buttons or add another mechanism for adding behaviors that can be configured.

This is what the webui looks like on a phone (sorry, github seems to be ignoring sizing and force width to fit)
![image](https://user-images.githubusercontent.com/1163329/175868377-98199958-45b0-4cf9-b538-23d2d21665b9.png)

This is what it looks like on desktop
![image](https://user-images.githubusercontent.com/1163329/175868584-d3a71cad-91ce-476e-b361-8169dbc4e7a8.png)
