### PR TITLE
Add support from Hokuyo lidar

### DIFF
--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -25,7 +25,7 @@ DRIVE_LOOP_HZ = 20      # the vehicle loop will pause if faster than this speed.
 MAX_LOOPS = None        # the vehicle loop can abort after this many iterations, when given a positive integer.
 
 #CAMERA
-CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|MOCK|IMAGE_LIST)
+CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|OAKD|MOCK|IMAGE_LIST|LIDAR_PLOT)
 IMAGE_W = 160
 IMAGE_H = 120
 IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
@@ -349,9 +349,11 @@ ODOM_DEBUG = False                  # Write out values on vel and distance as it
 
 # #LIDAR
 USE_LIDAR = False
-LIDAR_TYPE = 'RP' #(RP|YD)
+LIDAR_TYPE = 'RP' #(RP|YD|HOKUYO)
 LIDAR_LOWER_LIMIT = 90 # angles that will be recorded. Use this to block out obstructed areas on your car, or looking backwards. Note that for the RP A1M8 Lidar, "0" is in the direction of the motor
 LIDAR_UPPER_LIMIT = 270
+LIDAR_MAX_DIST = 10_000 # Maximum distance for LiDAR. Measured in mm
+LIDAR_ANGLE_OFFSET = 135 # The zero point of the LiDAR is rotated this much in degrees on LidarPlot
 
 # TFMINI
 HAVE_TFMINI = False

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -106,13 +106,18 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
 
     # add lidar
     if cfg.USE_LIDAR:
-        from donkeycar.parts.lidar import RPLidar
         if cfg.LIDAR_TYPE == 'RP':
+            from donkeycar.parts.lidar import RPLidar
             print("adding RP lidar part")
             lidar = RPLidar(lower_limit = cfg.LIDAR_LOWER_LIMIT, upper_limit = cfg.LIDAR_UPPER_LIMIT)
             V.add(lidar, inputs=[],outputs=['lidar/dist_array'], threaded=True)
         if cfg.LIDAR_TYPE == 'YD':
             print("YD Lidar not yet supported")
+        if cfg.LIDAR_TYPE == "HOKUYO":
+            from donkeycar.parts.lidar import HokuyoLidar
+            print("adding Hokuyo lidar part")
+            lidar = HokuyoLidar(max_dist = 10_000)
+            V.add(lidar, inputs=[], outputs=['lidar/dist_scan'], threaded=True)
 
     if cfg.HAVE_TFMINI:
         from donkeycar.parts.tfmini import TFMini
@@ -820,6 +825,9 @@ def get_camera(cfg):
         elif cfg.CAMERA_TYPE == "MOCK":
             from donkeycar.parts.camera import MockCamera
             cam = MockCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+        elif cfg.CAMERA_TYPE == "LIDAR_PLOT":
+            from donkeycar.parts.lidar import LidarPlot2
+            cam = LidarPlot2(resolution=(cfg.IMAGE_H, cfg.IMAGE_W))
         else:
             raise(Exception("Unkown camera type: %s" % cfg.CAMERA_TYPE))
     return cam

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -116,8 +116,8 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         if cfg.LIDAR_TYPE == "HOKUYO":
             from donkeycar.parts.lidar import HokuyoLidar
             print("adding Hokuyo lidar part")
-            lidar = HokuyoLidar(max_dist = 10_000)
-            V.add(lidar, inputs=[], outputs=['lidar/dist_scan'], threaded=True)
+            lidar = HokuyoLidar(max_dist = cfg.LIDAR_MAX_DIST)
+            V.add(lidar, inputs=[], outputs=['lidar/dist_scan'], threaded=False)
 
     if cfg.HAVE_TFMINI:
         from donkeycar.parts.tfmini import TFMini
@@ -880,7 +880,31 @@ def add_camera(V, cfg, camera_type):
               outputs=['cam/image_array', 'cam/depth_array',
                        'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
                        'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'],
+              threaded=False)
+        
+    elif cfg.CAMERA_TYPE == "OAKD":
+        from donkeycar.parts.oak_d import OakD
+        cam = OakD(
+            enable_rgb=cfg.OAKD_RGB,
+            enable_depth=cfg.OAKD_DEPTH,
+            device_id=cfg.OAKD_ID)
+        V.add(cam, inputs=[],
+              outputs=['cam/image_array', 'cam/depth_array'],
               threaded=True)
+    
+    elif cfg.CAMERA_TYPE == "LIDAR_PLOT":
+        from donkeycar.parts.lidar import LidarPlot2
+        cam = LidarPlot2(
+            resolution=(cfg.IMAGE_W, cfg.IMAGE_H),
+            rotate_plot=cfg.LIDAR_ANGLE_OFFSET,
+            max_dist=cfg.LIDAR_MAX_DIST,
+            plot_type=LidarPlot2.PLOT_TYPE_CIRCLE,
+            mark_px=1
+        )
+        V.add(cam, inputs=['lidar/dist_scan'],
+              outputs=['cam/image_array'],
+              threaded=True)
+
     else:
         inputs = []
         outputs = ['cam/image_array']


### PR DESCRIPTION
- Part in `lidar.py` to interface with Hokuyo
- Fixes to `LidarPlot2` to be used with Hokuyo so it can act as a `Camera` in the web interface
- Integration of `LidarPlot2` with existing templates/configs

**Notes:** 
To set it up you need to configure the Ethernet port on the Pi by creating a file in `/etc/interfaces.d`. This is well-described by many online tutorials, and googling "f1tenth hokuyo" also brings up a lot of helpful info. 

Also, unlike the RPLidar(2) parts, instead of returning a generator of individual measurements this part returns the entire scan at once. Thus in `complete.py` it is called `lidar/dist_scan` instead of `lidar/dist_array`. 

**Pictures:** 
![image](https://github.com/autorope/donkeycar/assets/37602685/0041826a-cd32-4c38-8db0-2498ce08213e)
![IMG_8345](https://github.com/autorope/donkeycar/assets/37602685/7c104d48-3243-4d80-a3fe-bf48aedf8f37)
![IMG_8347](https://github.com/autorope/donkeycar/assets/37602685/d2211e70-071e-42e5-877a-43bec6a81a80)



