### PR TITLE
991 gps path follow

### DIFF
--- a/donkeycar/parts/gps.py
+++ b/donkeycar/parts/gps.py
@@ -10,7 +10,7 @@ import serial
 import utm
 
 from donkeycar.parts.serial_port import SerialPort
-from donkeycar.utilities.dk_platform import is_mac
+from donkeycar.parts.text_writer import CsvLogger
 
 logger = logging.getLogger(__name__)
 

--- a/donkeycar/parts/gps.py
+++ b/donkeycar/parts/gps.py
@@ -65,7 +65,7 @@ class GpsPosition:
     def _start(self):
         # wait until we get at least one gps position
         while self.position is None:
-            print("Waiting for gps fix")
+            logger.info("Waiting for gps fix")
             self.position = self.run()
 
     def run_once(self, lines):
@@ -159,10 +159,10 @@ class GpsPlayer:
                 while within_time:
                     next_nmea = None
                     if self.index >= self.nmea.length():
+                        # wrap around from end to start
                         self.index = 0
                         self.starttime += offset_nmea_time
                         next_nmea = self.nmea.get(0)
-                        print("******************* Wrapping gps player **********************")
                     else:
                         next_nmea = self.nmea.get(self.index + 1)
 

--- a/donkeycar/parts/kinematics.py
+++ b/donkeycar/parts/kinematics.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Tuple
+
+from donkeycar.utils import is_number_type, clamp
+
+logger = logging.getLogger(__name__)
+
+
+def differential_steering(throttle: float, steering: float, steering_zero: float = 0.01) -> Tuple[float, float]:
+        """
+        Turn steering angle and speed/throttle into 
+        left and right wheel speeds/throttle.
+        This basically slows down one wheel by the steering value
+        while leaving the other wheel at the desired throttle.
+        So, except for the case where the steering is zero (going straight forward),
+        the effective throttle is low than the requested throttle.  
+        This is different than car-like vehicles, where the effective
+        forward throttle is not affected by the steering angle.
+        This is is NOT inverse kinematics; it is appropriate for managing throttle
+        when a user is driving the car (so the user is the controller)
+        This is the algorithm used by TwoWheelSteeringThrottle.
+
+        @Param throttle:float throttle or real speed; reverse < 0, 0 is stopped, forward > 0
+        @Param steering:float -1 to 1, -1 full left, 0 straight, 1 is full right
+        @Param steering_zero:float values abs(steering) <= steering_zero are considered zero.
+        """
+        if not is_number_type(throttle):
+            logger.error("throttle must be a number")
+            return 0, 0
+        if throttle > 1 or throttle < -1:
+            logger.warn(f"throttle = {throttle}, but must be between 1(right) and -1(left)")
+        throttle = clamp(throttle, -1, 1)
+
+        if not is_number_type(steering):
+            logger.error("steering must be a number")
+            return 0, 0
+        if steering > 1 or steering < -1:
+            logger.warn(f"steering = {steering}, but must be between 1(right) and -1(left)")
+        steering = clamp(steering, -1, 1)
+
+        left_throttle = throttle
+        right_throttle = throttle
+ 
+        if steering < -steering_zero:
+            left_throttle *= (1.0 + steering)
+        elif steering > steering_zero:
+            right_throttle *= (1.0 - steering)
+
+        return left_throttle, right_throttle        
+
+
+class TwoWheelSteeringThrottle:
+    """
+    convert throttle and steering into individual
+    wheel throttles in a differential drive robot
+    @Param steering_zero:float values abs(steering) <= steering_zero are considered zero.
+    """
+    def __init__(self, steering_zero: float = 0.01) -> None:
+        if not is_number_type(steering_zero):
+            raise ValueError("steering_zero must be a number")
+        if steering_zero > 1 or steering_zero < 0:
+            raise ValueError(f"steering_zero  {steering_zero}, but must be be between 1 and zero.")
+        self.steering_zero = steering_zero
+
+    def run(self, throttle, steering):
+        """
+        @Param throttle:float throttle or real speed; reverse < 0, 0 is stopped, forward > 0
+        @Param steering:float -1 to 1, -1 full left, 0 straight, 1 is full right
+        """
+        return differential_steering(throttle, steering, self.steering_zero)
+ 
+    def shutdown(self):
+        pass

--- a/donkeycar/parts/logger.py
+++ b/donkeycar/parts/logger.py
@@ -1,0 +1,34 @@
+import logging
+from typing import List, Set, Dict, Tuple, Optional
+
+
+class LoggerPart:
+    """
+    Log the given values in vehicle memory.
+    """
+    def __init__(self, inputs: List[str], level: str="INFO", rate: int=1, logger=None):
+        self.inputs = inputs
+        self.rate = rate
+        self.level = logging._nameToLevel.get(level, logging.INFO)
+        self.logger = logging.getLogger(logger if logger is not None else "LoggerPart")
+
+        self.values = {}
+        self.count = 0
+        self.running = True
+
+    def run(self, *args):
+        if self.running and args is not None and len(args) == len(self.inputs):
+            self.count = (self.count + 1) % (self.rate + 1)
+            for i in range(len(self.inputs)):
+                field = self.inputs[i]
+                value = args[i]
+                old_value = self.values.get(field)
+                if old_value != value:
+                    # always log changes
+                    self.logger.log(self.level, f"{field} = {old_value} -> {value}")
+                    self.values[field] = value
+                elif self.count >= self.rate:
+                    self.logger.log(self.level, f"{field} = {value}")
+
+    def shutdown(self):
+        self.running = False

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -16,7 +16,7 @@ class AbstractPath:
         self.y = math.inf
 
     def run(self, recording, x, y):
-        if recording is not None and recording:
+        if recording:
             d = dist(x, y, self.x, self.y)
             if d > self.min_dist:
                 logging.info(f"path point ({x},{y})")
@@ -254,7 +254,7 @@ class CTE(object):
         a, b = self.nearest_two_pts(path, x, y)
         
         if a and b:
-            logging.info("nearest: (%f, %f) to (%f, %f)" % ( a[0], a[1], x, y))
+            logging.info(f"nearest: ({a[0]}, {a[1]}) to ({x}, {y})")
             a_v = Vec3(a[0], 0., a[1])
             b_v = Vec3(b[0], 0., b[1])
             p_v = Vec3(x, 0., y)

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -1,38 +1,96 @@
 import pickle
 import math
 import logging
-
+import pathlib
 import numpy
 from PIL import Image, ImageDraw
 
-from donkeycar.utils import norm_deg, dist, deg2rad, arr_to_img
+from donkeycar.utils import norm_deg, dist, deg2rad, arr_to_img, is_number_type
 
 
-class Path(object):
-    def __init__(self, min_dist = 1.):
+class AbstractPath:
+    def __init__(self, min_dist=1.):
         self.path = []
         self.min_dist = min_dist
         self.x = math.inf
         self.y = math.inf
-        self.recording = True
 
-    def run(self, x, y):
-        d = dist(x, y, self.x, self.y)
-        if self.recording and d > self.min_dist:
-            self.path.append((x, y))
-            logging.info("path point (%f, %f)" % ( x, y))
-            self.x = x
-            self.y = y
+    def run(self, recording, x, y):
+        if recording is not None and recording:
+            d = dist(x, y, self.x, self.y)
+            if d > self.min_dist:
+                logging.info(f"path point ({x},{y})")
+                self.path.append((x, y))
+                self.x = x
+                self.y = y
         return self.path
+
+    def length(self):
+        return len(self.path)
+
+    def is_empty(self):
+        return 0 == self.length()
+
+    def is_loaded(self):
+        return not self.is_empty()
+
+    def get_xy(self):
+        return self.path
+
+    def reset(self):
+        self.path = []
+        return True
+
+    def save(self, filename):
+        return False
+
+    def load(self, filename):
+        return False
+
+
+class CsvPath(AbstractPath):
+    def __init__(self, min_dist=1.):
+        super().__init__(min_dist)
+
+    def save(self, filename):
+        if self.length() > 0:
+            with open(filename, 'w') as outfile:
+                for (x, y) in self.path:
+                    outfile.write(f"{x}, {y}\n")
+            return True
+        else:
+            return False
+
+    def load(self, filename):
+        path = pathlib.Path(filename)
+        if path.is_file():
+            with open(filename, "r") as infile:
+                self.path = []
+                for line in infile:
+                    xy = [float(i.strip()) for i in line.strip().split(sep=",")]
+                    self.path.append((xy[0], xy[1]))
+            return True
+        else:
+            logging.info(f"File '{filename}' does not exist")
+            return False
+
+        self.recording = False
+
+
+class RosPath(AbstractPath):
+    def __init__(self, min_dist=1.):
+        super().__init__(self, min_dist)
 
     def save(self, filename):
         outfile = open(filename, 'wb')
         pickle.dump(self.path, outfile)
-    
+        return True
+
     def load(self, filename):
         infile = open(filename, 'rb')
         self.path = pickle.load(infile)
         self.recording = False
+        return True
 
 class PImage(object):
     def __init__(self, resolution=(500, 500), color="white", clear_each_frame=False):
