### PR TITLE
Fix missing data handling

### DIFF
--- a/donkeycar/management/kivy_ui.py
+++ b/donkeycar/management/kivy_ui.py
@@ -393,6 +393,9 @@ class FullImage(Image):
         """ This method is called ever time a record gets updated. """
         try:
             img_arr = self.get_image(record)
+            if img_arr is None:
+                Logger.error(f'Record: Could not get any image data')
+                return
             pil_image = PilImage.fromarray(img_arr)
             bytes_io = io.BytesIO()
             pil_image.save(bytes_io, format='png')

--- a/donkeycar/parts/datastore_v2.py
+++ b/donkeycar/parts/datastore_v2.py
@@ -418,11 +418,14 @@ class ManifestIterator(object):
                 raise StopIteration('No more catalogs')
 
             if self.current_catalog is None:
-                current_catalog_path = os.path.join(
-                    self.manifest.base_path,
-                    self.manifest.catalog_paths[self.current_catalog_index])
+                catalog_path = self.manifest.catalog_paths[self.current_catalog_index]
+                current_catalog_path = os.path.join(self.manifest.base_path,catalog_path)
                 self.current_catalog = Catalog(current_catalog_path,
                                                read_only=self.manifest.read_only)
+                catalog_start_index = self.current_catalog.manifest.start_index()
+                if catalog_start_index is not None and self.current_index != catalog_start_index:
+                    logger.warning(f'Correcting current_index because Catalog [{catalog_path}] start_index [{catalog_start_index}] is not matching the current_index [{self.current_index}].')
+                    self.current_index = catalog_start_index
                 self.current_catalog.seekable.seek_line_start(1)
 
             contents = self.current_catalog.seekable.readline()

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -177,9 +177,8 @@ def load_pil_image(filename, cfg):
             img = img.convert('L')
         
         return img
-
     except Exception as e:
-        logger.error(f'failed to load image from {filename}: {e.message}')
+        logger.error(f'failed to load image from {filename}: {e}')
         return None
 
 
@@ -225,7 +224,7 @@ def load_image_sized(filename, image_width, image_height, image_depth):
         return img_arr
 
     except Exception as e:
-        logger.error(f'failed to load image from {filename}: {e.message}')
+        logger.error(f'failed to load image from {filename}: {e}')
         return None
 
 


### PR DESCRIPTION
This PR is for handling the case of some missing data during data loading better.

In our case we a lot of catalogs with really bad data so we just deleted that from the manifest.

Since the start index is specified in the catalogs, it seems only correct to use it.