### PR TITLE
Support velocity target on a waypoint in `path_follow`

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create python 3.7 conda env
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -76,6 +76,45 @@ class CsvPath(AbstractPath):
 
         self.recording = False
 
+class CsvVelocityPath(AbstractPath):
+    def __init__(self, min_dist=1.):
+        super().__init__(min_dist)
+        self.velocities = []
+
+    def run(self, recording, x, y, velocity):
+        if recording:
+            d = dist(x, y, self.x, self.y)
+            if d > self.min_dist:
+                logging.info(f"path point ({x},{y})")
+                self.path.append((x, y))
+                self.velocities.append(velocity)
+                self.x = x
+                self.y = y
+        return self.path, self.velocities
+
+    def save(self, filename):
+        if self.length() > 0:
+            with open(filename, 'w') as outfile:
+                for (x, y), v in zip(self.path, self.velocities):
+                    outfile.write(f"{x}, {y}, {v}\n")
+            return True
+        else:
+            return False
+
+    def load(self, filename):
+        path = pathlib.Path(filename)
+        if path.is_file():
+            with open(filename, "r") as infile:
+                self.path = []
+                for line in infile:
+                    xy = [float(i.strip()) for i in line.strip().split(sep=",")]
+                    self.path.append((xy[0], xy[1]))
+                    self.velocities.append(xy[2])
+            return True
+        else:
+            logging.info(f"File '{filename}' does not exist")
+            return False
+
 
 class RosPath(AbstractPath):
     def __init__(self, min_dist=1.):

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -76,26 +76,26 @@ class CsvPath(AbstractPath):
 
         self.recording = False
 
-class CsvVelocityPath(AbstractPath):
+class CsvThrottlePath(AbstractPath):
     def __init__(self, min_dist=1.):
         super().__init__(min_dist)
-        self.velocities = []
+        self.throttles = []
 
-    def run(self, recording, x, y, velocity):
+    def run(self, recording, x, y, throttle):
         if recording:
             d = dist(x, y, self.x, self.y)
             if d > self.min_dist:
                 logging.info(f"path point ({x},{y})")
                 self.path.append((x, y))
-                self.velocities.append(velocity)
+                self.throttles.append(throttle)
                 self.x = x
                 self.y = y
-        return self.path, self.velocities
+        return self.path, self.throttles
 
     def save(self, filename):
         if self.length() > 0:
             with open(filename, 'w') as outfile:
-                for (x, y), v in zip(self.path, self.velocities):
+                for (x, y), v in zip(self.path, self.throttles):
                     outfile.write(f"{x}, {y}, {v}\n")
             return True
         else:
@@ -109,7 +109,7 @@ class CsvVelocityPath(AbstractPath):
                 for line in infile:
                     xy = [float(i.strip()) for i in line.strip().split(sep=",")]
                     self.path.append((xy[0], xy[1]))
-                    self.velocities.append(xy[2])
+                    self.throttles.append(xy[2])
             return True
         else:
             logging.info(f"File '{filename}' does not exist")
@@ -430,11 +430,11 @@ class PID_Pilot(object):
         self.use_constant_throttle = use_constant_throttle
         self.variable_speed_multiplier = 1.0
 
-    def run(self, cte, velocities, closest_pt_idx):
+    def run(self, cte, throttles, closest_pt_idx):
         steer = self.pid.run(cte)
-        if self.use_constant_throttle or velocities is None or closest_pt_idx is None:
+        if self.use_constant_throttle or throttles is None or closest_pt_idx is None:
             throttle = self.throttle
         else:
-            throttle = velocities[closest_pt_idx] * self.variable_speed_multiplier
+            throttle = throttles[closest_pt_idx] * self.variable_speed_multiplier
         logging.info("CTE: %f steer: %f throttle: %f" % (cte, steer, throttle))
         return steer, throttle

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -112,7 +112,7 @@ class CsvThrottlePath(AbstractPath):
                     self.throttles.append(xy[2])
             return True
         else:
