### PR TITLE
Train script missing transfer parameter

### DIFF
--- a/donkeycar/templates/train.py
+++ b/donkeycar/templates/train.py
@@ -4,9 +4,11 @@ Scripts to train a keras model using tensorflow.
 Basic usage should feel familiar: train.py --tubs data/ --model models/mypilot.h5
 
 Usage:
-    train.py [--tubs=tubs] (--model=<model>)
-    [--type=(linear|inferred|tensorrt_linear|tflite_linear)]
+    train.py  [--tubs=tubs] (--model=<model>)
+    [--type=(linear|inferred|tensorrt_linear|tflite_linear)] 
+    [--transfer=<transfer_model>]
     [--comment=<comment>]
+
 
 Options:
     -h --help              Show this screen.
@@ -20,11 +22,15 @@ from donkeycar.pipeline.training import train
 def main():
     args = docopt(__doc__)
     cfg = dk.load_config()
-    tubs = args['--tubs']
+    tubs =  args['--tubs']
+    if tubs == None:
+        tubs = 'data/'
     model = args['--model']
     model_type = args['--type']
+    transfer = args['--transfer']
     comment = args['--comment']
-    train(cfg, tubs, model, model_type, comment)
+    
+    train(cfg, tubs, model, model_type, transfer, comment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The train.py script was missing the parameter to pass a transfer model.  This caused the comment to be interpreted as a transfer model and caused an error.  

1. Added a command line parameter to optionally specify transfer model
2. Updated docopt usage script
3. Updated call to pipeline.training.train()
4. Also added code to specify tubs as "data/" if not specified on command line.  The usage string specifies that the tubs parameter is optional.