@@ -53,21 +111,47 @@ class OriginOffset(object):
     Use this to set the car back to the origin without restarting it.
     '''
 
-    def __init__(self):
-        self.ox = 0.0
-        self.oy = 0.0
-        self.last_x = 0.
-        self.last_y = 0.
+    def __init__(self, debug=False):
+        self.debug = debug
+        self.ox = None
+        self.oy = None
+        self.last_x = 0.0
+        self.last_y = 0.0
 
     def run(self, x, y):
-        self.last_x = x
-        self.last_y = y
+        if is_number_type(x) and is_number_type(y):
+            # if origin is None, set it to current position
+            if self.ox is None and self.oy is None:
+                self.ox = x
+                self.oy = y
 
-        return x + self.ox, y + self.oy
+            self.last_x = x
+            self.last_y = y
+        else:
+            logging.debug("OriginOffset ignoring non-number")
+
+        # translate the given position by the origin
+        pos = (0, 0)
+        if self.last_x is not None and self.last_y is not None and self.ox is not None and self.oy is not None:
+            pos = (self.last_x - self.ox, self.last_y - self.oy)
+        if self.debug:
+            print(f"pos/x = {pos[0]}, pos/y = {pos[1]}")
+        return pos
+
+    def set_origin(self, x, y):
+        logging.info(f"Resetting origin to ({x}, {y})")
+        self.ox = x
+        self.oy = y
+
+    def reset_origin(self):
+        """
+        Reset the origin with the next value that comes in
+        """
+        self.ox = None
+        self.oy = None
 
     def init_to_last(self):
-        self.ox = -self.last_x
-        self.oy = -self.last_y
+        self.set_origin(self.last_x, self.last_y)
 
 
 class PathPlot(object):
@@ -91,18 +175,18 @@ class PathPlot(object):
             stacked_img = numpy.stack((img,)*3, axis=-1)
             img = arr_to_img(stacked_img)
 
-        draw = ImageDraw.Draw(img)
-        color = (255, 0, 0)
-        for iP in range(0, len(path) - 1):
-            ax, ay = path[iP]
-            bx, by = path[iP + 1]
-            self.plot_line(ax * self.scale + self.offset[0],
-                        ay * self.scale + self.offset[1], 
-                        bx * self.scale + self.offset[0], 
-                        by * self.scale + self.offset[1], 
-                        draw, 
-                        color)
-
+        if path:
+            draw = ImageDraw.Draw(img)
+            color = (255, 0, 0)
+            for iP in range(0, len(path) - 1):
+                ax, ay = path[iP]
+                bx, by = path[iP + 1]
+                self.plot_line(ax * self.scale + self.offset[0],
+                            ay * self.scale + self.offset[1],
+                            bx * self.scale + self.offset[0],
+                            by * self.scale + self.offset[1],
+                            draw,
+                            color)
         return img
 
 
@@ -143,8 +227,12 @@ from donkeycar.la import Line3D, Vec3
 
 class CTE(object):
 
+    # TODO: update so that we look for nearest two points starting from a given point
+    #       and up to a given number of points.  This will speed things up
+    #       but more importantly it can be used to handle crossing paths.
     def nearest_two_pts(self, path, x, y):
-        if len(path) < 2:
+        if path is None or len(path) < 2:
+            logging.error("path is none; cannot calculate nearest points")
             return None, None
 
         distances = []
@@ -166,7 +254,7 @@ class CTE(object):
         a, b = self.nearest_two_pts(path, x, y)
         
         if a and b:
-            #logging.info("nearest: (%f, %f) to (%f, %f)" % ( a[0], a[1], x, y))
+            logging.info("nearest: (%f, %f) to (%f, %f)" % ( a[0], a[1], x, y))
             a_v = Vec3(a[0], 0., a[1])
             b_v = Vec3(b[0], 0., b[1])
             p_v = Vec3(x, 0., y)
@@ -177,7 +265,8 @@ class CTE(object):
             if cp.y > 0.0 :
                 sign = -1.0
             cte = err.mag() * sign            
-
+        else:
+            logging.info(f"no nearest point to ({x},{y}))")
         return cte
 
 

--- a/donkeycar/parts/pipe.py
+++ b/donkeycar/parts/pipe.py
@@ -1,6 +1,3 @@
-from typing import List, Set, Dict, Tuple, Optional
-
-
 class Pipe:
     """
     Just pipe all inputs to the output, so they can be renamed.

--- a/donkeycar/parts/pipe.py
+++ b/donkeycar/parts/pipe.py
@@ -1,0 +1,16 @@
+from typing import List, Set, Dict, Tuple, Optional
+
+
+class Pipe:
+    """
+    Just pipe all inputs to the output, so they can be renamed.
+    """
+    def __init__(self):
+        self.running = True
+
+    def run(self, *args):
+        if self.running:
+            return args
+
+    def shutdown(self):
+        self.running = False

--- a/donkeycar/parts/serial_port.py
+++ b/donkeycar/parts/serial_port.py
@@ -1,0 +1,330 @@
+import logging
+from typing import Tuple
+import serial
+import serial.tools.list_ports
+import threading
+import time
+import donkeycar.utilities.dk_platform as dk_platform
+
+
+logger = logging.getLogger("donkeycar.utilities.serial_port")
+
+
+class SerialPort:
+    """
+    Wrapper for serial port connect/read/write.
+    Use this rather than raw pyserial api.
+    It provides a layer that automatically 
+    catches exceptions and encodes/decodes
+    between bytes and str.  
+    It also provides a layer of indirection 
+    so that we can mock this for testing.
+    """
+    def __init__(self, port:str='/dev/ttyACM0', baudrate:int=115200, bits:int=8, parity:str='N', stop_bits:int=1, charset:str='ascii', timeout:float=0.1):
+        self.port = port
+        self.baudrate = baudrate
+        self.bits = bits
+        self.parity = parity
+        self.stop_bits = stop_bits
+        self.charset = charset
+        self.timeout = timeout
+        self.ser = None
+
+    def start(self):
+        for item in serial.tools.list_ports.comports():
+            logger.info(item)  # list all the serial ports
+        self.ser = serial.Serial(self.port, self.baudrate, self.bits, self.parity, self.stop_bits, timeout=self.timeout)
+        logger.debug("Opened serial port " + self.ser.name)
+        return self
+
+    def stop(self):
+        if self.ser is not None:
+            sp = self.ser
+            self.ser = None
+            sp.close()
+        return self
+
+    def buffered(self) -> int:
+        """
+        return: the number of buffered characters
+        """
+        if self.ser is None or not self.ser.is_open:
+            return 0
+
+        # ser.in_waiting is always zero on mac, so act like we are buffered
+        if dk_platform.is_mac():
+            return 1
+
+        try:
+            return self.ser.in_waiting
+        except serial.serialutil.SerialException:
+            return 0
+
+    def clear(self):
+        """
+        Clear the serial read buffer
+        """
+        try:
+            if self.ser is not None and self.ser.is_open:
+                self.ser.reset_input_buffer()
+        except serial.serialutil.SerialException:
+            pass
+        return self
+
+    def readBytes(self, count:int=0) -> Tuple[bool, bytes]:
+        """
+        if there are characters waiting, 
+        then read them from the serial port
+        bytes: number of bytes to read 
+        return: tuple of
+                bool: True if count bytes were available to read, 
+                      false if not enough bytes were avaiable
+                bytes: string string if count bytes read (may be blank), 
+                       blank if count bytes are not available
+        """
+        if self.ser is None or not self.ser.is_open:
+            return (False, b'')
+
+        try:
+            input = ''
+            waiting = self.buffered() >= count
+            if waiting:   # read the serial port and see if there's any data there
+                input = self.ser.read(count)
+            return (waiting, input)
+        except (serial.serialutil.SerialException, TypeError):
+            logger.warn("failed reading bytes from serial port")
+            return (False, b'')
+
+    def read(self, count:int=0) -> Tuple[bool, str]:
+        """
+        if there are characters waiting, 
+        then read them from the serial port
+        bytes: number of bytes to read 
+        return: tuple of
+                bool: True if count bytes were available to read, 
+                      false if not enough bytes were available
+                str: ascii string if count bytes read (may be blank), 
+                     blank if count bytes are not available
+        """
+        ok, bytestring = self.readBytes(count)
+        try:
+            return (ok, bytestring.decode(self.charset))
+        except UnicodeDecodeError:
+            # the first read often includes mis-framed garbase
+            return (False, "")
+
+    def readln(self) -> Tuple[bool, str]:
+        """
+        if there are characters waiting, 
+        then read a line from the serial port.
+        This will block until end-of-line can be read.
+        The end-of-line is included in the return value.
+        return: tuple of
+                bool: True if line was read, false if not
+                str: line if read (may be blank), 
+                     blank if not read
+        """
+        if self.ser is None or not self.ser.is_open:
+            return (False, "")
+
+        try:
+            input = ''
+            waiting = self.buffered() > 0
+            if waiting:   # read the serial port and see if there's any data there
+                buffer = self.ser.readline()
+                input = buffer.decode(self.charset)
+            return (waiting, input)
+        except (serial.serialutil.SerialException, TypeError):
+            logger.warn("failed reading line from serial port")
+            return (False, "")
+        except UnicodeDecodeError:
+            # the first read often includes mis-framed garbase
+            logger.warn("failed decoding unicode line from serial port")
+            return (False, "")
+
+    def writeBytes(self, value:bytes):
+        """
+        write byte string to serial port
+        """
+        if self.ser is not None and self.ser.is_open:
+            try:
+                self.ser.write(value)  
+            except (serial.serialutil.SerialException, TypeError):
+                logger.warn("Can't write to serial port")
+
+    def write(self, value:str):
+        """
+        write string to serial port
+        """
+        self.writeBytes(value.encode())
+
+    def writeln(self, value:str):
+        """
+        write line to serial port
+        """
+        self.write(value + '\n')
+
+
+class SerialLineReader:
+    """
+    Donkeycar part for reading lines from a serial port
+    """
+    def __init__(self, serial:SerialPort, max_lines:int = 0, debug:bool = False):
+        self.serial = serial
+        self.max_lines = max_lines  # max number of lines per read cycle
+        self.debug = debug
+        self.lines = []
+        self.lock = threading.Lock()
+        self.running = True
+        self._open()
+        self.clear()
+
+    def _open(self):
+        with self.lock:
+            self.serial.start().clear()
+
+    def _close(self):
+        with self.lock:
+            self.serial.stop()
+
+    def clear(self):
+        """
+        Clear the lines buffer and serial port input buffer
+        """
+        with self.lock:
+            self.lines = []
+            self.serial.clear()
+
+    def _readline(self) -> str:
+        """
+        Read a line from the serial port in a threadsafe manner
+        returns line if read and None if no line was read
+        """
+        if self.lock.acquire(blocking=False):
+            try:
+                # TODO: Serial.in_waiting _always_ returns 0 in Macintosh
+                if dk_platform.is_mac() or (self.serial.buffered() > 0):
+                    success, buffer = self.serial.readln()
+                    if success:
+                        return buffer
+            finally:
+                self.lock.release()
+        return None
+
+    def run(self):
+        if self.running:
+            #
+            # in non-threaded mode, just max_lines and return them
+            #
+            lines = []
+            line = self._readline()
+            while line is not None:
+                lines.append((time.time(), line))
+                line = None
+                if self.max_lines is None or self.max_lines == 0 or len(lines) < self.max_lines:
+                    line = self._readline()
+            return lines
+        return []
+
+    def run_threaded(self):
+        if not self.running:
+            return []
+
+        #
+        # return the accumulated readings
+        #
+        with self.lock:
+            lines = self.lines
+            self.lines = []
+            return lines
+
+
+    def update(self):
+        #
+        # open serial port and run an infinite loop.
+        # NOTE: this is NOT compatible with non-threaded run()
+        #
+        buffered_lines = []  # local read buffer
+        while self.running:
+            line = self._readline()
+            if line:
+                buffered_lines.append((time.time(), line))
+            if buffered_lines:
+                #
+                # make sure we access self.positions in
+                # a threadsafe manner.
+                # This will NOT block:
+                # - If it can't write then it will leave
+                #   readings in buffered_lines.
+                # - If it can write then it will moved the
+                #   buffered_lines into self.positions
+                #   and clear the buffer.
+                #
+                if self.lock.acquire(blocking=False):
+                    try:
+                        self.lines += buffered_lines
+                        buffered_lines = []
+                    finally:
+                        self.lock.release()
+            time.sleep(0)  # give other threads time
+
+    def shutdown(self):
+        self.running = False
+        self._close()
+
+
+if __name__ == "__main__":
+    import sys
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--serial", type=str, required=True,
+                        help="Serial port address, like '/dev/tty.usbmodem1411'")
+    parser.add_argument("-b", "--baudrate", type=int, default=9600, help="Serial port baud rate.")
+    parser.add_argument("-t", "--timeout", type=float, default=0.5, help="Serial port timeout in seconds.")
+    parser.add_argument("-sp", '--samples', type=int, default=5, help="Number of samples per read cycle; 0 for unlimited.")
+    parser.add_argument("-th", "--threaded", action='store_true', help="run in threaded mode.")
+    parser.add_argument("-db", "--debug", action='store_true', help="Enable extra logging")
+    args = parser.parse_args()
+
+    if args.samples < 0:
+        print("Samples per read cycle, greater than zero OR zero for unlimited")
+        parser.print_help()
+        sys.exit(0)
+
+    if args.timeout <= 0:
+        print("Timeout must be greater than zero")
+        parser.print_help()
+        sys.exit(0)
+
+    update_thread = None
+    reader = None
+
+    try:
+        serial_port = SerialPort(args.serial, baudrate=args.baudrate, timeout=args.timeout)
+        line_reader = SerialLineReader(serial_port, max_lines=args.samples, debug=args.debug)
+
+        #
+        # start the threaded part
+        # and a threaded window to show plot
+        #
+        if args.threaded:
+            update_thread = threading.Thread(target=line_reader.update, args=())
+            update_thread.start()
+
+
+        def read_lines():
+            return line_reader.run_threaded() if args.threaded else line_reader.run()
+
+        while line_reader.running:
+            readings = read_lines()
+            if readings:
+                # just log the readings
+                for line in readings:
+                    print(line)
+    finally:
+        if line_reader:
+            line_reader.shutdown()
+        if update_thread is not None:
+            update_thread.join()  # wait for thread to end
+

--- a/donkeycar/parts/serial_port.py
+++ b/donkeycar/parts/serial_port.py
@@ -7,7 +7,7 @@ import time
 import donkeycar.utilities.dk_platform as dk_platform
 
 
-logger = logging.getLogger("donkeycar.utilities.serial_port")
+logger = logging.getLogger(__name__)
 
 
 class SerialPort:

--- a/donkeycar/parts/text_writer.py
+++ b/donkeycar/parts/text_writer.py
@@ -1,0 +1,125 @@
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class TextLogger:
+    """
+    Log data to a text file.
+    A 'row' ends up as one line of text when transformed by row_to_line().
+    The base implementation simply treats is as a text line, but subclasses
+    an overwrite row_to_line() and line_to_row() to save structured data,
+    like tuples or arrays as CSV.
+    """
+    def __init__(self, file_path:str, append:bool=False, allow_empty_file:bool=False, allow_empty_line:bool=True):
+        self.file_path = file_path
+        self.append = append
+        self.allow_empty_file = allow_empty_file
+        self.allow_empty_line = allow_empty_line
+        self.rows = []
+
+    def run(self, recording, rows):
+        if recording and len is not None and len(rows) > 0:
+            self.rows += rows
+        return self.rows
+
+    def length(self):
+        return len(self.rows)
+
+    def is_empty(self):
+        return 0 == self.length()
+
+    def is_loaded(self):
+        return not self.is_empty()
+
+    def get(self, row_index:int):
+        return self.rows[row_index] if (row_index >= 0) and (row_index < self.length()) else None
+
+    def reset(self):
+        self.rows = []
+        return True
+
+    def row_to_line(self, row):
+        """
+        convert a row into a string
+        """
+        if row is not None:
+            line = str(row)
+            if self.allow_empty_line or len(line) > 0:
+                return line
+        return None
+
+    def line_to_row(self, line:str):
+        """
+        convert a string into a row object
+        """
+        if isinstance(line, str):
+            line = line.rstrip('\n')
+            if self.allow_empty_line or len(line) > 0:
+                return line
+        return None
+
+    def save(self):
+        if self.is_loaded() or self.allow_empty_file:
+            with open(self.file_path, "a" if self.append else "w") as fp:
+                for row in self.rows:
+                    line = self.row_to_line(row)
+                    if line is not None:
+                        fp.write(self.row_to_line(row))
+                        fp.write('\n')
+            return True
+        return False
+
+    def load(self):
+        if os.path.exists(self.file_path):
+            rows = []
+            with open(self.file_path, "r") as file:
+                for line in file:
+                    row = self.line_to_row(line)
+                    if row is not None:
+                        rows.append(row)
+            if rows or self.allow_empty_file:
+                self.rows = rows
+                return True
+        return False
+
+
+class CsvLogger(TextLogger):
+    """
+    Log iterable to a comma-separated text file.
+    The separator can be customized.
+    """
+    def __init__(self, file_path:str, append:bool=False, allow_empty_file:bool=False, allow_empty_line:bool=True, separator:str=",", field_count:int=None, trim:bool=True):
+        super().__init__(file_path, append, allow_empty_file, allow_empty_line)
+        self.separator = separator
+        self.field_count = field_count
+        self.trim = trim
+
+    def row_to_line(self, row):
+        """
+        convert a row into a string
+        """
+        if row is not None:
+            line = self.separator.join([str(field) for field in row])
+            if self.allow_empty_line or len(line) > 0:
+                return line
+        return None
+
+    def line_to_row(self, line:str):
+        """
+        convert a string into a row object
+        """
+        row = None
+        if isinstance(line, str):
+            row = line.rstrip('\n').split(self.separator)
+            field_count = len(row)
+            if self.field_count is None or field_count == self.field_count:
+                if self.trim:
+                    row = [field.strip() for field in row]
+            else:
+                row = None
+                logger.debug(f"CsvLogger: dropping row with field count = {field_count}")
+        else:
+            logging.error("CsvLogger: line_to_row expected string")
+        return row

--- a/donkeycar/templates/cfg_path_follow.py
+++ b/donkeycar/templates/cfg_path_follow.py
@@ -1,5 +1,5 @@
-# """ 
-# My CAR CONFIG 
+"""
+PATH FOLLOWING: 'path_follow' template configurations
 
 # This file is read by your car application's manage.py script to change the car
 # performance
@@ -9,93 +9,660 @@
 # """
 
 import os
-# 
-# #PATHS
+
+
+import os
+
+#
+# FILE PATHS
+#
 CAR_PATH = PACKAGE_PATH = os.path.dirname(os.path.realpath(__file__))
 DATA_PATH = os.path.join(CAR_PATH, 'data')
 MODELS_PATH = os.path.join(CAR_PATH, 'models')
-# 
-# #VEHICLE
+
+
+#
+# VEHICLE loop
+#
 DRIVE_LOOP_HZ = 20      # the vehicle loop will pause if faster than this speed.
 MAX_LOOPS = None        # the vehicle loop can abort after this many iterations, when given a positive integer.
-# 
-
-#WEB CONTROL
-WEB_CONTROL_PORT = int(os.getenv("WEB_CONTROL_PORT", 8887))  # which port to listen on when making a web controller
-WEB_INIT_MODE = "user"              # which control mode to start in. one of user|local_angle|local. Setting local will start in ai mode.
 
 
-# #9865, over rides only if needed, ie. TX2..
+#
+# CAMERA configuration
+#
+CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|MOCK|IMAGE_LIST)
+IMAGE_W = 160
+IMAGE_H = 120
+IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
+CAMERA_FRAMERATE = DRIVE_LOOP_HZ
+CAMERA_VFLIP = False
+CAMERA_HFLIP = False
+CAMERA_INDEX = 0  # used for 'WEBCAM' and 'CVCAM' when there is more than one camera connected
+# For CSIC camera - If the camera is mounted in a rotated position, changing the below parameter will correct the output frame orientation
+CSIC_CAM_GSTREAMER_FLIP_PARM = 0 # (0 => none , 4 => Flip horizontally, 6 => Flip vertically)
+
+# For IMAGE_LIST camera
+PATH_MASK = "~/mycar/data/tub_1_20-03-12/*.jpg"
+
+
+#
+# PCA9685, over rides only if needed, ie. TX2..
+#
 PCA9685_I2C_ADDR = 0x40     #I2C address, use i2cdetect to validate this number
 PCA9685_I2C_BUSNUM = None   #None will auto detect, which is fine on the pi. But other platforms should specify the bus num.
-# 
-# #DRIVETRAIN is I2C_SERVO; PCA9685 outputs PWM to steering servo and ESC
-# #STEERING
-STEERING_CHANNEL = 1            #channel on the 9685 pwm board 0-15
+
+
+#
+# SSD1306_128_32
+#
+USE_SSD1306_128_32 = False    # Enable the SSD_1306 OLED Display
+SSD1306_128_32_I2C_ROTATION = 0 # 0 = text is right-side up, 1 = rotated 90 degrees clockwise, 2 = 180 degrees (flipped), 3 = 270 degrees
+SSD1306_RESOLUTION = 1 # 1 = 128x32; 2 = 128x64
+
+
+#
+# MEASURED ROBOT PROPERTIES
+#
+AXLE_LENGTH = 0.03     # length of axle; distance between left and right wheels in meters
+WHEEL_BASE = 0.1       # distance between front and back wheels in meters
+WHEEL_RADIUS = 0.0315  # radius of wheel in meters
+MIN_SPEED = 0.1        # minimum speed in meters per second; speed below which car stalls
+MAX_SPEED = 3.0        # maximum speed in meters per second; speed at maximum throttle (1.0)
+MIN_THROTTLE = 0.1     # throttle (0 to 1.0) that corresponds to MIN_SPEED, throttle below which car stalls
+MAX_STEERING_ANGLE = 3.141592653589793 / 4  # for car-like robot; maximum steering angle in radians (corresponding to tire angle at steering == -1)
+
+
+#
+# DRIVE_TRAIN_TYPE
+# These options specify which chasis and motor setup you are using.
+# See Actuators documentation https://docs.donkeycar.com/parts/actuators/
+# for a detailed explanation of each drive train type and it's configuration.
+# Choose one of the following and then update the related configuration section:
+#
+# "PWM_STEERING_THROTTLE" uses two PWM output pins to control a steering servo and an ESC, as in a standard RC car.
+# "MM1" Robo HAT MM1 board
+# "SERVO_HBRIDGE_2PIN" Servo for steering and HBridge motor driver in 2pin mode for motor
+# "SERVO_HBRIDGE_3PIN" Servo for steering and HBridge motor driver in 3pin mode for motor
+# "DC_STEER_THROTTLE" uses HBridge pwm to control one steering dc motor, and one drive wheel motor
+# "DC_TWO_WHEEL" uses HBridge in 2-pin mode to control two drive motors, one on the left, and one on the right.
+# "DC_TWO_WHEEL_L298N" using HBridge in 3-pin mode to control two drive motors, one of the left and one on the right.
+# "MOCK" no drive train.  This can be used to test other features in a test rig.
+# (deprecated) "SERVO_HBRIDGE_PWM" use ServoBlaster to output pwm control from the PiZero directly to control steering,
+#                                  and HBridge for a drive motor.
+# (deprecated) "PIGPIO_PWM" uses Raspberrys internal PWM
+# (deprecated) "I2C_SERVO" uses PCA9685 servo controller to control a steering servo and an ESC, as in a standard RC car
+#
+DRIVE_TRAIN_TYPE = "PWM_STEERING_THROTTLE"
+
+#
+# PWM_STEERING_THROTTLE drivetrain configuration
+#
+# Drive train for RC car with a steering servo and ESC.
+# Uses a PwmPin for steering (servo) and a second PwmPin for throttle (ESC)
+# Base PWM Frequence is presumed to be 60hz; use PWM_xxxx_SCALE to adjust pulse with for non-standard PWM frequencies
+#
+PWM_STEERING_THROTTLE = {
+    "PWM_STEERING_PIN": "PCA9685.1:40.1",   # PWM output pin for steering servo
+    "PWM_STEERING_SCALE": 1.0,              # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
+    "PWM_STEERING_INVERTED": False,         # True if hardware requires an inverted PWM pulse
+    "PWM_THROTTLE_PIN": "PCA9685.1:40.0",   # PWM output pin for ESC
+    "PWM_THROTTLE_SCALE": 1.0,              # used to compensate for PWM frequence differences from 60hz; NOT for increasing/limiting speed
+    "PWM_THROTTLE_INVERTED": False,         # True if hardware requires an inverted PWM pulse
+    "STEERING_LEFT_PWM": 460,               #pwm value for full left steering
+    "STEERING_RIGHT_PWM": 290,              #pwm value for full right steering
+    "THROTTLE_FORWARD_PWM": 500,            #pwm value for max forward throttle
+    "THROTTLE_STOPPED_PWM": 370,            #pwm value for no movement
+    "THROTTLE_REVERSE_PWM": 220,            #pwm value for max reverse throttle
+}
+
+#
+# I2C_SERVO (deprecated in favor of PWM_STEERING_THROTTLE)
+#
+STEERING_CHANNEL = 1            #(deprecated) channel on the 9685 pwm board 0-15
 STEERING_LEFT_PWM = 460         #pwm value for full left steering
-STEERING_RIGHT_PWM = 340        #pwm value for full right steering
-# 
-# #THROTTLE
-THROTTLE_CHANNEL = 0            #channel on the 9685 pwm board 0-15
-THROTTLE_FORWARD_PWM = 400       #pwm value for auto mode throttle
+STEERING_RIGHT_PWM = 290        #pwm value for full right steering
+THROTTLE_CHANNEL = 0            #(deprecated) channel on the 9685 pwm board 0-15
+THROTTLE_FORWARD_PWM = 500      #pwm value for max forward throttle
 THROTTLE_STOPPED_PWM = 370      #pwm value for no movement
 THROTTLE_REVERSE_PWM = 220      #pwm value for max reverse throttle
 
 #
-# 
-# 
-# #JOYSTICK
+# PIGPIO_PWM (deprecated in favor of PWM_STEERING_THROTTLE)
+#
+STEERING_PWM_PIN = 13           #(deprecated) Pin numbering according to Broadcom numbers
+STEERING_PWM_FREQ = 50          #Frequency for PWM
+STEERING_PWM_INVERTED = False   #If PWM needs to be inverted
+THROTTLE_PWM_PIN = 18           #(deprecated) Pin numbering according to Broadcom numbers
+THROTTLE_PWM_FREQ = 50          #Frequency for PWM
+THROTTLE_PWM_INVERTED = False   #If PWM needs to be inverted
+
+#
+# SERVO_HBRIDGE_2PIN drivetrain configuration
+# - configures a steering servo and an HBridge in 2pin mode (2 pwm pins)
+# - Servo takes a standard servo PWM pulse between 1 millisecond (fully reverse)
+#   and 2 milliseconds (full forward) with 1.5ms being neutral.
+# - the motor is controlled by two pwm pins,
+#   one for forward and one for backward (reverse).
+# - the pwm pin produces a duty cycle from 0 (completely LOW)
+#   to 1 (100% completely high), which is proportional to the
+#   amount of power delivered to the motor.
+# - in forward mode, the reverse pwm is 0 duty_cycle,
+#   in backward mode, the forward pwm is 0 duty cycle.
+# - both pwms are 0 duty cycle (LOW) to 'detach' motor and
+#   and glide to a stop.
+# - both pwms are full duty cycle (100% HIGH) to brake
+#
+# Pin specifier string format:
+# - use RPI_GPIO for RPi/Nano header pin output
+#   - use BOARD for board pin numbering
+#   - use BCM for Broadcom GPIO numbering
+#   - for example "RPI_GPIO.BOARD.18"
+# - use PIPGIO for RPi header pin output using pigpio server
+#   - must use BCM (broadcom) pin numbering scheme
+#   - for example, "PIGPIO.BCM.13"
+# - use PCA9685 for PCA9685 pin output
+#   - include colon separated I2C channel and address
+#   - for example "PCA9685.1:40.13"
+# - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
+#   although it is discouraged to mix RPI_GPIO and PIGPIO.
+#
+SERVO_HBRIDGE_2PIN = {
+    "FWD_DUTY_PIN": "RPI_GPIO.BOARD.18",  # provides forward duty cycle to motor
+    "BWD_DUTY_PIN": "RPI_GPIO.BOARD.16",  # provides reverse duty cycle to motor
+    "PWM_STEERING_PIN": "RPI_GPIO.BOARD.33",       # provides servo pulse to steering servo
+    "PWM_STEERING_SCALE": 1.0,        # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
+    "PWM_STEERING_INVERTED": False,   # True if hardware requires an inverted PWM pulse
+    "STEERING_LEFT_PWM": 460,         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+    "STEERING_RIGHT_PWM": 290,        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+}
+
+#
+# SERVO_HBRIDGE_3PIN drivetrain configuration
+# - configures a steering servo and an HBridge in 3pin mode (2 ttl pins, 1 pwm pin)
+# - Servo takes a standard servo PWM pulse between 1 millisecond (fully reverse)
+#   and 2 milliseconds (full forward) with 1.5ms being neutral.
+# - the motor is controlled by three pins,
+#   one ttl output for forward, one ttl output
+#   for backward (reverse) enable and one pwm pin
+#   for motor power.
+# - the pwm pin produces a duty cycle from 0 (completely LOW)
+#   to 1 (100% completely high), which is proportional to the
+#   amount of power delivered to the motor.
+# - in forward mode, the forward pin  is HIGH and the
+#   backward pin is LOW,
+# - in backward mode, the forward pin is LOW and the
+#   backward pin is HIGH.
+# - both forward and backward pins are LOW to 'detach' motor
+#   and glide to a stop.
+# - both forward and backward pins are HIGH to brake
+#
+# Pin specifier string format:
+# - use RPI_GPIO for RPi/Nano header pin output
+#   - use BOARD for board pin numbering
+#   - use BCM for Broadcom GPIO numbering
+#   - for example "RPI_GPIO.BOARD.18"
+# - use PIPGIO for RPi header pin output using pigpio server
+#   - must use BCM (broadcom) pin numbering scheme
+#   - for example, "PIGPIO.BCM.13"
+# - use PCA9685 for PCA9685 pin output
+#   - include colon separated I2C channel and address
+#   - for example "PCA9685.1:40.13"
+# - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
+#   although it is discouraged to mix RPI_GPIO and PIGPIO.
+#
+SERVO_HBRIDGE_3PIN = {
+    "FWD_PIN": "RPI_GPIO.BOARD.18",   # ttl pin, high enables motor forward
+    "BWD_PIN": "RPI_GPIO.BOARD.16",   # ttl pin, high enables motor reverse
+    "DUTY_PIN": "RPI_GPIO.BOARD.35",  # provides duty cycle to motor
+    "PWM_STEERING_PIN": "RPI_GPIO.BOARD.33",   # provides servo pulse to steering servo
+    "PWM_STEERING_SCALE": 1.0,        # used to compensate for PWM frequency differents from 60hz; NOT for adjusting steering range
+    "PWM_STEERING_INVERTED": False,   # True if hardware requires an inverted PWM pulse
+    "STEERING_LEFT_PWM": 460,         # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+    "STEERING_RIGHT_PWM": 290,        # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+}
+
+#
+# DRIVETRAIN_TYPE == "SERVO_HBRIDGE_PWM" (deprecated in favor of SERVO_HBRIDGE_2PIN)
+# - configures a steering servo and an HBridge in 2pin mode (2 pwm pins)
+# - Uses ServoBlaster library, which is NOT installed by default, so
+#   you will need to install it to make this work.
+# - Servo takes a standard servo PWM pulse between 1 millisecond (fully reverse)
+#   and 2 milliseconds (full forward) with 1.5ms being neutral.
+# - the motor is controlled by two pwm pins,
+#   one for forward and one for backward (reverse).
+# - the pwm pins produce a duty cycle from 0 (completely LOW)
+#   to 1 (100% completely high), which is proportional to the
+#   amount of power delivered to the motor.
+# - in forward mode, the reverse pwm is 0 duty_cycle,
+#   in backward mode, the forward pwm is 0 duty cycle.
+# - both pwms are 0 duty cycle (LOW) to 'detach' motor and
+#   and glide to a stop.
+# - both pwms are full duty cycle (100% HIGH) to brake
+#
+HBRIDGE_PIN_FWD = 18       # provides forward duty cycle to motor
+HBRIDGE_PIN_BWD = 16       # provides reverse duty cycle to motor
+STEERING_CHANNEL = 0       # PCA 9685 channel for steering control
+STEERING_LEFT_PWM = 460    # pwm value for full left steering (use `donkey calibrate` to measure value for your car)
+STEERING_RIGHT_PWM = 290   # pwm value for full right steering (use `donkey calibrate` to measure value for your car)
+
+#
+# DC_STEER_THROTTLE drivetrain with one motor as steering, one as drive
+# - uses L298N type motor controller in two pin wiring
+#   scheme utilizing two pwm pins per motor; one for
+#   forward(or right) and one for reverse (or left)
+#
+# GPIO pin configuration for the DRIVE_TRAIN_TYPE=DC_STEER_THROTTLE
+# - use RPI_GPIO for RPi/Nano header pin output
+#   - use BOARD for board pin numbering
+#   - use BCM for Broadcom GPIO numbering
+#   - for example "RPI_GPIO.BOARD.18"
+# - use PIPGIO for RPi header pin output using pigpio server
+#   - must use BCM (broadcom) pin numbering scheme
+#   - for example, "PIGPIO.BCM.13"
+# - use PCA9685 for PCA9685 pin output
+#   - include colon separated I2C channel and address
+#   - for example "PCA9685.1:40.13"
+# - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
+#   although it is discouraged to mix RPI_GPIO and PIGPIO.
+#
+DC_STEER_THROTTLE = {
+    "LEFT_DUTY_PIN": "RPI_GPIO.BOARD.18",   # pwm pin produces duty cycle for steering left
+    "RIGHT_DUTY_PIN": "RPI_GPIO.BOARD.16",  # pwm pin produces duty cycle for steering right
+    "FWD_DUTY_PIN": "RPI_GPIO.BOARD.15",    # pwm pin produces duty cycle for forward drive
+    "BWD_DUTY_PIN": "RPI_GPIO.BOARD.13",    # pwm pin produces duty cycle for reverse drive
+}
+
+#
+# DC_TWO_WHEEL drivetrain pin configuration
+# - configures L298N_HBridge_2pin driver
+# - two wheels as differential drive, left and right.
+# - each wheel is controlled by two pwm pins,
+#   one for forward and one for backward (reverse).
+# - each pwm pin produces a duty cycle from 0 (completely LOW)
+#   to 1 (100% completely high), which is proportional to the
+#   amount of power delivered to the motor.
+# - in forward mode, the reverse pwm is 0 duty_cycle,
+#   in backward mode, the forward pwm is 0 duty cycle.
+# - both pwms are 0 duty cycle (LOW) to 'detach' motor and
+#   and glide to a stop.
+# - both pwms are full duty cycle (100% HIGH) to brake
+#
+# Pin specifier string format:
+# - use RPI_GPIO for RPi/Nano header pin output
+#   - use BOARD for board pin numbering
+#   - use BCM for Broadcom GPIO numbering
+#   - for example "RPI_GPIO.BOARD.18"
+# - use PIPGIO for RPi header pin output using pigpio server
+#   - must use BCM (broadcom) pin numbering scheme
+#   - for example, "PIGPIO.BCM.13"
+# - use PCA9685 for PCA9685 pin output
+#   - include colon separated I2C channel and address
+#   - for example "PCA9685.1:40.13"
+# - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
+#   although it is discouraged to mix RPI_GPIO and PIGPIO.
+#
+DC_TWO_WHEEL = {
+    "LEFT_FWD_DUTY_PIN": "RPI_GPIO.BOARD.18",  # pwm pin produces duty cycle for left wheel forward
+    "LEFT_BWD_DUTY_PIN": "RPI_GPIO.BOARD.16",  # pwm pin produces duty cycle for left wheel reverse
+    "RIGHT_FWD_DUTY_PIN": "RPI_GPIO.BOARD.15", # pwm pin produces duty cycle for right wheel forward
+    "RIGHT_BWD_DUTY_PIN": "RPI_GPIO.BOARD.13", # pwm pin produces duty cycle for right wheel reverse
+}
+
+#
+# DC_TWO_WHEEL_L298N drivetrain pin configuration
+# - configures L298N_HBridge_3pin driver
+# - two wheels as differential drive, left and right.
+# - each wheel is controlled by three pins,
+#   one ttl output for forward, one ttl output
+#   for backward (reverse) enable and one pwm pin
+#   for motor power.
+# - the pwm pin produces a duty cycle from 0 (completely LOW)
+#   to 1 (100% completely high), which is proportional to the
+#   amount of power delivered to the motor.
+# - in forward mode, the forward pin  is HIGH and the
+#   backward pin is LOW,
+# - in backward mode, the forward pin is LOW and the
+#   backward pin is HIGH.
+# - both forward and backward pins are LOW to 'detach' motor
+#   and glide to a stop.
+# - both forward and backward pins are HIGH to brake
+#
+# GPIO pin configuration for the DRIVE_TRAIN_TYPE=DC_TWO_WHEEL_L298N
+# - use RPI_GPIO for RPi/Nano header pin output
+#   - use BOARD for board pin numbering
+#   - use BCM for Broadcom GPIO numbering
+#   - for example "RPI_GPIO.BOARD.18"
+# - use PIPGIO for RPi header pin output using pigpio server
+#   - must use BCM (broadcom) pin numbering scheme
+#   - for example, "PIGPIO.BCM.13"
+# - use PCA9685 for PCA9685 pin output
+#   - include colon separated I2C channel and address
+#   - for example "PCA9685.1:40.13"
+# - RPI_GPIO, PIGPIO and PCA9685 can be mixed arbitrarily,
+#   although it is discouraged to mix RPI_GPIO and PIGPIO.
+#
+DC_TWO_WHEEL_L298N = {
+    "LEFT_FWD_PIN": "RPI_GPIO.BOARD.16",        # TTL output pin enables left wheel forward
+    "LEFT_BWD_PIN": "RPI_GPIO.BOARD.18",        # TTL output pin enables left wheel reverse
+    "LEFT_EN_DUTY_PIN": "RPI_GPIO.BOARD.22",    # PWM pin generates duty cycle for left motor speed
+
+    "RIGHT_FWD_PIN": "RPI_GPIO.BOARD.15",       # TTL output pin enables right wheel forward
+    "RIGHT_BWD_PIN": "RPI_GPIO.BOARD.13",       # TTL output pin enables right wheel reverse
+    "RIGHT_EN_DUTY_PIN": "RPI_GPIO.BOARD.11",   # PWM pin generates duty cycle for right wheel speed
+}
+
+
+#
+# ODOMETRY
+#
+HAVE_ODOM = False               # Do you have an odometer/encoder
+HAVE_ODOM_2 = False             # Do you have a second odometer/encoder as in a differential drive robot.
+                                # In this case, the 'first' encoder is the left wheel encoder and
+                                # the second encoder is the right wheel encoder.
+ENCODER_TYPE = 'GPIO'           # What kind of encoder? GPIO|arduino.
+                                # - 'GPIO' refers to direct connect of a single-channel encoder to an RPi/Jetson GPIO header pin.
+                                #   Set ODOM_PIN to the gpio pin, based on board numbering.
+                                # - 'arduino' generically refers to any microcontroller connected over a serial port.
+                                #   Set ODOM_SERIAL to the serial port that connects the microcontroller.
+                                #   See 'arduino/encoder/encoder.ino' for an Arduino sketch that implements both a continuous and
+                                #    on demand protocol for sending readings from the microcontroller to the host.
+ENCODER_PPR = 20                # encoder's pulses (ticks) per revolution of encoder shaft.
+ENCODER_DEBOUNCE_NS = 0         # nanoseconds to wait before integrating subsequence encoder pulses.
+                                # For encoders with noisy transitions, this can be used to reject extra interrupts caused by noise.
+                                # If necessary, the exact value can be determined using an oscilliscope or logic analyzer or
+                                # simply by experimenting with various values.
+FORWARD_ONLY = 1
+FORWARD_REVERSE = 2
+FORWARD_REVERSE_STOP = 3
+TACHOMETER_MODE=FORWARD_REVERSE # FORWARD_ONLY, FORWARD_REVERSE or FORWARD_REVERSE_STOP
+                                # For dual channel quadrature encoders, 'FORWARD_ONLY' is always the correct mode.
+                                # For single-channel encoders, the tachometer mode depends upon the application.
+                                # - FORWARD_ONLY always increments ticks; effectively assuming the car is always moving forward
+                                #   and always has a positive throttle. This is best for racing on wide open circuits where
+                                #   the car is always under throttle and where we are not trying to model driving backwards or stopping.
+                                # - FORWARD_REVERSE uses the throttle value to decide if the car is moving forward or reverse
+                                #   increments or decrements ticks accordingly.  In the case of a zero throttle, ticks will be
+                                #   incremented or decremented based on the last non-zero throttle; effectively modelling 'coasting'.
+                                #   This can work well in situations where the car will be making progress even when the throttle
+                                #   drops to zero.  For instance, in a race situatino where the car may coast to slow down but not
+                                #   actually stop.
+                                # - FORWARD_REVERSE_STOP uses the throttle value to decide if the car is moving forward or reverse or stopped.
+                                #   This works well for a slower moving robot in situations where the robot is changing direction; for instance4
+                                #   when doing SLAM, the robot will explore the room slowly and may need to backup.
+MM_PER_TICK = WHEEL_RADIUS * 2 * 3.141592653589793 * 1000 / ENCODER_PPR           # How much travel with a single encoder tick, in mm. Roll you car a meter and divide total ticks measured by 1,000
+ODOM_SERIAL = '/dev/ttyACM0'    # serial port when ENCODER_TYPE is 'arduino'
+ODOM_SERIAL_BAUDRATE = 115200   # baud rate for serial port encoder
+ODOM_PIN = 13                   # if using ENCODER_TYPE=GPIO, which GPIO board mode pin to use as input
+ODOM_PIN_2 = 14                 # GPIO for second encoder in differential drivetrains
+ODOM_SMOOTHING = 1              # number of odometer readings to use when calculating velocity
+ODOM_DEBUG = False              # Write out values on vel and distance as it runs
+
+
+#
+# LIDAR
+#
+USE_LIDAR = False
+LIDAR_TYPE = 'RP' #(RP) NOTE: YD lidar is not full implemented
+LIDAR_LOWER_LIMIT = 90 # angles that will be recorded. Use this to block out obstructed areas on your car, or looking backwards. Note that for the RP A1M8 Lidar, "0" is in the direction of the motor
+LIDAR_UPPER_LIMIT = 270
+
+
+# IMU for imu model
+HAVE_IMU = False                #when true, this add a Mpu6050 part and records the data. Can be used with a
+IMU_SENSOR = 'mpu6050'          # (mpu6050|mpu9250)
+IMU_DLP_CONFIG = 0              # Digital Lowpass Filter setting (0:250Hz, 1:184Hz, 2:92Hz, 3:41Hz, 4:20Hz, 5:10Hz, 6:5Hz)
+
+
+#
+# Input controllers
+#
+#WEB CONTROL
+WEB_CONTROL_PORT = int(os.getenv("WEB_CONTROL_PORT", 8887))  # which port to listen on when making a web controller
+WEB_INIT_MODE = "user"              # which control mode to start in. one of user|local_angle|local. Setting local will start in ai mode.
+
+#JOYSTICK
 USE_JOYSTICK_AS_DEFAULT = False      #when starting the manage.py, when True, will not require a --js option to use the joystick
 JOYSTICK_MAX_THROTTLE = 0.5         #this scalar is multiplied with the -1 to 1 throttle value to limit the maximum throttle. This can help if you drop the controller or just don't need the full speed available.
 JOYSTICK_STEERING_SCALE = 1.0       #some people want a steering that is less sensitve. This scalar is multiplied with the steering -1 to 1. It can be negative to reverse dir.
-AUTO_RECORD_ON_THROTTLE = True      #if true, we will record whenever throttle is not zero. if false, you must manually toggle recording with some other trigger. Usually circle button on joystick.
-CONTROLLER_TYPE='ps4'               #(ps3|ps4|xbox|nimbus|wiiu|F710|rc3)
+AUTO_RECORD_ON_THROTTLE = False     #if true, we will record whenever throttle is not zero. if false, you must manually toggle recording with some other trigger. Usually circle button on joystick.
+CONTROLLER_TYPE = 'xbox'            #(ps3|ps4|xbox|pigpio_rc|nimbus|wiiu|F710|rc3|MM1|custom) custom will run the my_joystick.py controller written by the `donkey createjs` command
 USE_NETWORKED_JS = False            #should we listen for remote joystick control over the network?
-NETWORK_JS_SERVER_IP = "192.168.0.1"#when listening for network joystick control, which ip is serving this information
-JOYSTICK_DEADZONE = 0.0             # when non zero, this is the smallest throttle before recording triggered.
-JOYSTICK_THROTTLE_DIR = -1.0        # use -1.0 to flip forward/backward, use 1.0 to use joystick's natural forward/backward
-JOYSTICK_DEVICE_FILE = "/dev/input/js0" # this is the unix file use to access the joystick.
+NETWORK_JS_SERVER_IP = None         #when listening for network joystick control, which ip is serving this information
+JOYSTICK_DEADZONE = 0.01            # when non zero, this is the smallest throttle before recording triggered.
+JOYSTICK_THROTTLE_DIR = -1.0         # use -1.0 to flip forward/backward, use 1.0 to use joystick's natural forward/backward
 USE_FPV = False                     # send camera data to FPV webserver
+JOYSTICK_DEVICE_FILE = "/dev/input/js0" # this is the unix file use to access the joystick.
 
-# 
-# 
-# #SOMBRERO
-HAVE_SOMBRERO = False               #set to true when using the sombrero hat from the Donkeycar store. This will enable pwm on the hat.
-# 
-# 
-#Path following
-PATH_FILENAME = "donkey_path.pkl"   # the path will be saved to this filename
+
+#SOMBRERO
+HAVE_SOMBRERO = False           #set to true when using the sombrero hat from the Donkeycar store. This will enable pwm on the hat.
+
+#PIGPIO RC control
+STEERING_RC_GPIO = 26
+THROTTLE_RC_GPIO = 20
+DATA_WIPER_RC_GPIO = 19
+PIGPIO_STEERING_MID = 1500         # Adjust this value if your car cannot run in a straight line
+PIGPIO_MAX_FORWARD = 2000          # Max throttle to go fowrward. The bigger the faster
+PIGPIO_STOPPED_PWM = 1500
+PIGPIO_MAX_REVERSE = 1000          # Max throttle to go reverse. The smaller the faster
+PIGPIO_SHOW_STEERING_VALUE = False
+PIGPIO_INVERT = False
+PIGPIO_JITTER = 0.025   # threshold below which no signal is reported
+
+
+# ROBOHAT MM1 controller
+MM1_STEERING_MID = 1500         # Adjust this value if your car cannot run in a straight line
+MM1_MAX_FORWARD = 2000          # Max throttle to go fowrward. The bigger the faster
+MM1_STOPPED_PWM = 1500
+MM1_MAX_REVERSE = 1000          # Max throttle to go reverse. The smaller the faster
+MM1_SHOW_STEERING_VALUE = False
+# Serial port
+# -- Default Pi: '/dev/ttyS0'
+# -- Jetson Nano: '/dev/ttyTHS1'
+# -- Google coral: '/dev/ttymxc0'
+# -- Windows: 'COM3', Arduino: '/dev/ttyACM0'
+# -- MacOS/Linux:please use 'ls /dev/tty.*' to find the correct serial port for mm1
+#  eg.'/dev/tty.usbmodemXXXXXX' and replace the port accordingly
+MM1_SERIAL_PORT = '/dev/ttyS0'  # Serial Port for reading and sending MM1 data.
+
+
+#
+# LOGGING
+#
+HAVE_CONSOLE_LOGGING = True
+LOGGING_LEVEL = 'INFO'          # (Python logging level) 'NOTSET' / 'DEBUG' / 'INFO' / 'WARNING' / 'ERROR' / 'FATAL' / 'CRITICAL'
+LOGGING_FORMAT = '%(message)s'  # (Python logging format - https://docs.python.org/3/library/logging.html#formatter-objects
+
+
+#
+# MQTT TELEMETRY
+#
+HAVE_MQTT_TELEMETRY = False
+TELEMETRY_DONKEY_NAME = 'my_robot1234'
+TELEMETRY_MQTT_TOPIC_TEMPLATE = 'donkey/%s/telemetry'
+TELEMETRY_MQTT_JSON_ENABLE = False
+TELEMETRY_MQTT_BROKER_HOST = 'broker.hivemq.com'
+TELEMETRY_MQTT_BROKER_PORT = 1883
+TELEMETRY_PUBLISH_PERIOD = 1
+TELEMETRY_LOGGING_ENABLE = True
+TELEMETRY_LOGGING_LEVEL = 'INFO' # (Python logging level) 'NOTSET' / 'DEBUG' / 'INFO' / 'WARNING' / 'ERROR' / 'FATAL' / 'CRITICAL'
+TELEMETRY_LOGGING_FORMAT = '%(message)s'  # (Python logging format - https://docs.python.org/3/library/logging.html#formatter-objects
+TELEMETRY_DEFAULT_INPUTS = 'pilot/angle,pilot/throttle,recording'
+TELEMETRY_DEFAULT_TYPES = 'float,float'
+
+
+#
+# PERFORMANCE MONITOR
+#
+HAVE_PERFMON = False
+
+
+#
+# RECORD OPTIONS
+#
+RECORD_DURING_AI = False        #normally we do not record during ai mode. Set this to true to get image and steering records for your Ai. Be careful not to use them to train.
+AUTO_CREATE_NEW_TUB = False     #create a new tub (tub_YY_MM_DD) directory when recording or append records to data directory directly
+
+
+#
+# LED
+#
+HAVE_RGB_LED = False            #do you have an RGB LED like https://www.amazon.com/dp/B07BNRZWNF
+LED_INVERT = False              #COMMON ANODE? Some RGB LED use common anode. like https://www.amazon.com/Xia-Fly-Tri-Color-Emitting-Diffused/dp/B07MYJQP8B
+
+#LED board pin number for pwm outputs
+#These are physical pinouts. See: https://www.raspberrypi-spy.co.uk/2012/06/simple-guide-to-the-rpi-gpio-header-and-pins/
+LED_PIN_R = 12
+LED_PIN_G = 10
+LED_PIN_B = 16
+
+#LED status color, 0-100
+LED_R = 0
+LED_G = 0
+LED_B = 1
+
+#LED Color for record count indicator
+REC_COUNT_ALERT = 1000          #how many records before blinking alert
+REC_COUNT_ALERT_CYC = 15        #how many cycles of 1/20 of a second to blink per REC_COUNT_ALERT records
+REC_COUNT_ALERT_BLINK_RATE = 0.4 #how fast to blink the led in seconds on/off
+
+#first number is record count, second tuple is color ( r, g, b) (0-100)
+#when record count exceeds that number, the color will be used
+RECORD_ALERT_COLOR_ARR = [ (0, (1, 1, 1)),
+            (3000, (5, 5, 5)),
+            (5000, (5, 2, 0)),
+            (10000, (0, 5, 0)),
+            (15000, (0, 5, 5)),
+            (20000, (0, 0, 5)), ]
+
+#LED status color, 0-100, for model reloaded alert
+MODEL_RELOADED_LED_R = 100
+MODEL_RELOADED_LED_G = 0
+MODEL_RELOADED_LED_B = 0
+
+
+#
+# DonkeyGym
+#
+# Only on Ubuntu linux, you can use the simulator as a virtual donkey and
+# issue the same python manage.py drive command as usual, but have them control a virtual car.
+# This enables that, and sets the path to the simualator and the environment.
+# You will want to download the simulator binary from: https://github.com/tawnkramer/donkey_gym/releases/download/v18.9/DonkeySimLinux.zip
+# then extract that and modify DONKEY_SIM_PATH.
+DONKEY_GYM = False
+DONKEY_SIM_PATH = "path to sim" #"/home/tkramer/projects/sdsandbox/sdsim/build/DonkeySimLinux/donkey_sim.x86_64" when racing on virtual-race-league use "remote", or user "remote" when you want to start the sim manually first.
+DONKEY_GYM_ENV_NAME = "donkey-generated-track-v0" # ("donkey-generated-track-v0"|"donkey-generated-roads-v0"|"donkey-warehouse-v0"|"donkey-avc-sparkfun-v0")
+GYM_CONF = { "body_style" : "donkey", "body_rgb" : (128, 128, 128), "car_name" : "car", "font_size" : 100} # body style(donkey|bare|car01) body rgb 0-255
+GYM_CONF["racer_name"] = "Your Name"
+GYM_CONF["country"] = "Place"
+GYM_CONF["bio"] = "I race robots."
+
+SIM_HOST = "127.0.0.1"              # when racing on virtual-race-league use host "trainmydonkey.com"
+SIM_ARTIFICIAL_LATENCY = 0          # this is the millisecond latency in controls. Can use useful in emulating the delay when useing a remote server. values of 100 to 400 probably reasonable.
+
+# Save info from Simulator (pln)
+SIM_RECORD_LOCATION = False
+SIM_RECORD_GYROACCEL= False
+SIM_RECORD_VELOCITY = False
+SIM_RECORD_LIDAR = False
+
+# publish camera over network on TCP socket
+# This is used to create a tcp service to publish the camera feed
+PUB_CAMERA_IMAGES = False
+
+
+#
+# AI Overrides
+#
+# Launch mode: override AI at launch time (transition from user to Auto pilot).
+AI_LAUNCH_DURATION = 0.0            # the ai will output throttle for this many seconds
+AI_LAUNCH_THROTTLE = 0.0            # the ai will output this throttle value
+AI_LAUNCH_ENABLE_BUTTON = 'R2'      # this keypress will enable this boost. It must be enabled before each use to prevent accidental trigger.
+AI_LAUNCH_KEEP_ENABLED = False      # when False ( default) you will need to hit the AI_LAUNCH_ENABLE_BUTTON for each use. This is safest. When this True, is active on each trip into "local" ai mode.
+
+# throttle scaling: scale the output of the throttle of the ai pilot for all model types.
+AI_THROTTLE_MULT = 1.0              # this multiplier will scale every throttle value for all output from NN models
+
+
+#
+# Intel Realsense D435 and D435i depth sensing camera
+#
+REALSENSE_D435_RGB = True       # True to capture RGB image
+REALSENSE_D435_DEPTH = True     # True to capture depth as image array
+REALSENSE_D435_IMU = False      # True to capture IMU data (D435i only)
+REALSENSE_D435_ID = None        # serial number of camera or None if you only have one camera (it will autodetect)
+
+
+#
+# Stop Sign Detector
+#
+STOP_SIGN_DETECTOR = False
+STOP_SIGN_MIN_SCORE = 0.2
+STOP_SIGN_SHOW_BOUNDING_BOX = True
+STOP_SIGN_MAX_REVERSE_COUNT = 10    # How many times should the car reverse when detected a stop sign, set to 0 to disable reversing
+STOP_SIGN_REVERSE_THROTTLE = -0.5     # Throttle during reversing when detected a stop sign
+
+
+#
+# Frames/Second counter
+#
+SHOW_FPS = False
+FPS_DEBUG_INTERVAL = 10    # the interval in seconds for printing the frequency info into the shell
+
+#
+# TRACKING camera
+#
+HAVE_T265 = False       # True to use Intel Realsense T265 as a source of pose
+
+#
+# gps
+#
+HAVE_GPS = False            # True to read gps position
+GPS_SERIAL = '/dev/ttyUSB0' # serial device path, like '/dev/ttyAMA1' or '/dev/ttyUSB0'
+GPS_SERIAL_BAUDRATE = 115200
+GPS_NMEA_PATH = None        # File used to record gps, like "nmea.csv".
+                            # If this is set then when waypoints are recorded then
+                            # the underlying NMEA sentences will also be saved to
+                            # this file along with their time stamps.  Then when
+                            # the path is loaded and played in auto-pilot mode then
+                            # the NMEA sentences that were recorded will be played back.
+                            # This is for debugging and tuning the PID without having
+                            # to keep driving the car.
+GPS_DEBUG = False  # set to True to log UTM position (beware; lots of logging!)
+
+#
+# PATH FOLLOWING
+#
+PATH_FILENAME = "donkey_path.csv"   # the path will be saved to this filename as comma separated x,y values
+PATH_DEBUG = True                   # True to log x,y position
 PATH_SCALE = 10.0                   # the path display will be scaled by this factor in the web page
 PATH_OFFSET = (255, 255)            # 255, 255 is the center of the map. This offset controls where the origin is displayed.
 PATH_MIN_DIST = 0.2                 # after travelling this distance (m), save a path point
 PID_P = -0.5                        # proportional mult for PID path follower
 PID_I = 0.000                       # integral mult for PID path follower
-PID_D = -0.3                       # differential mult for PID path follower
-PID_THROTTLE = 0.30                 # constant throttle value during path following
+PID_D = -0.3                        # differential mult for PID path follower
+PID_THROTTLE = 0.50                 # constant throttle value during path following
+PID_D_DELTA = 0.25                  # amount the inc/dec function will change the D value
+PID_P_DELTA = 0.25                  # amount the inc/dec function will change the P value
 
-# the cross button is already reserved for the emergency stop
-SAVE_PATH_BTN = "circle"             # joystick button to save path
-RESET_ORIGIN_BTN = "square"       # joystick button to press to move car back to origin
-ERASE_PATH_BTN = "triangle"     # joystick button to erase path
+#
+# Assign path follow functions to buttons.
+# You can use game pad buttons OR web ui buttons ('web/w1' to 'web/w5')
+# Use None use the game controller default
+# NOTE: the cross button is already reserved for the emergency stop
+#
+SAVE_PATH_BTN = "circle"        # button to save path
+LOAD_PATH_BTN = "x"             # button (re)load path
+RESET_ORIGIN_BTN = "square"     # button to press to move car back to origin
+ERASE_PATH_BTN = "triangle"     # button to erase path
+TOGGLE_RECORDING_BTN = "option" # button to toggle recording mode
+INC_PID_D_BTN = None            # button to change PID 'D' constant by PID_D_DELTA
+DEC_PID_D_BTN = None            # button to change PID 'D' constant by -PID_D_DELTA
+INC_PID_P_BTN = "R2"            # button to change PID 'P' constant by PID_P_DELTA
+DEC_PID_P_BTN = "L2"            # button to change PID 'P' constant by -PID_P_DELTA
 
-
-
-# 
-# #Odometry
-HAVE_ODOM = False                   # Do you have an odometer? Uses pigpio 
-MM_PER_TICK = 12.7625               # How much travel with a single tick, in mm
-ODOM_PIN = 4                        # Which GPIO board mode pin to use as input
-ODOM_DEBUG = False                  # Write out values on vel and distance as it runs
-# 
-# #Intel T265
+# Intel Realsense T265 tracking camera
+REALSENSE_T265_ID = None # serial number of camera or None if you only have one camera (it will autodetect)
 WHEEL_ODOM_CALIB = "calibration_odometry.json"
-# 
-# #DonkeyGym
-# #Only on Ubuntu linux, you can use the simulator as a virtual donkey and
-# #issue the same python manage.py drive command as usual, but have them control a virtual car.
-# #This enables that, and sets the path to the simualator and the environment.
-# #You will want to download the simulator binary from: https://github.com/tawnkramer/donkey_gym/releases/download/v18.9/DonkeySimLinux.zip
-# #then extract that and modify DONKEY_SIM_PATH.
-DONKEY_GYM = False
-DONKEY_SIM_PATH = "path to sim" #"/home/tkramer/projects/sdsandbox/sdsim/build/DonkeySimLinux/donkey_sim.x86_64"
-DONKEY_GYM_ENV_NAME = "donkey-generated-track-v0" # ("donkey-generated-track-v0"|"donkey-generated-roads-v0"|"donkey-warehouse-v0"|"donkey-avc-sparkfun-v0")
+

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -65,6 +65,7 @@ from donkeycar.templates.complete import add_odometry, add_camera, \
     add_user_controller, add_drivetrain, add_simulator
 from donkeycar.parts.logger import LoggerPart
 from donkeycar.parts.transform import Lambda
+from donkeycar.parts.explode import ExplodeDict
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -165,6 +166,11 @@ def drive(cfg, use_joystick=False, camera_type='single'):
     #
     has_input_controller = hasattr(cfg, "CONTROLLER_TYPE") and cfg.CONTROLLER_TYPE != "mock"
     ctr = add_user_controller(V, cfg, use_joystick, input_image = 'map/image')
+
+    #
+    # explode the web buttons into their own key/values in memory
+    #
+    V.add(ExplodeDict(V.mem, "web/"), inputs=['web/buttons'])
 
     #
     # This part will reset the car back to the origin. You must put the car in the known origin
@@ -318,7 +324,7 @@ def drive(cfg, use_joystick=False, camera_type='single'):
                 if self.auto_record_on_throttle:
                     logger.info('auto record on throttle is enabled; ignoring toggle of manual mode.')
                 else:
-                    recording = not recording
+                    recording = not self.last_recording
                 self.toggle_latch = False
 
             if self.recording_latch is not None:
@@ -329,7 +335,7 @@ def drive(cfg, use_joystick=False, camera_type='single'):
                 logging.info("Ignoring recording in auto-pilot mode")
                 recording = False
 
-            if recording_in != recording:
+            if self.last_recording != recording:
                 logging.info(f"Setting Recording = {recording}")
 
             self.last_recording = recording

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """
-Scripts to drive a donkey car using Intel T265
+Scripts to record a path by driving a donkey car
+and using an autopilot to drive the recoded path.
+Works with wheel encoders and/or Intel T265
 
 Usage:
-    manage.py (drive) [--log=INFO]
+    manage.py (drive) [--js] [--log=INFO] [--camera=(single|stereo)]
  
 
 Options:
@@ -11,39 +13,75 @@ Options:
     --js               Use physical joystick.
     -f --file=<file>   A text file containing paths to tub files, one per line. Option may be used more than once.
     --meta=<key:value> Key/Value strings describing describing a piece of meta data about this drive. Option may be used more than once.
+
+Starts in user mode.
+- The user flow to 'train' a path.   
+  - start "python manage.py drive" 
+  - This starts in user mode; so user is in manual drive mode 
+    driving records path waypoints.
+  - drive to record a path; make the start and end close to each other.
+  - if you don't like path, select the reset button and it will
+    reset the origin _AND_ erase the path from memory.  MOve the
+    vehicle back to where the physical origin is and start driving
+    again to record a new path.
+  - if you like the path, select the save button to save it. 
+- The user flow for autopilot:  
+  - record or load a path (select load button) 
+  - select auto-pilot mode using joystick or web ui.  The
+    vehicle will start trying to follow the recorded path.
+  - switch back user model to stop autopilot.
+  - to restart using the saved path; 
+    - select reset button; this will erase path and reset origin 
+    - select load button to load path
+    - put the car back at the physical origin.
+
+
 """
+from distutils.log import debug
 import os
-import sys
-import time
 import logging
-import json
-from subprocess import Popen
-import shlex
+
+#
+# import cv2 early to avoid issue with importing after tensorflow
+# see https://github.com/opencv/opencv/issues/14884#issuecomment-599852128
+#
+import time
+
+try:
+    import cv2
+except:
+    pass
+
 
 from docopt import docopt
-import numpy as np
-import pigpio
 
 import donkeycar as dk
-from donkeycar.parts.controller import WebFpv, get_js_controller, LocalWebController
-from donkeycar.parts.actuator import PCA9685, PWMSteering, PWMThrottle
-from donkeycar.parts.path import Path, PathPlot, CTE, PID_Pilot, PlotCircle, PImage, OriginOffset
+from donkeycar.parts.controller import JoystickController
+from donkeycar.parts.path import CsvPath, PathPlot, CTE, PID_Pilot, \
+    PlotCircle, PImage, OriginOffset
 from donkeycar.parts.transform import PIDController
-from donkeycar.parts.pigpio_enc import PiPGIOEncoder, OdomDist
-from donkeycar.parts.realsense2 import RS_T265
-        
+from donkeycar.parts.kinematics import TwoWheelSteeringThrottle
+from donkeycar.templates.complete import add_odometry, add_camera, \
+    add_user_controller, add_drivetrain, add_simulator
+from donkeycar.parts.logger import LoggerPart
+from donkeycar.parts.transform import Lambda
 
-def drive(cfg):
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+def drive(cfg, use_joystick=False, camera_type='single'):
     '''
     Construct a working robotic vehicle from many parts.
     Each part runs as a job in the Vehicle loop, calling either