-            logging.info(f"File '{filename}' does not exist")
+            logging.warning(f"File '{filename}' does not exist")
             return False
 
 

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -436,5 +436,5 @@ class PID_Pilot(object):
             throttle = self.throttle
         else:
             throttle = throttles[closest_pt_idx] * self.variable_speed_multiplier
-        logging.info("CTE: %f steer: %f throttle: %f" % (cte, steer, throttle))
+        logging.info(f"CTE: {cte} steer: {steer} throttle: {throttle}")
         return steer, throttle

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -78,15 +78,17 @@ class CsvPath(AbstractPath):
         self.recording = False
 
 class CsvThrottlePath(AbstractPath):
-    def __init__(self, min_dist: float = 1.0):
+    def __init__(self, min_dist: float = 1.0, min_throttle: float = 0.2):
         super().__init__(min_dist)
         self.throttles = []
+        self.min_throttle = min_throttle
 
     def run(self, recording: bool, x: float, y: float, throttle: float):
         if recording:
             d = dist(x, y, self.x, self.y)
             if d > self.min_dist:
-                logging.info(f"path point ({x},{y})")
+                throttle = max(self.min_throttle, throttle)
+                logging.info(f"path point: ({x},{y}) throttle: {throttle}")
                 self.path.append((x, y))
                 self.throttles.append(throttle)
                 self.x = x

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -95,6 +95,11 @@ class CsvThrottlePath(AbstractPath):
                 self.y = y
         return self.path, self.throttles
 
+    def reset(self) -> bool:
+        super().reset()
+        self.throttles = []
+        return True
+
     def save(self, filename: str) -> bool:
         if self.length() > 0:
             with open(filename, 'w') as outfile:
@@ -427,6 +432,7 @@ class CTE(object):
 
 class PID_Pilot(object):
 
