### PR TITLE
Move adding camera, controller, drivetrain into functions

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -14,14 +14,19 @@ Options:
     --myconfig=filename     Specify myconfig file to use. 
                             [default: myconfig.py]
 """
-import os
-import time
-import logging
 from docopt import docopt
+
+#
+# import cv2 early to avoid issue with importing after tensorflow
+# see https://github.com/opencv/opencv/issues/14884#issuecomment-599852128
+#
+try:
+    import cv2
+except:
+    pass
 
 
 import donkeycar as dk
-from donkeycar.parts import actuator, pins
 from donkeycar.parts.transform import TriggeredCallback, DelayedTrigger
 from donkeycar.parts.tub_v2 import TubWriter
 from donkeycar.parts.datastore import TubHandler
@@ -77,109 +82,23 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         from donkeycar.parts.telemetry import MqttTelemetry
         tel = MqttTelemetry(cfg)
         
-    if cfg.HAVE_ODOM:
-        if cfg.ENCODER_TYPE == "GPIO":
-            from donkeycar.parts.encoder import RotaryEncoder
-            enc = RotaryEncoder(mm_per_tick=cfg.MM_PER_TICK, pin=cfg.ODOM_PIN, poll_delay=1.0/(cfg.DRIVE_LOOP_HZ*3), debug=cfg.ODOM_DEBUG)
-            V.add(enc, inputs=['throttle'], outputs=['enc/speed'], threaded=True)
-        elif cfg.ENCODER_TYPE == "arduino":
-            from donkeycar.parts.encoder import ArduinoEncoder
-            enc = ArduinoEncoder(mm_per_tick=cfg.MM_PER_TICK, debug=cfg.ODOM_DEBUG)
-            V.add(enc, outputs=['enc/speed'], threaded=True)
-        else:
-            print("No supported encoder found")
+    #
+    # if we are using the simulator, set it up
+    #
+    add_simulator(V, cfg)
 
-    logger.info("cfg.CAMERA_TYPE %s"%cfg.CAMERA_TYPE)
-    if camera_type == "stereo":
 
-        if cfg.CAMERA_TYPE == "WEBCAM":
-            from donkeycar.parts.camera import Webcam
+    #
+    # setup encoders, odometry and pose estimation
+    #
+    add_odometry(V, cfg)
 
-            camA = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 0)
-            camB = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 1)
 
-        elif cfg.CAMERA_TYPE == "CVCAM":
-            from donkeycar.parts.cv import CvCam
+    #
+    # setup primary camera
+    #
+    add_camera(V, cfg, camera_type)
 
-            camA = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 0)
-            camB = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 1)
-        else:
-            raise(Exception("Unsupported camera type: %s" % cfg.CAMERA_TYPE))
-
-        V.add(camA, outputs=['cam/image_array_a'], threaded=True)
-        V.add(camB, outputs=['cam/image_array_b'], threaded=True)
-
-        from donkeycar.parts.image import StereoPair
-
-        V.add(StereoPair(), inputs=['cam/image_array_a', 'cam/image_array_b'],
-            outputs=['cam/image_array'])
-    elif cfg.CAMERA_TYPE == "D435":
-        from donkeycar.parts.realsense435i import RealSense435i
-        cam = RealSense435i(
-            enable_rgb=cfg.REALSENSE_D435_RGB,
-            enable_depth=cfg.REALSENSE_D435_DEPTH,
-            enable_imu=cfg.REALSENSE_D435_IMU,
-            device_id=cfg.REALSENSE_D435_ID)
-        V.add(cam, inputs=[],
-              outputs=['cam/image_array', 'cam/depth_array',
-                       'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
-                       'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'],
-              threaded=True)
-
-    else:
-        if cfg.DONKEY_GYM:
-            from donkeycar.parts.dgym import DonkeyGymEnv
-
-        inputs = []
-        outputs = ['cam/image_array']
-        threaded = True
-        if cfg.DONKEY_GYM:
-            from donkeycar.parts.dgym import DonkeyGymEnv 
-            #rbx
-            cam = DonkeyGymEnv(cfg.DONKEY_SIM_PATH, host=cfg.SIM_HOST, env_name=cfg.DONKEY_GYM_ENV_NAME, conf=cfg.GYM_CONF, record_location=cfg.SIM_RECORD_LOCATION, record_gyroaccel=cfg.SIM_RECORD_GYROACCEL, record_velocity=cfg.SIM_RECORD_VELOCITY, record_lidar=cfg.SIM_RECORD_LIDAR, delay=cfg.SIM_ARTIFICIAL_LATENCY)
-            threaded = True
-            inputs = ['angle', 'throttle']
-        elif cfg.CAMERA_TYPE == "PICAM":
-            from donkeycar.parts.camera import PiCamera
-            cam = PiCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE, vflip=cfg.CAMERA_VFLIP, hflip=cfg.CAMERA_HFLIP)
-        elif cfg.CAMERA_TYPE == "WEBCAM":
-            from donkeycar.parts.camera import Webcam
-            cam = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, camera_index=cfg.CAMERA_INDEX)
-        elif cfg.CAMERA_TYPE == "CVCAM":
-            from donkeycar.parts.cv import CvCam
-            cam = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam=cfg.CAMERA_INDEX)
-        elif cfg.CAMERA_TYPE == "CSIC":
-            from donkeycar.parts.camera import CSICamera
-            cam = CSICamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE, 
-                            capture_width=cfg.IMAGE_W, capture_height=cfg.IMAGE_H, gstreamer_flip=cfg.CSIC_CAM_GSTREAMER_FLIP_PARM)
-        elif cfg.CAMERA_TYPE == "V4L":
-            from donkeycar.parts.camera import V4LCamera
-            cam = V4LCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE)
-        elif cfg.CAMERA_TYPE == "MOCK":
-            from donkeycar.parts.camera import MockCamera
-            cam = MockCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
-        elif cfg.CAMERA_TYPE == "IMAGE_LIST":
-            from donkeycar.parts.camera import ImageListCamera
-            cam = ImageListCamera(path_mask=cfg.PATH_MASK)
-        elif cfg.CAMERA_TYPE == "LEOPARD":
-            from donkeycar.parts.leopard_imaging import LICamera
-            cam = LICamera(width=cfg.IMAGE_W, height=cfg.IMAGE_H, fps=cfg.CAMERA_FRAMERATE)
-        else:
-            raise(Exception("Unkown camera type: %s" % cfg.CAMERA_TYPE))
-
-        
-        # Donkey gym part will output position information if it is configured
-        if cfg.DONKEY_GYM:
-            if cfg.SIM_RECORD_LOCATION:
-                outputs += ['pos/pos_x', 'pos/pos_y', 'pos/pos_z', 'pos/speed', 'pos/cte']
-            if cfg.SIM_RECORD_GYROACCEL:
-                outputs += ['gyro/gyro_x', 'gyro/gyro_y', 'gyro/gyro_z', 'accel/accel_x', 'accel/accel_y', 'accel/accel_z']
-            if cfg.SIM_RECORD_VELOCITY:
-                outputs += ['vel/vel_x', 'vel/vel_y', 'vel/vel_z']
-            if cfg.SIM_RECORD_LIDAR:
-                outputs += ['lidar/dist_array']
-            
-        V.add(cam, inputs=inputs, outputs=outputs, threaded=threaded)
 
     # add lidar
     if cfg.USE_LIDAR:
@@ -195,19 +114,18 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         from donkeycar.parts.tfmini import TFMini
         lidar = TFMini(port=cfg.TFMINI_SERIAL_PORT)
         V.add(lidar, inputs=[], outputs=['lidar/dist'], threaded=True)
-    
+
     if cfg.SHOW_FPS:
         from donkeycar.parts.fps import FrequencyLogger
         V.add(FrequencyLogger(cfg.FPS_DEBUG_INTERVAL), outputs=["fps/current", "fps/fps_list"])
 
-#This web controller will create a web server that is capable
-    #of managing steering, throttle, and modes, and more.
-    ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
-    
-    V.add(ctr,
-        inputs=['cam/image_array', 'tub/num_records', 'user/mode', 'recording'],
-        outputs=['user/angle', 'user/throttle', 'user/mode', 'recording', 'web/buttons'],
-        threaded=True)
+    #
+    # add the user input controller(s)
+    # - this will add the web controller
+    # - it will optionally add any configured 'joystick' controller
+    #
+    has_input_controller = hasattr(cfg, "CONTROLLER_TYPE") and cfg.CONTROLLER_TYPE != "mock"
+    ctr = add_user_controller(V, cfg, use_joystick)
 
     #
     # explode the buttons into their own key/values in memory
@@ -223,44 +141,6 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     V.add(Lambda(lambda v: print(f"web/w3 clicked")), inputs=["web/w3"], run_condition="web/w3")
     V.add(Lambda(lambda v: print(f"web/w4 clicked")), inputs=["web/w4"], run_condition="web/w4")
     V.add(Lambda(lambda v: print(f"web/w5 clicked")), inputs=["web/w5"], run_condition="web/w5")
-
-    if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
-        #modify max_throttle closer to 1.0 to have more power
-        #modify steering_scale lower than 1.0 to have less responsive steering
-        if cfg.CONTROLLER_TYPE == "pigpio_rc":    # an RC controllers read by GPIO pins. They typically don't have buttons
-            from donkeycar.parts.controller import RCReceiver
-            ctr = RCReceiver(cfg)
-            V.add(
-                ctr,
-                inputs=['user/mode', 'recording'], 
-                outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
-                threaded=False)
-        else:
-            if cfg.CONTROLLER_TYPE == "custom":  #custom controller created with `donkey createjs` command
-                from my_joystick import MyJoystickController
-                ctr = MyJoystickController(
-                throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
-                throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
-                steering_scale=cfg.JOYSTICK_STEERING_SCALE,
-                auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
-                ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)          
-            elif cfg.CONTROLLER_TYPE == "MM1":
-                from donkeycar.parts.robohat import RoboHATController            
-                ctr = RoboHATController(cfg)
-            else:
-                from donkeycar.parts.controller import get_js_controller
-                ctr = get_js_controller(cfg)
-                if cfg.USE_NETWORKED_JS:
-                    from donkeycar.parts.controller import JoyStickSub
-                    netwkJs = JoyStickSub(cfg.NETWORK_JS_SERVER_IP)
-                    V.add(netwkJs, threaded=True)
-                    ctr.js = netwkJs
-            V.add(
-                ctr, 
-                inputs=['cam/image_array', 'user/mode', 'recording'], 
-                outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
-                threaded=True)
-        
 
     #this throttle filter will allow one tap back for esc reverse
     th_filter = ThrottleFilter()
@@ -390,33 +270,6 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     if cfg.USE_FPV:
         V.add(WebFpv(), inputs=['cam/image_array'], threaded=True)
 
-    #Behavioral state
-    if cfg.TRAIN_BEHAVIORS:
-        bh = BehaviorPart(cfg.BEHAVIOR_LIST)
-        V.add(bh, outputs=['behavior/state', 'behavior/label', "behavior/one_hot_state_array"])
-        try:
-            ctr.set_button_down_trigger('L1', bh.increment_state)
-        except:
-            pass
-
-        inputs = ['cam/image_array', "behavior/one_hot_state_array"]
-    #IMU
-    elif cfg.USE_LIDAR:
-        inputs = ['cam/image_array', 'lidar/dist_array']
-
-    elif cfg.HAVE_ODOM:
-        inputs = ['cam/image_array', 'enc/speed']
-
-    elif model_type == "imu":
-        assert cfg.HAVE_IMU, 'Missing imu parameter in config'
-        # Run the pilot if the mode is not user.
-        inputs = ['cam/image_array',
-                  'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
-                  'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z']
-
-    else:
-        inputs = ['cam/image_array']
-
     def load_model(kl, model_path):
         start = time.time()
         print('loading model', model_path)
@@ -446,10 +299,17 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             print(e)
             print("ERR>> problems loading model json", json_fnm)
 
+    #
+    # load and configure model for inference
+    #
     if model_path:
-        # When we have a model, first create an appropriate Keras part
+        # If we have a model, create an appropriate Keras part
         kl = dk.utils.get_model_by_type(model_type, cfg)
 
+        #
+        # get callback function to reload the model
+        # for the configured model format
+        #
         model_reload_cb = None
 
         if '.h5' in model_path or '.trt' in model_path or '.tflite' in \
@@ -493,11 +353,45 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         V.add(TriggeredCallback(model_path, model_reload_cb),
               inputs=["modelfile/reload"], run_condition="ai_running")
 
+        #
+        # collect inputs to model for inference
+        #
+        if cfg.TRAIN_BEHAVIORS:
+            bh = BehaviorPart(cfg.BEHAVIOR_LIST)
+            V.add(bh, outputs=['behavior/state', 'behavior/label', "behavior/one_hot_state_array"])
+            try:
+                ctr.set_button_down_trigger('L1', bh.increment_state)
+            except:
+                pass
+
+            inputs = ['cam/image_array', "behavior/one_hot_state_array"]
+
+        elif cfg.USE_LIDAR:
+            inputs = ['cam/image_array', 'lidar/dist_array']
+
+        elif cfg.HAVE_ODOM:
+            inputs = ['cam/image_array', 'enc/speed']
+
+        elif model_type == "imu":
+            assert cfg.HAVE_IMU, 'Missing imu parameter in config'
+            # Run the pilot if the mode is not user.
+            inputs = ['cam/image_array',
+                    'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
+                    'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z']
+        else:
+            inputs = ['cam/image_array']
+
+        #
+        # collect model inference outputs
+        #
         outputs = ['pilot/angle', 'pilot/throttle']
 
         if cfg.TRAIN_LOCALIZER:
             outputs.append("pilot/loc")
+
+        #
         # Add image transformations like crop or trapezoidal mask
+        #
         if hasattr(cfg, 'TRANSFORMATIONS') and cfg.TRANSFORMATIONS:
             from donkeycar.pipeline.augmentations import ImageAugmentation
             V.add(ImageAugmentation(cfg, 'TRANSFORMATIONS'),
@@ -506,6 +400,9 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
 
         V.add(kl, inputs=inputs, outputs=outputs, run_condition='run_pilot')
 
+    #
+    # stop at a stop sign
+    #
     if cfg.STOP_SIGN_DETECTOR:
         from donkeycar.parts.object_detector.stop_sign_detector \
             import StopSignDetector
@@ -518,6 +415,19 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         V.add(ThrottleFilter(), 
               inputs=['pilot/throttle'],
               outputs=['pilot/throttle'])
+
+    #
+    # to give the car a boost when starting ai mode in a race.
+    # This will also override the stop sign detector so that
+    # you can start at a stop sign using launch mode, but
+    # will stop when it comes to the stop sign the next time.
+    #
+    # NOTE: when launch throttle is in effect, pilot speed is set to None
+    #
+    aiLauncher = AiLaunch(cfg.AI_LAUNCH_DURATION, cfg.AI_LAUNCH_THROTTLE, cfg.AI_LAUNCH_KEEP_ENABLED)
+    V.add(aiLauncher,
+          inputs=['user/mode', 'pilot/throttle'],
+          outputs=['pilot/throttle'])
 
     # Choose what inputs should change the car.
     class DriveMode:
@@ -541,12 +451,6 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
           outputs=['angle', 'throttle'])
 
 
-    #to give the car a boost when starting ai mode in a race.
-    aiLauncher = AiLaunch(cfg.AI_LAUNCH_DURATION, cfg.AI_LAUNCH_THROTTLE, cfg.AI_LAUNCH_KEEP_ENABLED)
-
-    V.add(aiLauncher,
-          inputs=['user/mode', 'throttle'],
-          outputs=['throttle'])
 
     if (cfg.CONTROLLER_TYPE != "pigpio_rc") and (cfg.CONTROLLER_TYPE != "MM1"):
         if isinstance(ctr, JoystickController):
@@ -576,211 +480,11 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     if cfg.RECORD_DURING_AI:
         V.add(AiRecordingCondition(), inputs=['user/mode', 'recording'], outputs=['recording'])
 
-    # Drive train setup
-    if cfg.DONKEY_GYM or cfg.DRIVE_TRAIN_TYPE == "MOCK":
-        pass
-    elif cfg.DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE":
-        #
-        # drivetrain for RC car with servo and ESC.
-        # using a PwmPin for steering (servo)
-        # and as second PwmPin for throttle (ESC)
-        #
-        from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PulseController
+    #
+    # Setup drivetrain
+    #
+    add_drivetrain(V, cfg)
 
-        dt = cfg.PWM_STEERING_THROTTLE
-        steering_controller = PulseController(
-            pwm_pin=pins.pwm_pin_by_id(dt["PWM_STEERING_PIN"]),
-            pwm_scale=dt["PWM_STEERING_SCALE"],
-            pwm_inverted=dt["PWM_STEERING_INVERTED"])
-        steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=dt["STEERING_LEFT_PWM"],
-                                        right_pulse=dt["STEERING_RIGHT_PWM"])
-        
-        throttle_controller = PulseController(
-            pwm_pin=pins.pwm_pin_by_id(dt["PWM_THROTTLE_PIN"]),
-            pwm_scale=dt["PWM_THROTTLE_SCALE"],
-            pwm_inverted=dt['PWM_THROTTLE_INVERTED'])
-        throttle = PWMThrottle(controller=throttle_controller,
-                                            max_pulse=dt['THROTTLE_FORWARD_PWM'],
-                                            zero_pulse=dt['THROTTLE_STOPPED_PWM'],
-                                            min_pulse=dt['THROTTLE_REVERSE_PWM'])
-        V.add(steering, inputs=['angle'], threaded=True)
-        V.add(throttle, inputs=['throttle'], threaded=True)
-
-    elif cfg.DRIVE_TRAIN_TYPE == "I2C_SERVO":
-        #
-        # This driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
-        # This driver will be removed in a future release
-        #
-        from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
-
-        steering_controller = PCA9685(cfg.STEERING_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
-        steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=cfg.STEERING_LEFT_PWM,
-                                        right_pulse=cfg.STEERING_RIGHT_PWM)
-
-        throttle_controller = PCA9685(cfg.THROTTLE_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
-        throttle = PWMThrottle(controller=throttle_controller,
-                                        max_pulse=cfg.THROTTLE_FORWARD_PWM,
-                                        zero_pulse=cfg.THROTTLE_STOPPED_PWM,
-                                        min_pulse=cfg.THROTTLE_REVERSE_PWM)
-
-        V.add(steering, inputs=['angle'], threaded=True)
-        V.add(throttle, inputs=['throttle'], threaded=True)
-
-    elif cfg.DRIVE_TRAIN_TYPE == "DC_STEER_THROTTLE":
-        dt = cfg.DC_STEER_THROTTLE
-        steering = actuator.L298N_HBridge_2pin(
-            pins.pwm_pin_by_id(dt['LEFT_DUTY_PIN']),
-            pins.pwm_pin_by_id(dt['RIGHT_DUTY_PIN']))
-        throttle = actuator.L298N_HBridge_2pin(
-            pins.pwm_pin_by_id(dt['FWD_DUTY_PIN']),
-            pins.pwm_pin_by_id(dt['BWD_DUTY_PIN']))
-
-        V.add(steering, inputs=['angle'])
-        V.add(throttle, inputs=['throttle'])
-
-    elif cfg.DRIVE_TRAIN_TYPE == "DC_TWO_WHEEL":
-        dt = cfg.DC_TWO_WHEEL
-        left_motor = actuator.L298N_HBridge_2pin(
-            pins.pwm_pin_by_id(dt['LEFT_FWD_DUTY_PIN']),
-            pins.pwm_pin_by_id(dt['LEFT_BWD_DUTY_PIN']))
-        right_motor = actuator.L298N_HBridge_2pin(
-            pins.pwm_pin_by_id(dt['RIGHT_FWD_DUTY_PIN']),
-            pins.pwm_pin_by_id(dt['RIGHT_BWD_DUTY_PIN']))
-
-        two_wheel_control = actuator.TwoWheelSteeringThrottle()
-
-        V.add(two_wheel_control,
-                inputs=['throttle', 'angle'],
-                outputs=['left_motor_speed', 'right_motor_speed'])
-
-        V.add(left_motor, inputs=['left_motor_speed'])
-        V.add(right_motor, inputs=['right_motor_speed'])
-
-    elif cfg.DRIVE_TRAIN_TYPE == "DC_TWO_WHEEL_L298N":
-        dt = cfg.DC_TWO_WHEEL_L298N
-        left_motor = actuator.L298N_HBridge_3pin(
-            pins.output_pin_by_id(dt['LEFT_FWD_PIN']),
-            pins.output_pin_by_id(dt['LEFT_BWD_PIN']),
-            pins.pwm_pin_by_id(dt['LEFT_EN_DUTY_PIN']))
-        right_motor = actuator.L298N_HBridge_3pin(
-            pins.output_pin_by_id(dt['RIGHT_FWD_PIN']),
-            pins.output_pin_by_id(dt['RIGHT_BWD_PIN']),
-            pins.pwm_pin_by_id(dt['RIGHT_EN_DUTY_PIN']))
-
-        two_wheel_control = actuator.TwoWheelSteeringThrottle()
-
-        V.add(two_wheel_control,
-                inputs=['throttle', 'angle'],
-                outputs=['left_motor_speed', 'right_motor_speed'])
-
-        V.add(left_motor, inputs=['left_motor_speed'])
-        V.add(right_motor, inputs=['right_motor_speed'])
-
-    elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_2PIN":
-        #
-        # Servo for steering and HBridge motor driver in 2pin mode for motor
-        #
-        from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PulseController
-
-        dt = cfg.SERVO_HBRIDGE_2PIN
-        steering_controller = PulseController(
-            pwm_pin=pins.pwm_pin_by_id(dt['PWM_STEERING_PIN']),
-            pwm_scale=dt['PWM_STEERING_SCALE'],
-            pwm_inverted=dt['PWM_STEERING_INVERTED'])
-        steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=dt['STEERING_LEFT_PWM'],
-                                        right_pulse=dt['STEERING_RIGHT_PWM'])
-
-        motor = actuator.L298N_HBridge_2pin(
-            pins.pwm_pin_by_id(dt['FWD_DUTY_PIN']),
-            pins.pwm_pin_by_id(dt['BWD_DUTY_PIN']))
-
-        V.add(steering, inputs=['angle'], threaded=True)
-        V.add(motor, inputs=["throttle"])
-        
-    elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_3PIN":
-        #
-        # Servo for steering and HBridge motor driver in 3pin mode for motor
-        #
-        from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PulseController
-
-        dt = cfg.SERVO_HBRIDGE_3PIN
-        steering_controller = PulseController(
-            pwm_pin=pins.pwm_pin_by_id(dt['PWM_STEERING_PIN']),
-            pwm_scale=dt['PWM_STEERING_SCALE'],
-            pwm_inverted=dt['PWM_STEERING_INVERTED'])
-        steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=dt['STEERING_LEFT_PWM'],
-                                        right_pulse=dt['STEERING_RIGHT_PWM'])
-
-        motor = actuator.L298N_HBridge_3pin(
-            pins.output_pin_by_id(dt['FWD_PIN']),
-            pins.output_pin_by_id(dt['BWD_PIN']),
-            pins.pwm_pin_by_id(dt['DUTY_PIN']))
-
-        V.add(steering, inputs=['angle'], threaded=True)
-        V.add(motor, inputs=["throttle"])
-        
-    elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_PWM":
-        #
-        # Thi driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_2PIN"'
-        # This driver will be removed in a future release
-        #
-        from donkeycar.parts.actuator import ServoBlaster, PWMSteering
-        steering_controller = ServoBlaster(cfg.STEERING_CHANNEL) #really pin
-        # PWM pulse values should be in the range of 100 to 200
-        assert(cfg.STEERING_LEFT_PWM <= 200)
-        assert(cfg.STEERING_RIGHT_PWM <= 200)
-        steering = PWMSteering(controller=steering_controller,
-                               left_pulse=cfg.STEERING_LEFT_PWM,
-                               right_pulse=cfg.STEERING_RIGHT_PWM)
-
-        from donkeycar.parts.actuator import Mini_HBridge_DC_Motor_PWM
-        motor = Mini_HBridge_DC_Motor_PWM(cfg.HBRIDGE_PIN_FWD, cfg.HBRIDGE_PIN_BWD)
-
-        V.add(steering, inputs=['angle'], threaded=True)
-        V.add(motor, inputs=["throttle"])
-
-    elif cfg.DRIVE_TRAIN_TYPE == "MM1":
-        from donkeycar.parts.robohat import RoboHATDriver
-        V.add(RoboHATDriver(cfg), inputs=['angle', 'throttle'])
-
-    elif cfg.DRIVE_TRAIN_TYPE == "PIGPIO_PWM":
-        #
-        # Thi driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
-        # This driver will be removed in a future release
-        #
-        from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PiGPIO_PWM
-        steering_controller = PiGPIO_PWM(cfg.STEERING_PWM_PIN, freq=cfg.STEERING_PWM_FREQ,
-                                         inverted=cfg.STEERING_PWM_INVERTED)
-        steering = PWMSteering(controller=steering_controller,
-                               left_pulse=cfg.STEERING_LEFT_PWM,
-                               right_pulse=cfg.STEERING_RIGHT_PWM)
-
-        throttle_controller = PiGPIO_PWM(cfg.THROTTLE_PWM_PIN, freq=cfg.THROTTLE_PWM_FREQ,
-                                         inverted=cfg.THROTTLE_PWM_INVERTED)
-        throttle = PWMThrottle(controller=throttle_controller,
-                               max_pulse=cfg.THROTTLE_FORWARD_PWM,
-                               zero_pulse=cfg.THROTTLE_STOPPED_PWM,
-                               min_pulse=cfg.THROTTLE_REVERSE_PWM)
-        V.add(steering, inputs=['angle'], threaded=True)
-        V.add(throttle, inputs=['throttle'], threaded=True)
-    
-    elif cfg.DRIVE_TRAIN_TYPE == "VESC":
-        from donkeycar.parts.actuator import VESC
-        logger.info("Creating VESC at port {}".format(cfg.VESC_SERIAL_PORT))
-        vesc = VESC(cfg.VESC_SERIAL_PORT,
-                      cfg.VESC_MAX_SPEED_PERCENT,
-                      cfg.VESC_HAS_SENSOR,
-                      cfg.VESC_START_HEARTBEAT,
-                      cfg.VESC_BAUDRATE, 
-                      cfg.VESC_TIMEOUT,
-                      cfg.VESC_STEERING_SCALE,
-                      cfg.VESC_STEERING_OFFSET
-                    )
-        V.add(vesc, inputs=['angle', 'throttle'])
 
     # OLED setup
     if cfg.USE_SSD1306_128_32:
@@ -817,19 +521,15 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         types +=['float', 'float', 'float',
            'float', 'float', 'float']
 
-    if cfg.HAVE_TFMINI:
-        inputs += ['lidar/dist']
-        types += ['float']
-
     # rbx
     if cfg.DONKEY_GYM:
-        if cfg.SIM_RECORD_LOCATION:  
+        if cfg.SIM_RECORD_LOCATION:
             inputs += ['pos/pos_x', 'pos/pos_y', 'pos/pos_z', 'pos/speed', 'pos/cte']
             types  += ['float', 'float', 'float', 'float', 'float']
-        if cfg.SIM_RECORD_GYROACCEL: 
+        if cfg.SIM_RECORD_GYROACCEL:
             inputs += ['gyro/gyro_x', 'gyro/gyro_y', 'gyro/gyro_z', 'accel/accel_x', 'accel/accel_y', 'accel/accel_z']
             types  += ['float', 'float', 'float', 'float', 'float', 'float']
-        if cfg.SIM_RECORD_VELOCITY:  
+        if cfg.SIM_RECORD_VELOCITY:
             inputs += ['vel/vel_x', 'vel/vel_y', 'vel/vel_z']
             types  += ['float', 'float', 'float']
         if cfg.SIM_RECORD_LIDAR:
@@ -857,6 +557,8 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
 
     # Telemetry (we add the same metrics added to the TubHandler
     if cfg.HAVE_MQTT_TELEMETRY:
+        from donkeycar.parts.telemetry import MqttTelemetry
+        tel = MqttTelemetry(cfg)
         telem_inputs, _ = tel.add_step_inputs(inputs, types)
         V.add(tel, inputs=telem_inputs, outputs=["tub/queue_size"], threaded=True)
 
@@ -867,19 +569,449 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         V.add(ImgArrToJpg(), inputs=['cam/image_array'], outputs=['jpg/bin'])
         V.add(pub, inputs=['jpg/bin'])
 
-    if type(ctr) is LocalWebController:
-        if cfg.DONKEY_GYM:
-            print("You can now go to http://localhost:%d to drive your car." % cfg.WEB_CONTROL_PORT)
-        else:
-            print("You can now go to <your hostname.local>:%d to drive your car." % cfg.WEB_CONTROL_PORT)        
-    elif (cfg.CONTROLLER_TYPE != "pigpio_rc") and (cfg.CONTROLLER_TYPE != "MM1"):
+
+    if cfg.DONKEY_GYM:
+        print("You can now go to http://localhost:%d to drive your car." % cfg.WEB_CONTROL_PORT)
+    else:
+        print("You can now go to <your hostname.local>:%d to drive your car." % cfg.WEB_CONTROL_PORT)
+    if has_input_controller:
+        print("You can now move your controller to drive your car.")
         if isinstance(ctr, JoystickController):
-            print("You can now move your joystick to drive your car.")
             ctr.set_tub(tub_writer.tub)
             ctr.print_controls()
 
     # run the vehicle
     V.start(rate_hz=cfg.DRIVE_LOOP_HZ, max_loop_count=cfg.MAX_LOOPS)
+
+
+def add_user_controller(V, cfg, use_joystick, input_image='cam/image_array'):
+    """
+    Add the web controller and any other
+    configured user input controller.
+    :param V: the vehicle pipeline.
+              On output this will be modified.
+    :param cfg: the configuration (from myconfig.py)
+    :return: the controller
+    """
+
+    #
+    # This web controller will create a web server that is capable
+    # of managing steering, throttle, and modes, and more.
+    #
+    ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
+    V.add(ctr,
+          inputs=[input_image, 'tub/num_records', 'user/mode', 'recording'],
+          outputs=['user/angle', 'user/throttle', 'user/mode', 'recording', 'web/buttons'],
+          threaded=True)
+
+    #
+    # also add a physical controller if one is configured
+    #
+    if use_joystick or cfg.USE_JOYSTICK_AS_DEFAULT:
+        #
+        # RC controller
+        #
+        if cfg.CONTROLLER_TYPE == "pigpio_rc":  # an RC controllers read by GPIO pins. They typically don't have buttons
+            from donkeycar.parts.controller import RCReceiver
+            ctr = RCReceiver(cfg)
+            V.add(
+                ctr,
+                inputs=['user/mode', 'recording'],
+                outputs=['user/angle', 'user/throttle',
+                         'user/mode', 'recording'],
+                threaded=False)
+        else:
+            #
+            # custom game controller mapping created with
+            # `donkey createjs` command
+            #
+            if cfg.CONTROLLER_TYPE == "custom":  # custom controller created with `donkey createjs` command
+                from my_joystick import MyJoystickController
+                ctr = MyJoystickController(
+                    throttle_dir=cfg.JOYSTICK_THROTTLE_DIR,
+                    throttle_scale=cfg.JOYSTICK_MAX_THROTTLE,
+                    steering_scale=cfg.JOYSTICK_STEERING_SCALE,
+                    auto_record_on_throttle=cfg.AUTO_RECORD_ON_THROTTLE)
+                ctr.set_deadzone(cfg.JOYSTICK_DEADZONE)
+            elif cfg.CONTROLLER_TYPE == "MM1":
+                from donkeycar.parts.robohat import RoboHATController
+                ctr = RoboHATController(cfg)
+            elif cfg.CONTROLLER_TYPE == "mock":
+                from donkeycar.parts.controller import MockController
+                ctr = MockController(steering=cfg.MOCK_JOYSTICK_STEERING,
+                                     throttle=cfg.MOCK_JOYSTICK_THROTTLE)
+            else:
+                #
+                # game controller
+                #
+                from donkeycar.parts.controller import get_js_controller
+                ctr = get_js_controller(cfg)
+                if cfg.USE_NETWORKED_JS:
+                    from donkeycar.parts.controller import JoyStickSub
+                    netwkJs = JoyStickSub(cfg.NETWORK_JS_SERVER_IP)
+                    V.add(netwkJs, threaded=True)
+                    ctr.js = netwkJs
+            V.add(
+                ctr,
+                inputs=[input_image, 'user/mode', 'recording'],
+                outputs=['user/angle', 'user/throttle',
+                         'user/mode', 'recording'],
+                threaded=True)
+    return ctr
+
+
+def add_simulator(V, cfg):
+    # Donkey gym part will output position information if it is configured
+    # TODO: the simulation outputs conflict with imu, odometry, kinematics pose estimation and T265 outputs; make them work together.
+    if cfg.DONKEY_GYM:
+        from donkeycar.parts.dgym import DonkeyGymEnv
+        # rbx
+        gym = DonkeyGymEnv(cfg.DONKEY_SIM_PATH, host=cfg.SIM_HOST, env_name=cfg.DONKEY_GYM_ENV_NAME, conf=cfg.GYM_CONF,
+                           record_location=cfg.SIM_RECORD_LOCATION, record_gyroaccel=cfg.SIM_RECORD_GYROACCEL,
+                           record_velocity=cfg.SIM_RECORD_VELOCITY, record_lidar=cfg.SIM_RECORD_LIDAR,
+                           record_distance=cfg.SIM_RECORD_DISTANCE, record_orientation=cfg.SIM_RECORD_ORIENTATION,
+                           delay=cfg.SIM_ARTIFICIAL_LATENCY)
+        threaded = True
+        inputs = ['angle', 'throttle']
+        outputs = ['cam/image_array']
+
+        if cfg.SIM_RECORD_LOCATION:
+            outputs += ['pos/pos_x', 'pos/pos_y', 'pos/pos_z', 'pos/speed', 'pos/cte']
+        if cfg.SIM_RECORD_GYROACCEL:
+            outputs += ['gyro/gyro_x', 'gyro/gyro_y', 'gyro/gyro_z', 'accel/accel_x', 'accel/accel_y', 'accel/accel_z']
+        if cfg.SIM_RECORD_VELOCITY:
+            outputs += ['vel/vel_x', 'vel/vel_y', 'vel/vel_z']
+        if cfg.SIM_RECORD_LIDAR:
+            outputs += ['lidar/dist_array']
+        if cfg.SIM_RECORD_DISTANCE:
+            outputs += ['dist/left', 'dist/right']
+        if cfg.SIM_RECORD_ORIENTATION:
+            outputs += ['roll', 'pitch', 'yaw']
+
+        V.add(gym, inputs=inputs, outputs=outputs, threaded=threaded)
+
+
+def get_camera(cfg):
+    """
+    Get the configured camera part
+    """
+    cam = None
+    if not cfg.DONKEY_GYM:
+        if cfg.CAMERA_TYPE == "PICAM":
+            from donkeycar.parts.camera import PiCamera
+            cam = PiCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH,
+                           framerate=cfg.CAMERA_FRAMERATE,
+                           vflip=cfg.CAMERA_VFLIP, hflip=cfg.CAMERA_HFLIP)
+        elif cfg.CAMERA_TYPE == "WEBCAM":
+            from donkeycar.parts.camera import Webcam
+            cam = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+        elif cfg.CAMERA_TYPE == "CVCAM":
+            from donkeycar.parts.cv import CvCam
+            cam = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+        elif cfg.CAMERA_TYPE == "CSIC":
+            from donkeycar.parts.camera import CSICamera
+            cam = CSICamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH,
+                            capture_width=cfg.IMAGE_W, capture_height=cfg.IMAGE_H,
+                            framerate=cfg.CAMERA_FRAMERATE, gstreamer_flip=cfg.CSIC_CAM_GSTREAMER_FLIP_PARM)
+        elif cfg.CAMERA_TYPE == "V4L":
+            from donkeycar.parts.camera import V4LCamera
+            cam = V4LCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, framerate=cfg.CAMERA_FRAMERATE)
+        elif cfg.CAMERA_TYPE == "IMAGE_LIST":
+            from donkeycar.parts.camera import ImageListCamera
+            cam = ImageListCamera(path_mask=cfg.PATH_MASK)
+        elif cfg.CAMERA_TYPE == "LEOPARD":
+            from donkeycar.parts.leopard_imaging import LICamera
+            cam = LICamera(width=cfg.IMAGE_W, height=cfg.IMAGE_H, fps=cfg.CAMERA_FRAMERATE)
+        elif cfg.CAMERA_TYPE == "MOCK":
+            from donkeycar.parts.camera import MockCamera
+            cam = MockCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+        else:
+            raise(Exception("Unkown camera type: %s" % cfg.CAMERA_TYPE))
+    return cam
+
+
+def add_camera(V, cfg, camera_type):
+    """
+    Add the configured camera to the vehicle pipeline.
+
+    :param V: the vehicle pipeline.
+              On output this will be modified.
+    :param cfg: the configuration (from myconfig.py)
+    """
+    logger.info("cfg.CAMERA_TYPE %s"%cfg.CAMERA_TYPE)
+    if camera_type == "stereo":
+        if cfg.CAMERA_TYPE == "WEBCAM":
+            from donkeycar.parts.camera import Webcam
+
+            camA = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 0)
+            camB = Webcam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 1)
+
+        elif cfg.CAMERA_TYPE == "CVCAM":
+            from donkeycar.parts.cv import CvCam
+
+            camA = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 0)
+            camB = CvCam(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH, iCam = 1)
+        else:
+            raise(Exception("Unsupported camera type: %s" % cfg.CAMERA_TYPE))
+
+        V.add(camA, outputs=['cam/image_array_a'], threaded=True)
+        V.add(camB, outputs=['cam/image_array_b'], threaded=True)
+
+        from donkeycar.parts.image import StereoPair
+
+        V.add(StereoPair(), inputs=['cam/image_array_a', 'cam/image_array_b'],
+            outputs=['cam/image_array'])
+    elif cfg.CAMERA_TYPE == "D435":
+        from donkeycar.parts.realsense435i import RealSense435i
+        cam = RealSense435i(
+            enable_rgb=cfg.REALSENSE_D435_RGB,
+            enable_depth=cfg.REALSENSE_D435_DEPTH,
+            enable_imu=cfg.REALSENSE_D435_IMU,
+            device_id=cfg.REALSENSE_D435_ID)
+        V.add(cam, inputs=[],
+              outputs=['cam/image_array', 'cam/depth_array',
+                       'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
+                       'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'],
+              threaded=True)
+    else:
+        inputs = []
+        outputs = ['cam/image_array']
+        threaded = True
+        cam = get_camera(cfg)
+        if cam:
+            V.add(cam, inputs=inputs, outputs=outputs, threaded=threaded)
+
+
+def add_odometry(V, cfg):
+    """
+    If the configuration support odometry, then
+    add encoders, odometry and kinematics to the vehicle pipeline
+    :param V: the vehicle pipeline.
+              On output this may be modified.
+    :param cfg: the configuration (from myconfig.py)
+    """
+    if cfg.HAVE_ODOM:
+        if cfg.ENCODER_TYPE == "GPIO":
+            from donkeycar.parts.encoder import RotaryEncoder
+            enc = RotaryEncoder(mm_per_tick=cfg.MM_PER_TICK, pin=cfg.ODOM_PIN, poll_delay=1.0/(cfg.DRIVE_LOOP_HZ*3), debug=cfg.ODOM_DEBUG)
+            V.add(enc, inputs=['throttle'], outputs=['enc/speed'], threaded=True)
+        elif cfg.ENCODER_TYPE == "arduino":
+            from donkeycar.parts.encoder import ArduinoEncoder
+            enc = ArduinoEncoder(mm_per_tick=cfg.MM_PER_TICK, debug=cfg.ODOM_DEBUG)
+            V.add(enc, outputs=['enc/speed'], threaded=True)
+        else:
+            print("No supported encoder found")
+
+
+#
+# Drive train setup
+#
+def add_drivetrain(V, cfg):
+
+    if (not cfg.DONKEY_GYM) and cfg.DRIVE_TRAIN_TYPE != "MOCK":
+        from donkeycar.parts import actuator, pins
+        from donkeycar.parts.actuator import TwoWheelSteeringThrottle
+
+        #
+        # To make differential drive steer,
+        # divide throttle between motors based on the steering value
+        #
+        is_differential_drive = cfg.DRIVE_TRAIN_TYPE.startswith("DC_TWO_WHEEL")
+        if is_differential_drive:
+            V.add(TwoWheelSteeringThrottle(),
+                  inputs=['throttle', 'angle'],
+                  outputs=['left/throttle', 'right/throttle'])
+
+        if cfg.DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE":
+            #
+            # drivetrain for RC car with servo and ESC.
+            # using a PwmPin for steering (servo)
+            # and as second PwmPin for throttle (ESC)
+            #
+            from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PulseController
+
+            dt = cfg.PWM_STEERING_THROTTLE
+            steering_controller = PulseController(
+                pwm_pin=pins.pwm_pin_by_id(dt["PWM_STEERING_PIN"]),
+                pwm_scale=dt["PWM_STEERING_SCALE"],
+                pwm_inverted=dt["PWM_STEERING_INVERTED"])
+            steering = PWMSteering(controller=steering_controller,
+                                            left_pulse=dt["STEERING_LEFT_PWM"],
+                                            right_pulse=dt["STEERING_RIGHT_PWM"])
+
+            throttle_controller = PulseController(
+                pwm_pin=pins.pwm_pin_by_id(dt["PWM_THROTTLE_PIN"]),
+                pwm_scale=dt["PWM_THROTTLE_SCALE"],
+                pwm_inverted=dt['PWM_THROTTLE_INVERTED'])
+            throttle = PWMThrottle(controller=throttle_controller,
+                                                max_pulse=dt['THROTTLE_FORWARD_PWM'],
+                                                zero_pulse=dt['THROTTLE_STOPPED_PWM'],
+                                                min_pulse=dt['THROTTLE_REVERSE_PWM'])
+            V.add(steering, inputs=['angle'], threaded=True)
+            V.add(throttle, inputs=['throttle'], threaded=True)
+
+        elif cfg.DRIVE_TRAIN_TYPE == "I2C_SERVO":
+            #
+            # This driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
+            # This driver will be removed in a future release
+            #
+            from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
+
+            steering_controller = PCA9685(cfg.STEERING_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
+            steering = PWMSteering(controller=steering_controller,
+                                            left_pulse=cfg.STEERING_LEFT_PWM,
+                                            right_pulse=cfg.STEERING_RIGHT_PWM)
+
+            throttle_controller = PCA9685(cfg.THROTTLE_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
+            throttle = PWMThrottle(controller=throttle_controller,
+                                            max_pulse=cfg.THROTTLE_FORWARD_PWM,
+                                            zero_pulse=cfg.THROTTLE_STOPPED_PWM,
+                                            min_pulse=cfg.THROTTLE_REVERSE_PWM)
+
+            V.add(steering, inputs=['angle'], threaded=True)
+            V.add(throttle, inputs=['throttle'], threaded=True)
+
+        elif cfg.DRIVE_TRAIN_TYPE == "DC_STEER_THROTTLE":
+            dt = cfg.DC_STEER_THROTTLE
+            steering = actuator.L298N_HBridge_2pin(
+                pins.pwm_pin_by_id(dt['LEFT_DUTY_PIN']),
+                pins.pwm_pin_by_id(dt['RIGHT_DUTY_PIN']))
+            throttle = actuator.L298N_HBridge_2pin(
+                pins.pwm_pin_by_id(dt['FWD_DUTY_PIN']),
+                pins.pwm_pin_by_id(dt['BWD_DUTY_PIN']))
+
+            V.add(steering, inputs=['angle'])
+            V.add(throttle, inputs=['throttle'])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "DC_TWO_WHEEL":
+            dt = cfg.DC_TWO_WHEEL
+            left_motor = actuator.L298N_HBridge_2pin(
+                pins.pwm_pin_by_id(dt['LEFT_FWD_DUTY_PIN']),
+                pins.pwm_pin_by_id(dt['LEFT_BWD_DUTY_PIN']))
+            right_motor = actuator.L298N_HBridge_2pin(
+                pins.pwm_pin_by_id(dt['RIGHT_FWD_DUTY_PIN']),
+                pins.pwm_pin_by_id(dt['RIGHT_BWD_DUTY_PIN']))
+
+            V.add(left_motor, inputs=['left/throttle'])
+            V.add(right_motor, inputs=['right/throttle'])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "DC_TWO_WHEEL_L298N":
+            dt = cfg.DC_TWO_WHEEL_L298N
+            left_motor = actuator.L298N_HBridge_3pin(
+                pins.output_pin_by_id(dt['LEFT_FWD_PIN']),
+                pins.output_pin_by_id(dt['LEFT_BWD_PIN']),
+                pins.pwm_pin_by_id(dt['LEFT_EN_DUTY_PIN']))
+            right_motor = actuator.L298N_HBridge_3pin(
+                pins.output_pin_by_id(dt['RIGHT_FWD_PIN']),
+                pins.output_pin_by_id(dt['RIGHT_BWD_PIN']),
+                pins.pwm_pin_by_id(dt['RIGHT_EN_DUTY_PIN']))
+
+            V.add(left_motor, inputs=['left/throttle'])
+            V.add(right_motor, inputs=['right/throttle'])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_2PIN":
+            #
+            # Servo for steering and HBridge motor driver in 2pin mode for motor
+            #
+            from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PulseController
+
+            dt = cfg.SERVO_HBRIDGE_2PIN
+            steering_controller = PulseController(
+                pwm_pin=pins.pwm_pin_by_id(dt['PWM_STEERING_PIN']),
+                pwm_scale=dt['PWM_STEERING_SCALE'],
+                pwm_inverted=dt['PWM_STEERING_INVERTED'])
+            steering = PWMSteering(controller=steering_controller,
+                                            left_pulse=dt['STEERING_LEFT_PWM'],
+                                            right_pulse=dt['STEERING_RIGHT_PWM'])
+
+            motor = actuator.L298N_HBridge_2pin(
+                pins.pwm_pin_by_id(dt['FWD_DUTY_PIN']),
+                pins.pwm_pin_by_id(dt['BWD_DUTY_PIN']))
+
+            V.add(steering, inputs=['angle'], threaded=True)
+            V.add(motor, inputs=["throttle"])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_3PIN":
+            #
+            # Servo for steering and HBridge motor driver in 3pin mode for motor
+            #
+            from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PulseController
+
+            dt = cfg.SERVO_HBRIDGE_3PIN
+            steering_controller = PulseController(
+                pwm_pin=pins.pwm_pin_by_id(dt['PWM_STEERING_PIN']),
+                pwm_scale=dt['PWM_STEERING_SCALE'],
+                pwm_inverted=dt['PWM_STEERING_INVERTED'])
+            steering = PWMSteering(controller=steering_controller,
+                                            left_pulse=dt['STEERING_LEFT_PWM'],
+                                            right_pulse=dt['STEERING_RIGHT_PWM'])
+
+            motor = actuator.L298N_HBridge_3pin(
+                pins.output_pin_by_id(dt['FWD_PIN']),
+                pins.output_pin_by_id(dt['BWD_PIN']),
+                pins.pwm_pin_by_id(dt['DUTY_PIN']))
+
+            V.add(steering, inputs=['angle'], threaded=True)
+            V.add(motor, inputs=["throttle"])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_PWM":
+            #
+            # This driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "SERVO_HBRIDGE_2PIN"'
+            # This driver will be removed in a future release
+            #
+            from donkeycar.parts.actuator import ServoBlaster, PWMSteering
+            steering_controller = ServoBlaster(cfg.STEERING_CHANNEL) #really pin
+            # PWM pulse values should be in the range of 100 to 200
+            assert(cfg.STEERING_LEFT_PWM <= 200)
+            assert(cfg.STEERING_RIGHT_PWM <= 200)
+            steering = PWMSteering(controller=steering_controller,
+                                   left_pulse=cfg.STEERING_LEFT_PWM,
+                                   right_pulse=cfg.STEERING_RIGHT_PWM)
+
+            from donkeycar.parts.actuator import Mini_HBridge_DC_Motor_PWM
+            motor = Mini_HBridge_DC_Motor_PWM(cfg.HBRIDGE_PIN_FWD, cfg.HBRIDGE_PIN_BWD)
+
+            V.add(steering, inputs=['angle'], threaded=True)
+            V.add(motor, inputs=["throttle"])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "MM1":
+            from donkeycar.parts.robohat import RoboHATDriver
+            V.add(RoboHATDriver(cfg), inputs=['angle', 'throttle'])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "PIGPIO_PWM":
+            #
+            # This driver is DEPRECATED in favor of 'DRIVE_TRAIN_TYPE == "PWM_STEERING_THROTTLE"'
+            # This driver will be removed in a future release
+            #
+            from donkeycar.parts.actuator import PWMSteering, PWMThrottle, PiGPIO_PWM
+            steering_controller = PiGPIO_PWM(cfg.STEERING_PWM_PIN, freq=cfg.STEERING_PWM_FREQ,
+                                             inverted=cfg.STEERING_PWM_INVERTED)
+            steering = PWMSteering(controller=steering_controller,
+                                   left_pulse=cfg.STEERING_LEFT_PWM,
+                                   right_pulse=cfg.STEERING_RIGHT_PWM)
+
+            throttle_controller = PiGPIO_PWM(cfg.THROTTLE_PWM_PIN, freq=cfg.THROTTLE_PWM_FREQ,
+                                             inverted=cfg.THROTTLE_PWM_INVERTED)
+            throttle = PWMThrottle(controller=throttle_controller,
+                                   max_pulse=cfg.THROTTLE_FORWARD_PWM,
+                                   zero_pulse=cfg.THROTTLE_STOPPED_PWM,
+                                   min_pulse=cfg.THROTTLE_REVERSE_PWM)
+            V.add(steering, inputs=['angle'], threaded=True)
+            V.add(throttle, inputs=['throttle'], threaded=True)
+    
+        elif cfg.DRIVE_TRAIN_TYPE == "VESC":
+            from donkeycar.parts.actuator import VESC
+            logger.info("Creating VESC at port {}".format(cfg.VESC_SERIAL_PORT))
+            vesc = VESC(cfg.VESC_SERIAL_PORT,
+                          cfg.VESC_MAX_SPEED_PERCENT,
+                          cfg.VESC_HAS_SENSOR,
+                          cfg.VESC_START_HEARTBEAT,
+                          cfg.VESC_BAUDRATE,
+                          cfg.VESC_TIMEOUT,
+                          cfg.VESC_STEERING_SCALE,
+                          cfg.VESC_STEERING_OFFSET
+                        )
+            V.add(vesc, inputs=['angle', 'throttle'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is the first step in updating the path_follow.py template to use GPS.  This step is just to make the same sensor available in complete.py available to any template, and to simplify the complete.py template as well.  The full process for merging in the GPS branch can be found in [Issue 991}(https://github.com/autorope/donkeycar/issues/991#issuecomment-1242763724)
 
- refactored complete.py to move adding of common parts into functions that can be shared with other templates (path follow in particular).
     - add_drivetrain() adds the configured drive train to the vehicle.
     - add_odometry() adds configured encoders to the vehicle.
     - get_camera()/add_camera() adds configured camera(s) to the vehicle.
     - add_simulator() adds donkey gym if it is configured.
     - add_user_controller() adds the webui and any configured game controller, or the donkey hat.
