### PR TITLE
#1154 - Add tensorflow-metal to Mac setup 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ pc =
 
 macos =
     tensorflow-macos==2.9.2
-    tensorflow-metal=0.5.1
+    tensorflow-metal==0.5.1
     matplotlib
     kivy==2.1
     pandas


### PR DESCRIPTION
Tensorflow-metal will accelerate tensorflow on Mac computers, both Intel and ARM (M1 M2 M3).