### PR TITLE
Fix imu input in the complete template. 

### DIFF
--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -371,10 +371,16 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
 
         elif model_type == "imu":
             assert cfg.HAVE_IMU, 'Missing imu parameter in config'
-            # Run the pilot if the mode is not user.
-            inputs = ['cam/image_array',
-                    'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
-                    'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z']
+
+            class Vectorizer:
+                def run(self, *components):
+                    return components
+
+            V.add(Vectorizer, inputs=['imu/acl_x', 'imu/acl_y', 'imu/acl_z',
+                                      'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'],
+                  outputs=['imu_array'])
+
+            inputs = ['cam/image_array', 'imu_array']
         else:
             inputs = ['cam/image_array']
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="4.4.2-main",
+      version="4.4.3-main",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',


### PR DESCRIPTION
The imu keras part expects an array for the imu data as a second input to the model. Creating a 3-liner vectorizer part to do this. This is a follow up from the discussion on discord: https://discord.com/channels/662098530411741184/1046926296116101180/1047206276066717746.