+    def __init__(
             self,
             pid: PIDController,
             throttle: float,

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -5,6 +5,7 @@ import pathlib
 import numpy
 from PIL import Image, ImageDraw
 
+from donkeycar.parts.transform import PIDController
 from donkeycar.utils import norm_deg, dist, deg2rad, arr_to_img, is_number_type
 
 
@@ -77,11 +78,11 @@ class CsvPath(AbstractPath):
         self.recording = False
 
 class CsvThrottlePath(AbstractPath):
-    def __init__(self, min_dist=1.):
+    def __init__(self, min_dist: float = 1.0):
         super().__init__(min_dist)
         self.throttles = []
 
-    def run(self, recording, x, y, throttle):
+    def run(self, recording: bool, x: float, y: float, throttle: float):
         if recording:
             d = dist(x, y, self.x, self.y)
             if d > self.min_dist:
@@ -92,7 +93,7 @@ class CsvThrottlePath(AbstractPath):
                 self.y = y
         return self.path, self.throttles
 
-    def save(self, filename):
+    def save(self, filename: str):
         if self.length() > 0:
             with open(filename, 'w') as outfile:
                 for (x, y), v in zip(self.path, self.throttles):
@@ -101,7 +102,7 @@ class CsvThrottlePath(AbstractPath):
         else:
             return False
 
-    def load(self, filename):
+    def load(self, filename: str):
         path = pathlib.Path(filename)
         if path.is_file():
             with open(filename, "r") as infile:
@@ -424,13 +425,13 @@ class CTE(object):
 
 class PID_Pilot(object):
 
-    def __init__(self, pid, throttle, use_constant_throttle: bool = False):
+    def __init__(self, pid: PIDController, throttle: float, use_constant_throttle: bool = False):
         self.pid = pid
         self.throttle = throttle
         self.use_constant_throttle = use_constant_throttle
         self.variable_speed_multiplier = 1.0
 
-    def run(self, cte, throttles, closest_pt_idx):
+    def run(self, cte: float, throttles: list, closest_pt_idx: int):
         steer = self.pid.run(cte)
         if self.use_constant_throttle or throttles is None or closest_pt_idx is None:
             throttle = self.throttle

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -424,11 +424,17 @@ class CTE(object):
 
 class PID_Pilot(object):
 
-    def __init__(self, pid, throttle):
+    def __init__(self, pid, throttle, use_constant_throttle: bool = False):
         self.pid = pid
         self.throttle = throttle
+        self.use_constant_throttle = use_constant_throttle
+        self.variable_speed_multiplier = 1.0
 
-    def run(self, cte):
+    def run(self, cte, velocities, closest_pt_idx):
         steer = self.pid.run(cte)
-        logging.info("CTE: %f steer: %f" % (cte, steer))
-        return steer, self.throttle
+        if self.use_constant_throttle or velocities is None or closest_pt_idx is None:
+            throttle = self.throttle
+        else:
+            throttle = velocities[closest_pt_idx] * self.variable_speed_multiplier
+        logging.info("CTE: %f steer: %f throttle: %f" % (cte, steer, throttle))
+        return steer, throttle

--- a/donkeycar/parts/path.py
+++ b/donkeycar/parts/path.py
@@ -78,12 +78,12 @@ class CsvPath(AbstractPath):
         self.recording = False
 
 class CsvThrottlePath(AbstractPath):
-    def __init__(self, min_dist: float = 1.0, min_throttle: float = 0.2):
+    def __init__(self, min_dist: float = 1.0, min_throttle: float = 0.2) -> None:
         super().__init__(min_dist)
         self.throttles = []
         self.min_throttle = min_throttle
 
-    def run(self, recording: bool, x: float, y: float, throttle: float):
+    def run(self, recording: bool, x: float, y: float, throttle: float) -> tuple:
         if recording:
             d = dist(x, y, self.x, self.y)
             if d > self.min_dist:
@@ -95,7 +95,7 @@ class CsvThrottlePath(AbstractPath):
                 self.y = y
         return self.path, self.throttles
 
-    def save(self, filename: str):
+    def save(self, filename: str) -> bool:
         if self.length() > 0:
             with open(filename, 'w') as outfile:
                 for (x, y), v in zip(self.path, self.throttles):
@@ -104,7 +104,7 @@ class CsvThrottlePath(AbstractPath):
         else:
             return False
 
-    def load(self, filename: str):
+    def load(self, filename: str) -> bool:
         path = pathlib.Path(filename)
         if path.is_file():
             with open(filename, "r") as infile:
@@ -427,13 +427,16 @@ class CTE(object):
 
 class PID_Pilot(object):
 
-    def __init__(self, pid: PIDController, throttle: float, use_constant_throttle: bool = False):
+            self,
+            pid: PIDController,
+            throttle: float,
+            use_constant_throttle: bool = False) -> None:
         self.pid = pid
         self.throttle = throttle
         self.use_constant_throttle = use_constant_throttle
         self.variable_speed_multiplier = 1.0
 
-    def run(self, cte: float, throttles: list, closest_pt_idx: int):
+    def run(self, cte: float, throttles: list, closest_pt_idx: int) -> tuple:
         steer = self.pid.run(cte)
         if self.use_constant_throttle or throttles is None or closest_pt_idx is None:
             throttle = self.throttle

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -601,6 +601,7 @@ PID_P = -10.0                       # proportional mult for PID path follower
 PID_I = 0.000                       # integral mult for PID path follower
 PID_D = -0.2                        # differential mult for PID path follower
 PID_THROTTLE = 0.2                  # constant throttle value during path following
+USE_CONSTANT_THROTTLE = False       # whether or not to use the constant throttle or variable throttle captured during path recording
 SAVE_PATH_BTN = "cross"             # joystick button to save path
 RESET_ORIGIN_BTN = "triangle"       # joystick button to press to move car back to origin
 

--- a/donkeycar/templates/cfg_path_follow.py
+++ b/donkeycar/templates/cfg_path_follow.py
@@ -647,6 +647,7 @@ PID_P = -0.5                        # proportional mult for PID path follower
 PID_I = 0.000                       # integral mult for PID path follower
 PID_D = -0.3                        # differential mult for PID path follower
 PID_THROTTLE = 0.50                 # constant throttle value during path following
+USE_CONSTANT_THROTTLE = False       # whether or not to use the constant throttle or variable throttle captured during path recording
 PID_D_DELTA = 0.25                  # amount the inc/dec function will change the D value
 PID_P_DELTA = 0.25                  # amount the inc/dec function will change the P value
 

