### PR TITLE
Add Support for Video Games as a Medium of Control/Recording

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -21,6 +21,11 @@ except ImportError as e:
     logger.warning(f"RPi.GPIO was not imported. {e}")
     globals()["GPIO"] = None
 
+try:
+    import pyxinput
+except ImportError as e:
+    logger.warn(f"pyxinput was not imported. {e}")
+
 from donkeycar.parts.pins import OutputPin, PwmPin, PinState
 from donkeycar.utilities.deprecated import deprecated
 
@@ -1158,3 +1163,29 @@ class ArdPWMThrottle:
         # stop vehicle
         self.run(0)
         self.running = False
+
+class VirtualController:
+    '''
+    Simulate a controller with a virtual joystick.
+    For use with video game control.
+    '''
+    def __init__(self):
+        self.angle = 0
+        self.throttle = 0
+        self.controller = pyxinput.vController()
+
+    def run(self, angle, throttle):
+        self.angle = angle
+        self.throttle = throttle
+
+        # angle
+        self.controller.set_value('AxisLx', angle)
+
+        # throttle
+        if throttle > 0:
+            self.controller.set_value('TriggerR', throttle)
+        else:
+            self.controller.set_value('TriggerL', -throttle)
+
+    def shutdown(self):
+        self.controller.UnPlug()

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -25,7 +25,7 @@ DRIVE_LOOP_HZ = 20      # the vehicle loop will pause if faster than this speed.
 MAX_LOOPS = None        # the vehicle loop can abort after this many iterations, when given a positive integer.
 
 #CAMERA
-CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|MOCK|IMAGE_LIST)
+CAMERA_TYPE = "PICAM"   # (PICAM|WEBCAM|CVCAM|CSIC|V4L|D435|MOCK|IMAGE_LIST|SCREENSHOT)
 IMAGE_W = 160
 IMAGE_H = 120
 IMAGE_DEPTH = 3         # default RGB=3, make 1 for mono
@@ -66,6 +66,7 @@ SSD1306_RESOLUTION = 1 # 1 = 128x32; 2 = 128x64
 # "DC_TWO_WHEEL_L298N" using HBridge in 3-pin mode to control two drive motors, one of the left and one on the right.
 # "MOCK" no drive train.  This can be used to test other features in a test rig.
 # "VESC" VESC Motor controller to set servo angle and duty cycle
+# "VIRTUAL" Simulates an Xbox controller, can be used with Donkey in a video game environment.
 # (deprecated) "SERVO_HBRIDGE_PWM" use ServoBlaster to output pwm control from the PiZero directly to control steering,
 #                                  and HBridge for a drive motor.
 # (deprecated) "PIGPIO_PWM" uses Raspberrys internal PWM

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -820,6 +820,9 @@ def get_camera(cfg):
         elif cfg.CAMERA_TYPE == "MOCK":
             from donkeycar.parts.camera import MockCamera
             cam = MockCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
+        elif cfg.CAMERA_TYPE == "SCREENSHOT":
+            from donkeycar.parts.camera import ScreenCamera
+            cam = ScreenCamera(image_w=cfg.IMAGE_W, image_h=cfg.IMAGE_H, image_d=cfg.IMAGE_DEPTH)
         else:
             raise(Exception("Unkown camera type: %s" % cfg.CAMERA_TYPE))
     return cam
@@ -873,6 +876,18 @@ def add_camera(V, cfg, camera_type):
                        'imu/acl_x', 'imu/acl_y', 'imu/acl_z',
                        'imu/gyr_x', 'imu/gyr_y', 'imu/gyr_z'],
               threaded=True)
+        
+    elif cfg.CAMERA_TYPE == "SCREENSHOT":
+        from donkeycar.parts.camera import ScreenCamera
+        cam = ScreenCamera(
+            image_w=cfg.IMAGE_W, 
+            image_h=cfg.IMAGE_H,
+            vflip=cfg.CAMERA_VFLIP,
+            hflip=cfg.CAMERA_HFLIP)
+        V.add(cam, 
+              outputs=['cam/image_array'], 
+              threaded=False)
+        
     else:
         inputs = []
         outputs = ['cam/image_array']
@@ -1130,6 +1145,11 @@ def add_drivetrain(V, cfg):
                           cfg.VESC_STEERING_OFFSET
                         )
             V.add(vesc, inputs=['steering', 'throttle'])
+
+        elif cfg.DRIVE_TRAIN_TYPE == "VIRTUAL":
+            from donkeycar.parts.actuator import VirtualController
+            logger.info("Creating virtual controller")
+            V.add(VirtualController(), inputs=['steering', 'throttle'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces two parts:

1. `ScreenCamera` is a part in `camera.py` which takes screenshots and uses those as camera images.
2. `VirtualController` in `actuator.py` is a part for an emulated Xbox controller which can be used to control a car in videogames.

I used these two parts to make a (mostly) successful pilot in Forza Horizon 3: https://youtu.be/LIuH6aonYWU

