### PR TITLE
Upgrade to python 3.11 and TensorFlow 2.15.X

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Create python 3.9 conda env
+      - name: Create python 3.11 conda env
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.9
+          python-version: 3.11
           mamba-version: "*"
           activate-environment: donkey
           auto-activate-base: false

--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -3,7 +3,7 @@ import sys
 from pyfiglet import Figlet
 import logging
 
-__version__ = '5.1.dev0'
+__version__ = '5.1.dev1'
 
 logging.basicConfig(level=os.environ.get('LOGLEVEL', 'INFO').upper())
 
@@ -13,8 +13,8 @@ f = Figlet(font='speed')
 print(f.renderText('Donkey Car'))
 print(f'using donkey v{__version__} ...')
 
-if sys.version_info.major < 3 or sys.version_info.minor < 8:
-    msg = f'Donkey Requires Python 3.8 or greater. You are using {sys.version}'
+if sys.version_info.major < 3 or sys.version_info.minor < 11:
+    msg = f'Donkey Requires Python 3.11 or greater. You are using {sys.version}'
     raise ValueError(msg)
 
 # The default recursion limits in CPython are too small.

--- a/donkeycar/management/ui.kv
+++ b/donkeycar/management/ui.kv
@@ -104,7 +104,7 @@
         valign: 'middle'
         font_size: 14 if platform == 'linux' else 28
         size_hint_x: 0.8
-        padding_x: 10
+        padding: 10, 0
         canvas.before:
             Color:
                 rgba: 0.14, 0.15, 0.22, 1

--- a/donkeycar/parts/pytorch/torch_train.py
+++ b/donkeycar/parts/pytorch/torch_train.py
@@ -46,7 +46,7 @@ def train(cfg, tub_paths, model_output_path, model_type, checkpoint_path=None):
 
     if cfg.PRINT_MODEL_SUMMARY:
         summarize(model)
