### PR TITLE
Add IMU_ADDRESS configuration

### DIFF
--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -444,6 +444,7 @@ SEQUENCE_LENGTH = 3             #some models use a number of images over time. T
 #IMU
 HAVE_IMU = False                #when true, this add a Mpu6050 part and records the data. Can be used with a
 IMU_SENSOR = 'mpu6050'          # (mpu6050|mpu9250)
+IMU_ADDRESS = 0x68              # if AD0 pin is pulled high them address is 0x69, otherwise it is 0x68
 IMU_DLP_CONFIG = 0              # Digital Lowpass Filter setting (0:250Hz, 1:184Hz, 2:92Hz, 3:41Hz, 4:20Hz, 5:10Hz, 6:5Hz)
 
 #SOMBRERO

--- a/donkeycar/templates/cfg_path_follow.py
+++ b/donkeycar/templates/cfg_path_follow.py
@@ -411,6 +411,7 @@ LIDAR_UPPER_LIMIT = 270
 # IMU for imu model
 HAVE_IMU = False                #when true, this add a Mpu6050 part and records the data. Can be used with a
 IMU_SENSOR = 'mpu6050'          # (mpu6050|mpu9250)
+IMU_ADDRESS = 0x68              # if AD0 pin is pulled high them address is 0x69, otherwise it is 0x68
 IMU_DLP_CONFIG = 0              # Digital Lowpass Filter setting (0:250Hz, 1:184Hz, 2:92Hz, 3:41Hz, 4:20Hz, 5:10Hz, 6:5Hz)
 
 

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -260,11 +260,8 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         s = Sombrero()
 
     #IMU
-    if cfg.HAVE_IMU:
-        from donkeycar.parts.imu import IMU
-        imu = IMU(sensor=cfg.IMU_SENSOR, dlp_setting=cfg.IMU_DLP_CONFIG)
-        V.add(imu, outputs=['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
-            'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'], threaded=True)
+    add_imu(V, cfg)
+
 
     # Use the FPV preview, which will show the cropped image output, or the full frame.
     if cfg.USE_FPV:
@@ -801,6 +798,20 @@ def add_odometry(V, cfg):
             V.add(enc, outputs=['enc/speed'], threaded=True)
         else:
             print("No supported encoder found")
+
+#
+# IMU setup
+#
+def add_imu(V, cfg):
+    imu = None
+    if cfg.HAVE_IMU:
+        from donkeycar.parts.imu import IMU
+
+        imu = IMU(sensor=cfg.IMU_SENSOR, addr=cfg.IMU_ADDRESS,
+                  dlp_setting=cfg.IMU_DLP_CONFIG)
+        V.add(imu, outputs=['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
+                            'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'], threaded=True)
+    return imu
 
 
 #

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -62,7 +62,7 @@ from donkeycar.parts.path import CsvPath, PathPlot, CTE, PID_Pilot, \
 from donkeycar.parts.transform import PIDController
 from donkeycar.parts.kinematics import TwoWheelSteeringThrottle
 from donkeycar.templates.complete import add_odometry, add_camera, \
-    add_user_controller, add_drivetrain, add_simulator
+    add_user_controller, add_drivetrain, add_simulator, add_imu
 from donkeycar.parts.logger import LoggerPart
 from donkeycar.parts.transform import Lambda
 from donkeycar.parts.explode import ExplodeDict
@@ -106,6 +106,14 @@ def drive(cfg, use_joystick=False, camera_type='single'):
     #
     add_simulator(V, cfg)
 
+    #
+    # IMU
+    #
+    add_imu(V, cfg)
+
+    #
+    # odometry/tachometer/speed control
+    #
     if cfg.HAVE_ODOM:
         #
         # setup encoders, odometry and pose estimation


### PR DESCRIPTION
The MPU6050 and MPU9250 allow for two different I2C addresses based on how an input line is set.  Our code does not support the secondary address, which is how the MM1 hat is setup.  This code allows those IMUs to be used with their secondary address.
- move construction of IMU part and addition to vehicle into a method in complete.py and make complete.py and path_follow.py use it.
- add IMU_ADDRESS defaulted to 0x68 to cfg_complete.py and cfg_path_follow.py
- make path follow use add_imu()