-    it's run or run_threaded method depending on the constructor flag `threaded`.
-    All parts are updated one after another at the framerate given in
-    cfg.DRIVE_LOOP_HZ assuming each part finishes processing in a timely manner.
-    Parts may have named outputs and inputs. The framework handles passing named outputs
-    to parts requesting the same named input.
+    it's run or run_threaded method depending on the constructor flag
+    `threaded`.  All parts are updated one after another at the framerate given
+    in cfg.DRIVE_LOOP_HZ assuming each part finishes processing in a timely
+    manner. Parts may have named outputs and inputs. The framework handles
+    passing named outputs to parts requesting the same named input.
     '''
-    
+
+    is_differential_drive = cfg.DRIVE_TRAIN_TYPE.startswith("DC_TWO_WHEEL")
+
     #Initialize car
     V = dk.vehicle.Vehicle()
 
@@ -51,26 +89,27 @@ def drive(cfg):
         from donkeycar.utils import Sombrero
         s = Sombrero()
    
-    ctr = get_js_controller(cfg)
+    #Initialize logging before anything else to allow console logging
+    if cfg.HAVE_CONSOLE_LOGGING:
+        logger.setLevel(logging.getLevelName(cfg.LOGGING_LEVEL))
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter(cfg.LOGGING_FORMAT))
+        logger.addHandler(ch)
 
-    V.add(ctr,
-            inputs=['cam/image_array'],
-            outputs=['user/angle', 'user/throttle', 'user/mode', 'recording'],
-            threaded=True)
+    if cfg.HAVE_MQTT_TELEMETRY:
+        from donkeycar.parts.telemetry import MqttTelemetry
+        tel = MqttTelemetry(cfg)
+
+    #
+    # if we are using the simulator, set it up
+    #
+    add_simulator(V, cfg)
 
     if cfg.HAVE_ODOM:
-        pi = pigpio.pi()
-        enc = PiPGIOEncoder(cfg.ODOM_PIN, pi)
-        V.add(enc, outputs=['enc/ticks'])
-
-        odom = OdomDist(mm_per_tick=cfg.MM_PER_TICK, debug=cfg.ODOM_DEBUG)
-        V.add(odom, inputs=['enc/ticks', 'user/throttle'], outputs=['enc/dist_m', 'enc/vel_m_s', 'enc/delta_vel_m_s'])
-
-        if not os.path.exists(cfg.WHEEL_ODOM_CALIB):
-            print("You must supply a json file when using odom with T265. There is a sample file in templates.")
-            print("cp donkeycar/donkeycar/templates/calibration_odometry.json .")
-            exit(1)
-
+        #
+        # setup encoders, odometry and pose estimation
+        #
+        add_odometry(V, cfg)
     else:
         # we give the T265 no calib to indicated we don't have odom
         cfg.WHEEL_ODOM_CALIB = None
@@ -81,25 +120,58 @@ def drive(cfg):
                 return 0.0
 
         V.add(NoOdom(), outputs=['enc/vel_m_s'])
-   
-    # This requires use of the Intel Realsense T265
-    rs = RS_T265(image_output=False, calib_filename=cfg.WHEEL_ODOM_CALIB)
-    V.add(rs, inputs=['enc/vel_m_s'], outputs=['rs/pos', 'rs/vel', 'rs/acc', 'rs/camera/left/img_array'], threaded=True)
 
-    # Pull out the realsense T265 position stream, output 2d coordinates we can use to map.
-    class PosStream:
-        def run(self, pos):
-            #y is up, x is right, z is backwards/forwards
-            return pos.x, pos.z
+    if cfg.HAVE_T265:
+        from donkeycar.parts.realsense2 import RS_T265
+        if cfg.HAVE_ODOM and not os.path.exists(cfg.WHEEL_ODOM_CALIB):
+            print("You must supply a json file when using odom with T265. "
+                  "There is a sample file in templates.")
+            print("cp donkeycar/donkeycar/templates/calibration_odometry.json .")
+            exit(1)
 
-    V.add(PosStream(), inputs=['rs/pos'], outputs=['pos/x', 'pos/y'])
+        #
+        # NOTE: image output on the T265 is broken in the python API and
+        #       will never get fixed, so not image output from T265
+        #
+        rs = RS_T265(image_output=False, calib_filename=cfg.WHEEL_ODOM_CALIB, device_id=cfg.REALSENSE_T265_ID)
+        V.add(rs, inputs=['enc/vel_m_s'], outputs=['rs/pos', 'rs/vel', 'rs/acc'], threaded=True)
 
+        #
+        # Pull out the realsense T265 position stream, output 2d coordinates we can use to map.
+        # Transform the T265 augmented reality coordinate system into a traditional
+        # top-down POSE coordinate system where east is positive-x and north is positive-y.
+        #
+        class PosStream:
+            def run(self, pos):
+                #y is up, x is right, z is backwards/forwards (negative going forwards)
+                return -pos.z, -pos.x
+
+        V.add(PosStream(), inputs=['rs/pos'], outputs=['pos/x', 'pos/y'])
+
+    #
+    # gps outputs ['pos/x', 'pos/y']
+    #
+    gps_player = add_gps(V, cfg)
+
+    #
+    # setup primary camera
+    #
+    add_camera(V, cfg, camera_type)
+
+    #
+    # add the user input controller(s)
+    # - this will add the web controller
+    # - it will optionally add any configured 'joystick' controller
+    #
+    has_input_controller = hasattr(cfg, "CONTROLLER_TYPE") and cfg.CONTROLLER_TYPE != "mock"
+    ctr = add_user_controller(V, cfg, use_joystick, input_image = 'map/image')
+
+    #
     # This part will reset the car back to the origin. You must put the car in the known origin
     # and push the cfg.RESET_ORIGIN_BTN on your controller. This will allow you to induce an offset
     # in the mapping.
-
-
-    origin_reset = OriginOffset()
+    #
+    origin_reset = OriginOffset(cfg.PATH_DEBUG)
     V.add(origin_reset, inputs=['pos/x', 'pos/y'], outputs=['pos/x', 'pos/y'] )
 
 
@@ -125,47 +197,69 @@ def drive(cfg):
 
     # This is the path object. It will record a path when distance changes and it travels
     # at least cfg.PATH_MIN_DIST meters. Except when we are in follow mode, see below...
-    path = Path(min_dist=cfg.PATH_MIN_DIST)
-    V.add(path, inputs=['pos/x', 'pos/y'], outputs=['path'], run_condition='run_user')
+    path = CsvPath(min_dist=cfg.PATH_MIN_DIST)
+    V.add(path, inputs=['recording', 'pos/x', 'pos/y'], outputs=['path'])
 
-    # When a path is loaded, we will be in follow mode. We will not record.
-    path_loaded = False
-    if os.path.exists(cfg.PATH_FILENAME):
-        path.load(cfg.PATH_FILENAME)
-        path_loaded = True
+    if cfg.DONKEY_GYM:
+        lpos = LoggerPart(inputs=['dist/left', 'dist/right', 'dist', 'pos/pos_x', 'pos/pos_y', 'yaw'], level="INFO", logger="simulator")
+        V.add(lpos, inputs=lpos.inputs)
+    if cfg.HAVE_ODOM:
+        if cfg.HAVE_ODOM_2:
+            lpos = LoggerPart(inputs=['enc/left/distance', 'enc/right/distance', 'enc/left/timestamp', 'enc/right/timestamp'], level="INFO", logger="odometer")
+            V.add(lpos, inputs=lpos.inputs)
+        lpos = LoggerPart(inputs=['enc/distance', 'enc/timestamp'], level="INFO", logger="odometer")
+        V.add(lpos, inputs=lpos.inputs)
+        lpos = LoggerPart(inputs=['pos/x', 'pos/y', 'pos/angle'], level="INFO", logger="kinematics")
+        V.add(lpos, inputs=lpos.inputs)
 
     def save_path():
-        path.save(cfg.PATH_FILENAME)
-        print("saved path:", cfg.PATH_FILENAME)
+        if path.length() > 0:
+            if path.save(cfg.PATH_FILENAME):
+                print("That path was saved to ", cfg.PATH_FILENAME)
+
+                # save any recorded gps readings
+                if gps_player:
+                    gps_player.nmea.save()
+            else:
+                print("The path could NOT be saved; check the PATH_FILENAME in myconfig.py to make sure it is a legal path")
+        else:
+            print("There is no path to save; try recording the path.")
+
+    def load_path():
+        if os.path.exists(cfg.PATH_FILENAME) and path.load(cfg.PATH_FILENAME):
+           print("The path was loaded was loaded from ", cfg.PATH_FILENAME)
+
+           # we loaded the path; also load any recorded gps readings
+           if gps_player:
+               gps_player.stop().nmea.load()
+               gps_player.start()
+        else:
+           print("path _not_ loaded; make sure you have saved a path.")
 
     def erase_path():
-        global mode, path_loaded
-        if os.path.exists(cfg.PATH_FILENAME):
-            os.remove(cfg.PATH_FILENAME)
-            mode = 'user'
-            path_loaded = False
-            print("erased path", cfg.PATH_FILENAME)
+        origin_reset.reset_origin()
+        if path.reset():
+            print("The origin and the path were reset; you are ready to record a new path.")
+            if gps_player:
+                gps_player.stop().nmea.reset()
         else:
-            print("no path found to erase")
-    
+            print("The origin was reset; you are ready to record a new path.")
+
     def reset_origin():
-        print("Resetting origin")
-        origin_reset.init_to_last
+        """
+        Reset effective pose to (0, 0)
+        """
+        origin_reset.reset_origin()
+        print("The origin was reset to the current position.")
+
+        # restart any recorded gps readings from the start.
+        if gps_player:
+            gps_player.start()
 
 
-    
-    # Here's a trigger to save the path. Complete one circuit of your course, when you
-    # have exactly looped, or just shy of the loop, then save the path and shutdown
-    # this process. Restart and the path will be loaded.
-    ctr.set_button_down_trigger(cfg.SAVE_PATH_BTN, save_path)
-
-    # Here's a trigger to erase a previously saved path. 
-
-    ctr.set_button_down_trigger(cfg.ERASE_PATH_BTN, erase_path)
-
-    # Here's a trigger to reset the origin. 
-
-    ctr.set_button_down_trigger(cfg.RESET_ORIGIN_BTN, reset_origin)
+    # When a path is loaded, we will be in follow mode. We will not record.
+    if os.path.exists(cfg.PATH_FILENAME):
+        load_path()
 
     # Here's an image we can map to.
     img = PImage(clear_each_frame=True)
@@ -186,102 +280,235 @@ def drive(cfg):
     V.add(pilot, inputs=['cte/error'], outputs=['pilot/angle', 'pilot/throttle'], run_condition="run_pilot")
 
     def dec_pid_d():
-        pid.Kd -= 0.5
+        pid.Kd -= cfg.PID_D_DELTA
         logging.info("pid: d- %f" % pid.Kd)
 
     def inc_pid_d():
-        pid.Kd += 0.5
+        pid.Kd += cfg.PID_D_DELTA
         logging.info("pid: d+ %f" % pid.Kd)
 
+    def dec_pid_p():
+        pid.Kp -= cfg.PID_P_DELTA
+        logging.info("pid: p- %f" % pid.Kp)
+
+    def inc_pid_p():
+        pid.Kp += cfg.PID_P_DELTA
+        logging.info("pid: p+ %f" % pid.Kp)
+
+
+    class ToggleRecording:
+        def __init__(self, auto_record_on_throttle):
+            self.auto_record_on_throttle = auto_record_on_throttle
+            self.recording_latch:bool = None
+            self.toggle_latch:bool = False
+            self.last_recording = None
+
+        def set_recording(self, recording:bool):
+            self.recording_latch = recording
+
+        def toggle_recording(self):
+            self.toggle_latch = True
+
+        def run(self, mode:str, recording:bool):
+            recording_in = recording
+            if recording_in != self.last_recording:
+                logging.info(f"Recording Change = {recording_in}")
+
+            if self.toggle_latch:
+                if self.auto_record_on_throttle:
+                    logger.info('auto record on throttle is enabled; ignoring toggle of manual mode.')
+                else:
+                    recording = not recording
+                self.toggle_latch = False
+
+            if self.recording_latch is not None:
+                recording = self.recording_latch
+                self.recording_latch = None
+
+            if recording and mode != 'user':
+                logging.info("Ignoring recording in auto-pilot mode")
+                recording = False
+
+            if recording_in != recording:
+                logging.info(f"Setting Recording = {recording}")
+
+            self.last_recording = recording
+
+            return recording
+
+
+    recording_control = ToggleRecording(cfg.AUTO_RECORD_ON_THROTTLE)
+    V.add(recording_control, inputs=['user/mode', "recording"], outputs=["recording"])
+
+
+    #
+    # Add buttons for handling various user actions
+    # The button names are in configuration.
+    # They may refer to game controller (joystick) buttons OR web ui buttons
+    #
+    # There are 5 programmable webui buttons, "web/w1" to "web/w5"
+    # adding a button handler for a webui button
+    # is just adding a part with a run_condition set to
+    # the button's name, so it runs when button is pressed.
+    #
+    have_joystick = ctr is not None and isinstance(ctr, JoystickController)
+
+    # Here's a trigger to save the path. Complete one circuit of your course, when you
+    # have exactly looped, or just shy of the loop, then save the path and shutdown
+    # this process. Restart and the path will be loaded.
+    if cfg.SAVE_PATH_BTN:
+        print(f"Save path button is {cfg.SAVE_PATH_BTN}")
+        if cfg.SAVE_PATH_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: save_path()), run_condition=cfg.SAVE_PATH_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.SAVE_PATH_BTN, save_path)
+
+    # allow controller to (re)load the path
+    if cfg.LOAD_PATH_BTN:
+        print(f"Load path button is {cfg.LOAD_PATH_BTN}")
+        if cfg.LOAD_PATH_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: load_path()), run_condition=cfg.LOAD_PATH_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.LOAD_PATH_BTN, load_path)
+
+    # Here's a trigger to erase a previously saved path.
+    # This erases the path in memory; it does NOT erase any saved path file
+    if cfg.ERASE_PATH_BTN:
+        print(f"Erase path button is {cfg.ERASE_PATH_BTN}")
+        if cfg.ERASE_PATH_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: erase_path()), run_condition=cfg.ERASE_PATH_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.ERASE_PATH_BTN, erase_path)
+
+    # Here's a trigger to reset the origin based on the current position
+    if cfg.RESET_ORIGIN_BTN:
+        print(f"Reset origin button is {cfg.RESET_ORIGIN_BTN}")
+        if cfg.RESET_ORIGIN_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: reset_origin()), run_condition=cfg.RESET_ORIGIN_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.RESET_ORIGIN_BTN, reset_origin)
+
+    # button to toggle recording
+    if cfg.TOGGLE_RECORDING_BTN:
+        print(f"Toggle recording button is {cfg.TOGGLE_RECORDING_BTN}")
+        if cfg.TOGGLE_RECORDING_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: recording_control.toggle_recording()), run_condition=cfg.TOGGLE_RECORDING_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.TOGGLE_RECORDING_BTN, recording_control.toggle_recording)
+
     # Buttons to tune PID constants
-    ctr.set_button_down_trigger("L2", dec_pid_d)
-    ctr.set_button_down_trigger("R2", inc_pid_d)
+    if cfg.DEC_PID_P_BTN and cfg.PID_P_DELTA:
+        print(f"Decrement PID P button is {cfg.DEC_PID_P_BTN}")
+        if cfg.DEC_PID_P_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: dec_pid_p()), run_condition=cfg.DEC_PID_P_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.DEC_PID_P_BTN, dec_pid_p)
+    if cfg.INC_PID_P_BTN and cfg.PID_P_DELTA:
+        print(f"Increment PID P button is {cfg.INC_PID_P_BTN}")
+        if cfg.INC_PID_P_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: inc_pid_p()), run_condition=cfg.INC_PID_P_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.INC_PID_P_BTN, inc_pid_p)
+    if cfg.DEC_PID_D_BTN and cfg.PID_D_DELTA:
+        print(f"Decrement PID D button is {cfg.DEC_PID_D_BTN}")
+        if cfg.DEC_PID_D_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: dec_pid_d()), run_condition=cfg.DEC_PID_D_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.DEC_PID_D_BTN, dec_pid_d)
+    if cfg.INC_PID_D_BTN and cfg.PID_D_DELTA:
+        print(f"Increment PID D button is {cfg.INC_PID_D_BTN}")
+        if cfg.INC_PID_D_BTN.startswith("web/w"):
+            V.add(Lambda(lambda: inc_pid_d()), run_condition=cfg.INC_PID_D_BTN)
+        elif have_joystick:
+            ctr.set_button_down_trigger(cfg.INC_PID_D_BTN, inc_pid_d)
 
-    # #This web controller will create a web server. We aren't using any controls, just for visualization.
-
-    web_ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT,
-                                 mode=cfg.WEB_INIT_MODE)
-
-    V.add(web_ctr,
-        inputs=['map/image'],
-        outputs=['web/angle', 'web/throttle', 'web/mode', 'web/recording'],
-        threaded=True)
-    
 
     #Choose what inputs should change the car.
     class DriveMode:
         def run(self, mode, 
-                    user_angle, user_throttle,
-                    pilot_angle, pilot_throttle):
+                user_angle, user_throttle,
+                pilot_angle, pilot_throttle):
             if mode == 'user':
-                #print(user_angle, user_throttle)
                 return user_angle, user_throttle
-            
             elif mode == 'local_angle':
                 return pilot_angle, user_throttle
-            
-            else: 
+            else:
                 return pilot_angle, pilot_throttle
-        
+
     V.add(DriveMode(), 
           inputs=['user/mode', 'user/angle', 'user/throttle',
                   'pilot/angle', 'pilot/throttle'], 
           outputs=['angle', 'throttle'])
-    
 
-    if not cfg.DONKEY_GYM:
-        steering_controller = PCA9685(cfg.STEERING_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
-        steering = PWMSteering(controller=steering_controller,
-                                        left_pulse=cfg.STEERING_LEFT_PWM, 
-                                        right_pulse=cfg.STEERING_RIGHT_PWM)
-        
-        throttle_controller = PCA9685(cfg.THROTTLE_CHANNEL, cfg.PCA9685_I2C_ADDR, busnum=cfg.PCA9685_I2C_BUSNUM)
-        throttle = PWMThrottle(controller=throttle_controller,
-                                        max_pulse=cfg.THROTTLE_FORWARD_PWM,
-                                        zero_pulse=cfg.THROTTLE_STOPPED_PWM, 
-                                        min_pulse=cfg.THROTTLE_REVERSE_PWM)
+    #
+    # To make differential drive steer,
+    # divide throttle between motors based on the steering value
+    #
+    if is_differential_drive:
+        V.add(TwoWheelSteeringThrottle(),
+            inputs=['throttle', 'angle'],
+            outputs=['left/throttle', 'right/throttle'])
 
-        V.add(steering, inputs=['angle'])
-        V.add(throttle, inputs=['throttle'])
+    #
+    # Setup drivetrain
+    #
+    add_drivetrain(V, cfg)
 
     # Print Joystick controls
-    ctr.print_controls()
+    if ctr is not None and isinstance(ctr, JoystickController):
+        ctr.print_controls()
 
-    if path_loaded:
-        print("###############################################################################")
-        print("Loaded path:", cfg.PATH_FILENAME)
-        print("Make sure your car is sitting at the origin of the path.")
-        print("View web page and refresh. You should see your path.")
-        print("Hit 'select' twice to change to ai drive mode.")
-        print("You can press the X button (e-stop) to stop the car at any time.")
-        print("Delete file", cfg.PATH_FILENAME, "and re-start")
-        print("to record a new path.")
-        print("###############################################################################")
-        carcolor = "blue"
-        loc_plot = PlotCircle(scale=cfg.PATH_SCALE, offset=cfg.PATH_OFFSET, color = carcolor)
-        V.add(loc_plot, inputs=['map/image', 'pos/x', 'pos/y'], outputs=['map/image'])
+    #
+    # draw a map image as the vehicle moves
+    #
+    loc_plot = PlotCircle(scale=cfg.PATH_SCALE, offset=cfg.PATH_OFFSET, color = "blue")
+    V.add(loc_plot, inputs=['map/image', 'pos/x', 'pos/y'], outputs=['map/image'], run_condition='run_pilot')
 
-    else:
-        print("###############################################################################")
-        print("You are now in record mode. Open the web page to your car")
-        print("and as you drive you should see a path.")
-        print("Complete one circuit of your course.")
-        print("When you have exactly looped, or just shy of the ")
-        print("loop, then save the path (press %s)." % cfg.SAVE_PATH_BTN)
-        print("You can also erase a path with the Triangle button.")
-        print("When you're done, close this process with Ctrl+C.")
-        print("Place car exactly at the start. ")
-        print("Then restart the car with 'python manage drive'.")
-        print("It will reload the path and you will be ready to  ")
-        print("follow the path using  'select' to change to ai drive mode.")
-        print("You can also press the Square button to reset the origin")
-        print("###############################################################################")
-        carcolor = 'green'
-        loc_plot = PlotCircle(scale=cfg.PATH_SCALE, offset=cfg.PATH_OFFSET, color = carcolor)
-        V.add(loc_plot, inputs=['map/image', 'pos/x', 'pos/y'], outputs=['map/image'])
+    loc_plot = PlotCircle(scale=cfg.PATH_SCALE, offset=cfg.PATH_OFFSET, color = "green")
+    V.add(loc_plot, inputs=['map/image', 'pos/x', 'pos/y'], outputs=['map/image'], run_condition='run_user')
 
     V.start(rate_hz=cfg.DRIVE_LOOP_HZ, 
         max_loop_count=cfg.MAX_LOOPS)
+
+
+from donkeycar.parts.text_writer import CsvLogger
+
+
+def add_gps(V, cfg):
+    if cfg.HAVE_GPS:
+        from donkeycar.parts.serial_port import SerialPort, SerialLineReader
+        from donkeycar.parts.gps import GpsNmeaPositions, GpsLatestPosition, GpsPlayer
+        from donkeycar.parts.pipe import Pipe
+        from donkeycar.parts.text_writer import CsvLogger
+
+        #
+        # parts to
+        # - read nmea lines from serial port
+        # - OR play from recorded file
+        # - convert nmea lines to positions
+        # - retrieve the most recent position
+        #
+        serial_port = SerialPort(cfg.GPS_SERIAL, cfg.GPS_SERIAL_BAUDRATE)
+        nmea_reader = SerialLineReader(serial_port)
+        V.add(nmea_reader, outputs=['gps/nmea'], threaded=True)
+
+        # part to save nmea sentences for later playback
+        nmea_player = None
+        if cfg.GPS_NMEA_PATH:
+            nmea_writer = CsvLogger(cfg.GPS_NMEA_PATH, separator='\t', field_count=2)
+            V.add(nmea_writer, inputs=['recording', 'gps/nmea'], outputs=['gps/recorded/nmea'])  # only record nmea sentences in user mode
+            nmea_player = GpsPlayer(nmea_writer)
+            V.add(nmea_player, inputs=['run_pilot', 'gps/nmea'], outputs=['gps/playing', 'gps/nmea'])  # only play nmea sentences in autopilot mode
+
+        gps_positions = GpsNmeaPositions(debug=cfg.GPS_DEBUG)
+        V.add(gps_positions, inputs=['gps/nmea'], outputs=['gps/positions'])
+        gps_latest_position = GpsLatestPosition(debug=cfg.GPS_DEBUG)
+        V.add(gps_latest_position, inputs=['gps/positions'], outputs=['gps/timestamp', 'gps/utm/longitude', 'gps/utm/latitude'])
+
+        # rename gps utm position to pose values
+        V.add(Pipe(), inputs=['gps/utm/longitude', 'gps/utm/latitude'], outputs=['pos/x', 'pos/y'])
+
+        return nmea_player
 
 
 if __name__ == '__main__':
@@ -294,6 +521,6 @@ if __name__ == '__main__':
         raise ValueError('Invalid log level: %s' % log_level)
     logging.basicConfig(level=numeric_level)
 
-    
+
     if args['drive']:
-        drive(cfg)
+        drive(cfg, use_joystick=args['--js'], camera_type=args['--camera'])

--- a/donkeycar/tests/test_kinematics.py
+++ b/donkeycar/tests/test_kinematics.py
@@ -1,0 +1,27 @@
+import math
+import time
+import unittest
+
+from donkeycar.parts.kinematics import differential_steering
+
+
+class TestTwoWheelSteeringThrottle(unittest.TestCase):
+    def test_differential_steering(self):
+        # Straight within steering_zero tolerance
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, 0.0, 0.0))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, 0.05, 0.10))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, 0.10, 0.10))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, -0.05, 0.10))
+        self.assertEqual((1.0, 1.0), differential_steering(1.0, -0.10, 0.10))
+
+        # left
+        self.assertEqual((0.9, 1.0), differential_steering(1.0, -0.10, 0.0))
+        self.assertEqual((0.8, 1.0), differential_steering(1.0, -0.20, 0.0))
+        self.assertEqual((0.45, 0.5), differential_steering(0.5, -0.10, 0.0))
+        self.assertEqual((0.40, 0.5), differential_steering(0.5, -0.20, 0.0))
+
+        # right
+        self.assertEqual((1.0, 0.9), differential_steering(1.0, 0.10, 0.0))
+        self.assertEqual((1.0, 0.8), differential_steering(1.0, 0.20, 0.0))
+        self.assertEqual((0.5, 0.45), differential_steering(0.5, 0.10, 0.0))
+        self.assertEqual((0.5, 0.40), differential_steering(0.5, 0.20, 0.0))

--- a/donkeycar/tests/test_path.py
+++ b/donkeycar/tests/test_path.py
@@ -1,0 +1,51 @@
+import os
+import tempfile
+import unittest
+
+from donkeycar.parts.path import CsvPath, RosPath
+
+
+class TestCsvPath(unittest.TestCase):
+
+    def test_csvpath_run(self):
+        path = CsvPath()
+        self.assertListEqual([(1, 2)], path.run(1, 2))
+        self.assertListEqual([(1, 2), (3, 4)], path.run(3, 4))
+        self.assertEqual(2, len(path.get_xy()))
+
+    def test_csvpath_save(self):
+        path = CsvPath()
+        path.run(1, 2)
+        path.run(3, 4)
+        with tempfile.TemporaryDirectory() as td:
+            filename = os.path.join(td, "test.csv")
+            path.save(filename)
+            with open(filename, "r") as testfile:
+                lines = testfile.readlines()
+                self.assertEqual(2, len(lines))
+                self.assertEqual("1, 2", lines[0].strip())
+                self.assertEqual("3, 4", lines[1].strip())
+
+    def test_csvpath_reset(self):
+        path = CsvPath()
+        path.run(1, 2)
+        path.run(3, 4)
+        path.reset()
+        self.assertEqual([], path.get_xy())
+
+
+    def test_csvpath_load(self):
+        path = CsvPath()
+        path.run(1, 2)
+        path.run(3, 4)
+        with tempfile.TemporaryDirectory() as td:
+            filename = os.path.join(td, "test.csv")
+            path.save(filename)
+            path.reset()
+            path.load(filename)
+            xy = path.get_xy()
+            self.assertEqual(2, len(xy))
+            self.assertEqual((1, 2), xy[0])
+            self.assertEqual((3, 4), xy[1])
+
+

--- a/donkeycar/tests/test_path.py
+++ b/donkeycar/tests/test_path.py
@@ -9,14 +9,21 @@ class TestCsvPath(unittest.TestCase):
 
     def test_csvpath_run(self):
         path = CsvPath()
-        self.assertListEqual([(1, 2)], path.run(1, 2))
-        self.assertListEqual([(1, 2), (3, 4)], path.run(3, 4))
+        self.assertListEqual([(1, 2)], path.run(True, 1, 2))
+        self.assertListEqual([(1, 2), (3, 4)], path.run(True, 3, 4))
+        self.assertEqual(2, len(path.get_xy()))
+
+    def test_csvpath_run_not_recording(self):
+        path = CsvPath()
+        self.assertListEqual([(1, 2)], path.run(True, 1, 2))
+        self.assertListEqual([(1, 2)], path.run(False, 3, 4))
+        self.assertListEqual([(1, 2), (3, 4)], path.run(True, 3, 4))
         self.assertEqual(2, len(path.get_xy()))
 
     def test_csvpath_save(self):
         path = CsvPath()
-        path.run(1, 2)
-        path.run(3, 4)
+        path.run(True, 1, 2)
+        path.run(True, 3, 4)
         with tempfile.TemporaryDirectory() as td:
             filename = os.path.join(td, "test.csv")
             path.save(filename)
@@ -28,16 +35,16 @@ class TestCsvPath(unittest.TestCase):
 
     def test_csvpath_reset(self):
         path = CsvPath()
-        path.run(1, 2)
-        path.run(3, 4)
+        path.run(True, 1, 2)
+        path.run(True, 3, 4)
         path.reset()
         self.assertEqual([], path.get_xy())
 
 
     def test_csvpath_load(self):
         path = CsvPath()
-        path.run(1, 2)
-        path.run(3, 4)
+        path.run(True, 1, 2)
+        path.run(True, 3, 4)
         with tempfile.TemporaryDirectory() as td:
             filename = os.path.join(td, "test.csv")
             path.save(filename)

--- a/donkeycar/utilities/dk_platform.py
+++ b/donkeycar/utilities/dk_platform.py
@@ -1,0 +1,34 @@
+import os
+import platform
+
+#
+# functions to query hardware and os 
+#
+def is_mac():
+    return "Darwin" == platform.system()
+
+#
+# read tegra chip id if it exists.
+#
+def read_chip_id() -> str:
+    """
+    Read the tegra chip id.
+    On non-tegra platforms this will be blank.
+    """
+    try:
+        with open("/sys/module/tegra_fuse/parameters/tegra_chip_id", "r") as f:
+            return next(f)
+    except FileNotFoundError:
+        pass
+    return ""
+
+_chip_id = None
+
+def is_jetson() -> bool:
+    """
+    Determine if platform is a jetson
+    """
+    global _chip_id
+    if _chip_id is None:
+        _chip_id = read_chip_id()
+    return _chip_id != ""


### PR DESCRIPTION
[Issue 991](https://github.com/autorope/donkeycar/issues/991)

- Refactor gps part so serial input is done in a separate part.  The gps part only parses NMEA and outputs position in meters
- Add a part for reading serial input so serial code can be reused.
- Add a part for reading and writing delimited text files (like CSV or TSV)
- Update the path_follow template
    - Support the same cameras, drivetrains, odometry and game controllers used by the complete.py template.
    - allows use of web ui and controller buttons to set recording mode, load/save/reset paths, reset origin.
    - use GPS as a source of (x, y) position.

This is been cherry picked from [921-gps-logger](https://github.com/autorope/donkeycar/tree/921-gps-logger) branch, which was successfully used in the Sept. 2022 Fremont outdoor race.  See [Ezward on GPS](https://ezward.github.io/gps/) for a complete description of how the car and software were setup to use this branch.
