### PR TITLE
Fixing setup.py for jetson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,6 @@ setup(name='donkeycar',
               'adafruit-circuitpython-rplidar',
               'Jetson.GPIO',
               'matplotlib',
-              'kivy-jetson',
-              'plotly'
           ],
           'nano': [
               'Adafruit_PCA9685',
@@ -82,7 +80,7 @@ setup(name='donkeycar',
               'adafruit-circuitpython-rplidar',
               'Jetson.GPIO',
               'matplotlib',
-              'kivy',
+              'kivy-jetson',
               'plotly'
           ],
           'pc': [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='donkeycar',
-      version="5.0.dev2",
+      version="5.0.dev3",
       long_description=long_description,
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',
@@ -53,7 +53,8 @@ setup(name='donkeycar',
           "pynmea2",
           'pyserial',
           "utm",
-          'pandas'
+          'pandas',
+          'pyyaml',
       ],
       extras_require={
           # if installing into a conda (i.e. miniforge) env on Pi we have to
@@ -71,10 +72,8 @@ setup(name='donkeycar',
               'adafruit-circuitpython-ssd1306',
               'adafruit-circuitpython-rplidar',
               'Jetson.GPIO',
-              'albumentations',
               'matplotlib',
               'kivy-jetson',
-              'pyyaml',
               'plotly'
           ],
           'nano': [
@@ -84,14 +83,12 @@ setup(name='donkeycar',
               'Jetson.GPIO',
               'matplotlib',
               'kivy',
-              'pyyaml',
               'plotly'
           ],
           'pc': [
               'matplotlib',
               'kivy',
               'pandas',
-              'pyyaml',
               'plotly',
               'albumentations'
           ],
@@ -128,8 +125,8 @@ setup(name='donkeycar',
           'License :: OSI Approved :: MIT License',
           # Specify the Python versions you support here. In particular, ensure
           # that you indicate whether you support Python 2, Python 3 or both.
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
       ],
       keywords='selfdriving cars donkeycar diyrobocars',
       packages=find_packages(exclude=(['tests', 'docs', 'site', 'env'])),


### PR DESCRIPTION
Remove albumentations from jetson setup and move pyyaml into the required section, so it also installs on RPi. Also bump version.