### PR TITLE
1104 fix user angle in deep learning

### DIFF
--- a/donkeycar/parts/pipe.py
+++ b/donkeycar/parts/pipe.py
@@ -2,12 +2,7 @@ class Pipe:
     """
     Just pipe all inputs to the output, so they can be renamed.
     """
-    def __init__(self):
-        self.running = True
-
     def run(self, *args):
-        if self.running:
-            return args
-
-    def shutdown(self):
-        self.running = False
+        # seems to be a python bug that takes a single argument
+        # return makes it into two element tuple with empty last element.
+        return args if len(args) > 1 else args[0]

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -41,6 +41,7 @@ from donkeycar.parts.kinematics import Bicycle, InverseBicycle, BicycleUnnormali
 from donkeycar.parts.explode import ExplodeDict
 from donkeycar.parts.transform import Lambda
 from donkeycar.parts.logger import LoggerPart
+from donkeycar.parts.pipe import Pipe
 from donkeycar.utils import *
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,11 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     #
     has_input_controller = hasattr(cfg, "CONTROLLER_TYPE") and cfg.CONTROLLER_TYPE != "mock"
     ctr = add_user_controller(V, cfg, use_joystick)
+
+    #
+    # convert 'user/steering' to 'user/angle' to be backward compatible with deep learning data
+    #
+    V.add(Pipe(inputs='user/steering', outputs='user/angle'))
 
     #
     # explode the buttons input map into individual output key/values in memory
@@ -437,7 +443,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     # based on the choice of user or autopilot drive mode
     #
     V.add(DriveMode(cfg.AI_THROTTLE_MULT),
-          inputs=['user/mode', 'user/steering', 'user/throttle',
+          inputs=['user/mode', 'user/angle', 'user/throttle',
                   'pilot/steering', 'pilot/throttle'],
           outputs=['steering', 'throttle'])
 
@@ -471,10 +477,10 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     # add tub to save data
     #
     if cfg.USE_LIDAR:
-        inputs = ['cam/image_array', 'lidar/dist_array', 'user/steering', 'user/throttle', 'user/mode']
+        inputs = ['cam/image_array', 'lidar/dist_array', 'user/angle', 'user/throttle', 'user/mode']
         types = ['image_array', 'nparray','float', 'float', 'str']
     else:
-        inputs=['cam/image_array','user/steering', 'user/throttle', 'user/mode']
+        inputs=['cam/image_array','user/angle', 'user/throttle', 'user/mode']
         types=['image_array','float', 'float','str']
 
     if cfg.HAVE_ODOM:

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -393,7 +393,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         #
         # collect model inference outputs
         #
-        outputs = ['pilot/steering', 'pilot/throttle']
+        outputs = ['pilot/angle', 'pilot/throttle']
 
         if cfg.TRAIN_LOCALIZER:
             outputs.append("pilot/loc")
@@ -444,7 +444,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     #
     V.add(DriveMode(cfg.AI_THROTTLE_MULT),
           inputs=['user/mode', 'user/angle', 'user/throttle',
-                  'pilot/steering', 'pilot/throttle'],
+                  'pilot/angle', 'pilot/throttle'],
           outputs=['steering', 'throttle'])
 
     V.add(LoggerPart(['steering', 'throttle']), inputs=['steering', 'throttle'])
@@ -518,7 +518,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             types  += ['nparray']
 
     if cfg.RECORD_DURING_AI:
-        inputs += ['pilot/steering', 'pilot/throttle']
+        inputs += ['pilot/angle', 'pilot/throttle']
         types += ['float', 'float']
 
     if cfg.HAVE_PERFMON:

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -40,7 +40,6 @@ from donkeycar.parts.kinematics import Unicycle, InverseUnicycle, UnicycleUnnorm
 from donkeycar.parts.kinematics import Bicycle, InverseBicycle, BicycleUnnormalizeAngularVelocity
 from donkeycar.parts.explode import ExplodeDict
 from donkeycar.parts.transform import Lambda
-from donkeycar.parts.logger import LoggerPart
 from donkeycar.parts.pipe import Pipe
 from donkeycar.utils import *
 
@@ -136,7 +135,7 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     #
     # convert 'user/steering' to 'user/angle' to be backward compatible with deep learning data
     #
-    V.add(Pipe(inputs='user/steering', outputs='user/angle'))
+    V.add(Pipe(), inputs=['user/steering'], outputs=['user/angle'])
 
     #
     # explode the buttons input map into individual output key/values in memory
@@ -447,7 +446,6 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
                   'pilot/angle', 'pilot/throttle'],
           outputs=['steering', 'throttle'])
 
-    V.add(LoggerPart(['steering', 'throttle']), inputs=['steering', 'throttle'])
 
     if (cfg.CONTROLLER_TYPE != "pigpio_rc") and (cfg.CONTROLLER_TYPE != "MM1"):
         if isinstance(ctr, JoystickController):


### PR DESCRIPTION
I added a serious bug in complete.py when I renamed the steering output from `'user/angle'` to `'user/steering'`.  It turns out the the literal string 'user/angle' is used all over the place in the deep learning pipeline and DonkeyUI, so we can't change it.  

This fix the fixes complete.py so it uses 'user/angle' and 'pilot/angle'.  This has been tested doing data collection, training and inference in autopilot mode.

The fix works by renaming the 'user/steering' value to 'user/angle' so both are in memory.  I found and fixed a bug in the Pipe() part that happens when renaming a single argument; Python's variable argument facility outputs a tuple with two elements when only a single argument was passed; I now check for that and explicitly send back the single argument.