--- a/donkeycar/templates/cfg_simulator.py
+++ b/donkeycar/templates/cfg_simulator.py
@@ -264,6 +264,7 @@ PID_P = -10.0                       # proportional mult for PID path follower
 PID_I = 0.000                       # integral mult for PID path follower
 PID_D = -0.2                        # differential mult for PID path follower
 PID_THROTTLE = 0.2                  # constant throttle value during path following
+USE_CONSTANT_THROTTLE = False       # whether or not to use the constant throttle or variable throttle captured during path recording
 SAVE_PATH_BTN = "cross"             # joystick button to save path
 RESET_ORIGIN_BTN = "triangle"       # joystick button to press to move car back to origin
 

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -57,7 +57,7 @@ from docopt import docopt
 
 import donkeycar as dk
 from donkeycar.parts.controller import JoystickController
-from donkeycar.parts.path import CsvVelocityPath, PathPlot, CTE, PID_Pilot, \
+from donkeycar.parts.path import CsvThrottlePath, PathPlot, CTE, PID_Pilot, \
     PlotCircle, PImage, OriginOffset
 from donkeycar.parts.transform import PIDController
 from donkeycar.parts.kinematics import TwoWheelSteeringThrottle
@@ -211,8 +211,8 @@ def drive(cfg, use_joystick=False, camera_type='single'):
 
     # This is the path object. It will record a path when distance changes and it travels
     # at least cfg.PATH_MIN_DIST meters. Except when we are in follow mode, see below...
-    path = CsvVelocityPath(min_dist=cfg.PATH_MIN_DIST)
-    V.add(path, inputs=['recording', 'pos/x', 'pos/y', 'user/throttle'], outputs=['path', 'velocities'])
+    path = CsvThrottlePath(min_dist=cfg.PATH_MIN_DIST)
+    V.add(path, inputs=['recording', 'pos/x', 'pos/y', 'user/throttle'], outputs=['path', 'throttles'])
 
     if cfg.DONKEY_GYM:
         lpos = LoggerPart(inputs=['dist/left', 'dist/right', 'dist', 'pos/pos_x', 'pos/pos_y', 'yaw'], level="INFO", logger="simulator")
@@ -291,7 +291,7 @@ def drive(cfg, use_joystick=False, camera_type='single'):
     # This will use the cross track error and PID constants to try to steer back towards the path.
     pid = PIDController(p=cfg.PID_P, i=cfg.PID_I, d=cfg.PID_D)
     pilot = PID_Pilot(pid, cfg.PID_THROTTLE, cfg.USE_CONSTANT_THROTTLE)
-    V.add(pilot, inputs=['cte/error', 'velocities', 'cte/closest_pt'], outputs=['pilot/angle', 'pilot/throttle'], run_condition="run_pilot")
+    V.add(pilot, inputs=['cte/error', 'throttles', 'cte/closest_pt'], outputs=['pilot/angle', 'pilot/throttle'], run_condition="run_pilot")
 
     def dec_pid_d():
         pid.Kd -= cfg.PID_D_DELTA

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -211,7 +211,7 @@ def drive(cfg, use_joystick=False, camera_type='single'):
 
     # This is the path object. It will record a path when distance changes and it travels
     # at least cfg.PATH_MIN_DIST meters. Except when we are in follow mode, see below...
-    path = CsvThrottlePath(min_dist=cfg.PATH_MIN_DIST, default_throttle=cfg.PID_THROTTLE)
+    path = CsvThrottlePath(min_dist=cfg.PATH_MIN_DIST)
     V.add(path, inputs=['recording', 'pos/x', 'pos/y', 'user/throttle'], outputs=['path', 'throttles'])
 
     if cfg.DONKEY_GYM:

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -290,7 +290,7 @@ def drive(cfg, use_joystick=False, camera_type='single'):
 
     # This will use the cross track error and PID constants to try to steer back towards the path.
     pid = PIDController(p=cfg.PID_P, i=cfg.PID_I, d=cfg.PID_D)
