### PR TITLE
Update test expression to remove logical short circuit

### DIFF
--- a/donkeycar/management/makemovie.py
+++ b/donkeycar/management/makemovie.py
@@ -169,7 +169,7 @@ class MakeMovie(object):
                 output_name.append(layer.name)
                 layer_idx.append(i)
 
-        if output_name is []:
+        if output_name == []:
             print("Failed to find the model layer named with 'out'. Skipping salient.")
             return False
 


### PR DESCRIPTION
In file: makemovie.py, method: `init_salient`, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity an match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

The following binary operation

      output_name is []

compares a newly created object with the identity operator which will always evaluate to False.

I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.