-    trainer = pl.Trainer(gpus=gpus, logger=logger, max_epochs=cfg.MAX_EPOCHS,
+    trainer = pl.Trainer(logger=logger, max_epochs=cfg.MAX_EPOCHS,
                          default_root_dir=output_dir)
 
     data_module = TorchTubDataModule(cfg, tub_paths)

--- a/donkeycar/parts/pytorch/torch_train.py
+++ b/donkeycar/parts/pytorch/torch_train.py
@@ -46,8 +46,8 @@ def train(cfg, tub_paths, model_output_path, model_type, checkpoint_path=None):
 
     if cfg.PRINT_MODEL_SUMMARY:
         summarize(model)
-    trainer = pl.Trainer(logger=logger, max_epochs=cfg.MAX_EPOCHS,
-                         default_root_dir=output_dir)
+    trainer = pl.Trainer(accelerator='cpu', logger=logger,
+                         max_epochs=cfg.MAX_EPOCHS, default_root_dir=output_dir)
 
     data_module = TorchTubDataModule(cfg, tub_paths)
     trainer.fit(model, data_module)

--- a/donkeycar/parts/telemetry.py
+++ b/donkeycar/parts/telemetry.py
@@ -14,6 +14,7 @@ import logging
 import numpy as np
 from logging import StreamHandler
 from paho.mqtt.client import Client as MQTTClient
+from paho.mqtt.enums import CallbackAPIVersion
 
 logger = logging.getLogger()
 
@@ -40,7 +41,7 @@ class MqttTelemetry(StreamHandler):
         self._mqtt_broker = os.environ.get('DONKEY_MQTT_BROKER', cfg.TELEMETRY_MQTT_BROKER_HOST)  # 'iot.eclipse.org'
         self._topic = cfg.TELEMETRY_MQTT_TOPIC_TEMPLATE % self._donkey_name
         self._use_json_format = cfg.TELEMETRY_MQTT_JSON_ENABLE
-        self._mqtt_client = MQTTClient()
+        self._mqtt_client = MQTTClient(callback_api_version=CallbackAPIVersion.VERSION2)
         self._mqtt_client.connect(self._mqtt_broker, cfg.TELEMETRY_MQTT_BROKER_PORT)
         self._mqtt_client.loop_start()
         self._on = True

--- a/donkeycar/tests/test_telemetry.py
+++ b/donkeycar/tests/test_telemetry.py
@@ -3,6 +3,8 @@
 import time
 from unittest import mock
 from paho.mqtt.client import Client
+from paho.mqtt.enums import CallbackAPIVersion
+
 import donkeycar.templates.cfg_complete as cfg
 from donkeycar.parts.telemetry import MqttTelemetry
 import pytest
@@ -16,7 +18,8 @@ def test_mqtt_telemetry():
     cfg.TELEMETRY_MQTT_JSON_ENABLE = True
 
     # Create receiver
-    sub = Client(clean_session=True)
+    sub = Client(callback_api_version=CallbackAPIVersion.API_VERSION2,
+                 clean_session=True)
 
     # def on_message(client, userdata, message):
     #     data = message.payload

--- a/donkeycar/tests/test_telemetry.py
+++ b/donkeycar/tests/test_telemetry.py
@@ -7,7 +7,6 @@ from paho.mqtt.enums import CallbackAPIVersion
 
 import donkeycar.templates.cfg_complete as cfg
 from donkeycar.parts.telemetry import MqttTelemetry
-import pytest
 from random import randint
 
 
@@ -18,12 +17,8 @@ def test_mqtt_telemetry():
     cfg.TELEMETRY_MQTT_JSON_ENABLE = True
 
     # Create receiver
-    sub = Client(callback_api_version=CallbackAPIVersion.API_VERSION2,
+    sub = Client(callback_api_version=CallbackAPIVersion.VERSION2,
                  clean_session=True)
-
-    # def on_message(client, userdata, message):
-    #     data = message.payload
-    #     print(message)
 
     on_message_mock = mock.Mock()
     sub.on_message = on_message_mock

--- a/donkeycar/tests/test_torch.py
+++ b/donkeycar/tests/test_torch.py
@@ -109,7 +109,7 @@ def test_training_pipeline(config: Config, model_type: str, car_dir: str) \
         gpus = 0
 
     # Overfit the data
-    trainer = pl.Trainer(gpus=gpus, overfit_batches=2, max_epochs=30)
+    trainer = pl.Trainer(overfit_batches=2, max_epochs=30)
     trainer.fit(model, data_module)
     final_loss = model.loss_history[-1]
     assert final_loss < 0.35, \

--- a/donkeycar/tests/test_torch.py
+++ b/donkeycar/tests/test_torch.py
@@ -109,7 +109,7 @@ def test_training_pipeline(config: Config, model_type: str, car_dir: str) \
         gpus = 0
 
     # Overfit the data
-    trainer = pl.Trainer(overfit_batches=2, max_epochs=30)
+    trainer = pl.Trainer(accelerator='cpu', overfit_batches=2, max_epochs=30)
     trainer.fit(model, data_module)
     final_loss = model.loss_history[-1]
     assert final_loss < 0.35, \

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,14 +17,13 @@ classifiers =
     # Indicate who your project is intended for
     Intended Audience :: Developers
     Topic :: Scientific/Engineering :: Artificial Intelligence
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find_namespace:
 zip_safe = True
 include_package_data = True
-python_requires = >=3.8,<4
+python_requires = >=3.11.0,<3.12
 install_requires =
     numpy
     pillow
@@ -51,7 +50,7 @@ pi =
     adafruit-circuitpython-ssd1306
     adafruit-circuitpython-rplidar
     RPi.GPIO
-    tensorflow-aarch64==2.9.3
+    tensorflow-aarch64==2.15
     opencv-contrib-python
 
 nano =
@@ -66,7 +65,7 @@ nano =
     pandas==2.0
 
 pc =
-    tensorflow==2.9
+    tensorflow==2.13
     matplotlib
     kivy==2.1
     pandas
@@ -74,7 +73,7 @@ pc =
     albumentations
 
 macos =
-    tensorflow-macos==2.9
+    tensorflow-macos==2.13
     matplotlib
     kivy==2.1
     pandas
@@ -88,7 +87,8 @@ dev =
     mypy
 
 torch =
-    pytorch
+    torch
+    pytorch-lightning
     torchvision==0.12
     torchaudio
     fastai

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     paho-mqtt
     simple_pid
     progress
-    typing_extensions
     pyfiglet
     psutil
     pynmea2
@@ -60,14 +59,14 @@ nano =
     Jetson.GPIO
     numpy==1.23
     matplotlib==3.7
-    kivy==2.1
+    kivy
     plotly
     pandas==2.0
 
 pc =
     tensorflow==2.13
     matplotlib
-    kivy==2.1
+    kivy
     pandas
     plotly
     albumentations
@@ -75,7 +74,7 @@ pc =
 macos =
     tensorflow-macos==2.13
     matplotlib
-    kivy==2.1
+    kivy
     pandas
     plotly
     albumentations
@@ -89,7 +88,7 @@ dev =
 torch =
     torch
     pytorch-lightning
-    torchvision==0.12
+    torchvision
     torchaudio
     fastai
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ pi =
     adafruit-circuitpython-ssd1306
     adafruit-circuitpython-rplidar
     RPi.GPIO
-    tensorflow-aarch64==2.15
+    tensorflow-aarch64==2.15.*
     opencv-contrib-python
 
 nano =
@@ -57,14 +57,14 @@ nano =
     adafruit-circuitpython-ssd1306
     adafruit-circuitpython-rplidar
     Jetson.GPIO
-    numpy==1.23
-    matplotlib==3.7
+    numpy==1.23.*
+    matplotlib==3.7.*
     kivy
     plotly
-    pandas==2.0
+    pandas==2.0.*
 
 pc =
-    tensorflow==2.13
+    tensorflow==2.15.*
     matplotlib
     kivy
     pandas
@@ -72,7 +72,7 @@ pc =
     albumentations
 
 macos =
-    tensorflow-macos==2.13
+    tensorflow-macos==2.15.*
     matplotlib
     kivy
     pandas


### PR DESCRIPTION
# Upgrade Python and TensorFlow

After upgrading of the default Raspberry Pi OS version to bookworm which is using Python 3.11 as system python version we need to lock into that upgrade for Donkey Car. The changes here consist of:

* Upgrading the CI to use python 3.11: the CI now runs about twice as fast as before
* Upgrading and unfreezing certain python package in setup.cfg as they were tagging too old versions
* Fixing minor compatibility issues in the pytorch, telemetry and ui code as a consequence of above package upgrades

The python upgrade is improving performance by a measurable amount because 3.11 has a much faster Cpython implementation than 3.9.  