-    pilot = PID_Pilot(pid, cfg.PID_THROTTLE, cfg.USE_CONSTANT_THROTTLE)
+    pilot = PID_Pilot(pid, cfg.PID_THROTTLE, cfg.USE_CONSTANT_THROTTLE, min_throttle=cfg.PID_THROTTLE)
     V.add(pilot, inputs=['cte/error', 'throttles', 'cte/closest_pt'], outputs=['pilot/angle', 'pilot/throttle'], run_condition="run_pilot")
 
     def dec_pid_d():

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -57,7 +57,7 @@ from docopt import docopt
 
 import donkeycar as dk
 from donkeycar.parts.controller import JoystickController
-from donkeycar.parts.path import CsvPath, PathPlot, CTE, PID_Pilot, \
+from donkeycar.parts.path import CsvVelocityPath, PathPlot, CTE, PID_Pilot, \
     PlotCircle, PImage, OriginOffset
 from donkeycar.parts.transform import PIDController
 from donkeycar.parts.kinematics import TwoWheelSteeringThrottle
@@ -211,8 +211,8 @@ def drive(cfg, use_joystick=False, camera_type='single'):
 
     # This is the path object. It will record a path when distance changes and it travels
     # at least cfg.PATH_MIN_DIST meters. Except when we are in follow mode, see below...
-    path = CsvPath(min_dist=cfg.PATH_MIN_DIST)
-    V.add(path, inputs=['recording', 'pos/x', 'pos/y'], outputs=['path'])
+    path = CsvVelocityPath(min_dist=cfg.PATH_MIN_DIST)
+    V.add(path, inputs=['recording', 'pos/x', 'pos/y', 'user/throttle'], outputs=['path', 'velocities'])
 
     if cfg.DONKEY_GYM:
         lpos = LoggerPart(inputs=['dist/left', 'dist/right', 'dist', 'pos/pos_x', 'pos/pos_y', 'yaw'], level="INFO", logger="simulator")

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -290,8 +290,8 @@ def drive(cfg, use_joystick=False, camera_type='single'):
 
     # This will use the cross track error and PID constants to try to steer back towards the path.
     pid = PIDController(p=cfg.PID_P, i=cfg.PID_I, d=cfg.PID_D)
-    pilot = PID_Pilot(pid, cfg.PID_THROTTLE)
-    V.add(pilot, inputs=['cte/error'], outputs=['pilot/angle', 'pilot/throttle'], run_condition="run_pilot")
+    pilot = PID_Pilot(pid, cfg.PID_THROTTLE, cfg.USE_CONSTANT_THROTTLE)
+    V.add(pilot, inputs=['cte/error', 'velocities', 'cte/closest_pt'], outputs=['pilot/angle', 'pilot/throttle'], run_condition="run_pilot")
 
     def dec_pid_d():
         pid.Kd -= cfg.PID_D_DELTA

--- a/donkeycar/templates/path_follow.py
+++ b/donkeycar/templates/path_follow.py
@@ -211,7 +211,7 @@ def drive(cfg, use_joystick=False, camera_type='single'):
 
     # This is the path object. It will record a path when distance changes and it travels
     # at least cfg.PATH_MIN_DIST meters. Except when we are in follow mode, see below...
-    path = CsvThrottlePath(min_dist=cfg.PATH_MIN_DIST)
+    path = CsvThrottlePath(min_dist=cfg.PATH_MIN_DIST, default_throttle=cfg.PID_THROTTLE)
     V.add(path, inputs=['recording', 'pos/x', 'pos/y', 'user/throttle'], outputs=['path', 'throttles'])
 
     if cfg.DONKEY_GYM:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.24",
+      version="4.3.25",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.3.25",
+      version="4.4.1-main",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(name='donkeycar',
           'pc': [
               'matplotlib',
               'kivy',
+              'protobuf==3.20.3',
               'pandas',
               'pyyaml',
               'plotly',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.4.3-main",
+      version="4.4.4-main",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
Added support for variable throttle in `path_follow` by modifying the waypoint data structure to record the throttle at each waypoint. The feature may be turned off by setting `USE_CONSTANT_THROTTLE = True` in your `myconfig.py` (the flag is set to `False` by default).

Closes #1047.