### PR TITLE
Fix augmentations and matplotlib

### DIFF
--- a/donkeycar/config.py
+++ b/donkeycar/config.py
@@ -66,8 +66,7 @@ class Config:
 def load_config(config_path=None, myconfig="myconfig.py"):
     
     if config_path is None:
-        import __main__ as main
-        main_path = os.path.dirname(os.path.realpath(main.__file__))
+        main_path = os.getcwd()
         config_path = os.path.join(main_path, 'config.py')
         if not os.path.exists(config_path):
             local_config = os.path.join(os.path.curdir, 'config.py')

--- a/donkeycar/management/ui/common.kv
+++ b/donkeycar/management/ui/common.kv
@@ -1,6 +1,7 @@
 #:import platform sys.platform
 
-#:set common_height 30
+#:set reduced_height 40 if platform == 'darwin' else 20
+#:set common_height 60 if platform == 'darwin' else 30
 #:set spacing 10
 #:set layout_height common_height + spacing
 
@@ -226,7 +227,7 @@
     current_field: data_spinner.text
     BoxLayout:
         size_hint_y: None
-        height: 20
+        height: reduced_height
         spacing: 2
         MyLabel:
             id: label

--- a/donkeycar/management/ui/pilot_screen.kv
+++ b/donkeycar/management/ui/pilot_screen.kv
@@ -104,7 +104,7 @@
         pilot_loader: pilot_loader
     DataPanel:
         size_hint_y: None
-        height: 20 + (self.minimum_height - 20) * 15
+        height: reduced_height + (self.minimum_height - reduced_height) * 15
         id: data_panel
         is_linked: True
         font_color: [0.2, 0.2, 1, 1]
@@ -126,7 +126,7 @@
         BackgroundBoxLayout:
             orientation: 'vertical'
             size_hint_y: None
-            height: self.minimum_height +60
+            height: self.minimum_height + 2 * common_height
             Header:
                 title: 'Multi Pilot Loader'
                 description:
@@ -217,7 +217,7 @@
         BackgroundBoxLayout:
             orientation: 'vertical'
             size_hint_y: None
-            height: self.minimum_height + 90
+            height: self.minimum_height + 3 * common_height
             Slider:
                 size_hint_y: None
                 height: common_height

--- a/donkeycar/management/ui/train_screen.kv
+++ b/donkeycar/management/ui/train_screen.kv
@@ -123,7 +123,7 @@
             orientation: 'vertical'
             spacing: spacing
             size_hint_y: None
-            height: self.minimum_height + 80
+            height: self.minimum_height + 4 * reduced_height
             Header:
                 size_hint_y: 1.5
                 id: cfg_header

--- a/donkeycar/management/ui/ui.kv
+++ b/donkeycar/management/ui/ui.kv
@@ -13,7 +13,7 @@ BoxLayout:
     ActionView:
         id: av
         size_hint_y: None
-        height: 20
+        height: reduced_height
 
         ActionPrevious:
             with_previous: False

--- a/donkeycar/pipeline/augmentations.py
+++ b/donkeycar/pipeline/augmentations.py
@@ -40,6 +40,8 @@ class ImageAugmentation:
 
     # Parts interface
     def run(self, img_arr):
+        if len(self.augmentations) == 0:
+            return img_arr
         aug_img_arr = self.augmentations(image=img_arr)["image"]
         return aug_img_arr
 

--- a/donkeycar/pipeline/training.py
+++ b/donkeycar/pipeline/training.py
@@ -153,7 +153,7 @@ def train(cfg: Config, tub_paths: str, model: str = None,
     assert val_size > 0, "Not enough validation data, decrease the batch " \
                          "size or add more data."
     logger.info(f'Train with image caching: '
-                f'{getattr(cfg, "CACHE_IMAGES", True)}')
+                f'{getattr(cfg, "CACHE_IMAGES", "ARRAY")}')
     history = kl.train(model_path=model_path,
                        train_data=dataset_train,
                        train_steps=train_size,

--- a/donkeycar/tests/setup.py
+++ b/donkeycar/tests/setup.py
@@ -7,7 +7,7 @@ from donkeycar.management.base import CreateCar
 
 
 def on_pi():
-    if 'arm' in platform.machine():
+    if 'aarch64' in platform.machine():
         return True
     return False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ macos =
     albumentations
 
 dev =
-    pytest
+    pytest==8.1.*
     pytest-cov
     responses
     mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ pi =
     flatbuffers==24.3.*
     tensorflow-aarch64==2.15.*
     opencv-contrib-python
-    matplotlib
+    matplotlib==3.8.*
     kivy
     kivy-garden.matplotlib
     pandas
@@ -73,7 +73,7 @@ nano =
 
 pc =
     tensorflow==2.15.*
-    matplotlib
+    matplotlib==3.8.*
     kivy
     kivy-garden.matplotlib
     pandas
@@ -81,8 +81,8 @@ pc =
     albumentations
 
 macos =
-    tensorflow-macos==2.15.*
-    matplotlib
+    tensorflow==2.15.*
+    matplotlib==3.8.*
     kivy
     kivy-garden.matplotlib
     pandas


### PR DESCRIPTION
# Fix recent compatibility issues with augmentations and matplotlib
* There seems to be a non-backward compatible change in matplotlib 3.9.* which we can resolve for the time being, by pegging it to version 3.8.* (https://discord.com/channels/662098530411741184/671604367706554388/1242225275941425193)
* There also seems to be a non-back compatible change in albumentations for empty compositions, for which we have a code fix here
* There is another backward incompatible change in `pytest`, hence pinning this to version 8.1 (https://github.com/mtreinish/stestr/issues/363)
* Also updated layout height for certain widgets in the UI under OSX which are too compressed
* Fixed tensor flow package name under OSX
* Fixed an older `__main__.__file__` expression in `load_config` which I found to be not working