### PR TITLE
Updated to handle Pi Zero properly

### DIFF
--- a/donkeycar/parts/oled.py
+++ b/donkeycar/parts/oled.py
@@ -1,5 +1,8 @@
 # requires the Adafruit ssd1306 library: pip install adafruit-circuitpython-ssd1306
 
+
+import os
+import re
 import subprocess
 import time
 from board import SCL, SDA
@@ -33,11 +36,10 @@ class OLEDDisplay(object):
             # Create the I2C interface.
             i2c = busio.I2C(SCL, SDA)
             # Create the SSD1306 OLED class.
-            # The first two parameters are the pixel width and pixel height.  Change these
+            # The first two parameters are the pixel width and pixel height. Change these
             # to the right size for your display!
             self.display = adafruit_ssd1306.SSD1306_I2C(128, self.height, i2c)
             self.display.rotation = self.rotation
-
 
             self.display.fill(0)
             self.display.show()
@@ -99,14 +101,24 @@ class OLEDPart(object):
             self.recording = 'NO'
         self.num_records = 0
         self.user_mode = None
-        eth0 = OLEDPart.get_ip_address('eth0')
-        wlan0 = OLEDPart.get_ip_address('wlan0')
-        if eth0 is not None:
-            self.eth0 = 'eth0:%s' % (eth0)
+
+        # Bookworm / systemd often doesn't have "eth0" (predictable interface names).
+        # Only query interfaces that actually exist to avoid crashing.
+        eth0 = None
+        wlan0 = None
+
+        if os.path.exists('/sys/class/net/eth0'):
+            eth0 = OLEDPart.get_ip_address('eth0')
+        if os.path.exists('/sys/class/net/wlan0'):
+            wlan0 = OLEDPart.get_ip_address('wlan0')
+
+        if eth0:
+            self.eth0 = f'eth0:{eth0}'
         else:
             self.eth0 = None
-        if wlan0 is not None:
-            self.wlan0 = 'wlan0:%s' % (wlan0)
+
+        if wlan0:
+            self.wlan0 = f'wlan0:{wlan0}'
         else:
             self.wlan0 = None
 
@@ -147,15 +159,42 @@ class OLEDPart(object):
         self.oled.clear_display()
         self.on = False
 
-    # https://github.com/NVIDIA-AI-IOT/jetbot/blob/master/jetbot/utils/utils.py
-
     @classmethod
     def get_ip_address(cls, interface):
-        if OLEDPart.get_network_interface_state(interface) == 'down':
+        # If interface is missing or down, don't crash.
+        if cls.get_network_interface_state(interface) != 'up':
             return None
-        cmd = "ifconfig %s | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'" % interface
-        return subprocess.check_output(cmd, shell=True).decode('ascii')[:-1]
+
+        # Prefer `ip` (present on Bookworm Lite) over `ifconfig` (often not installed).
+        try:
+            out = subprocess.check_output(
+                ["ip", "-4", "addr", "show", "dev", interface],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+        except Exception:
+            return None
+
+        # Parse e.g. "inet 192.168.86.62/24 ..."
+        m = re.search(r"\binet\s+([0-9]+(?:\.[0-9]+){3})/", out)
+        if not m:
+            return None
+        ip = m.group(1)
+        if ip == "127.0.0.1":
+            return None
+        return ip
 
     @classmethod
     def get_network_interface_state(cls, interface):
-        return subprocess.check_output('cat /sys/class/net/%s/operstate' % interface, shell=True).decode('ascii')[:-1]
+        # Return 'down' for missing interfaces instead of throwing.
+        path = f"/sys/class/net/{interface}/operstate"
+        try:
+            with open(path, "r") as f:
+                state = f.read().strip()
+        except FileNotFoundError:
+            return "down"
+        except Exception:
+            return "down"
+
+        # Normalize common values: up/down/unknown/dormant...
+        return state if state else "down"


### PR DESCRIPTION
Because the Pi Zero doesn't have an Ethernet port, the call to eth0 fails. This fixes it