### PR TITLE
Simplified TFLite support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ pi =
     adafruit-circuitpython-rplidar
     RPi.GPIO
     flatbuffers==24.3.*
-    tensorflow-aarch64==2.15.*
+    tflite-runtime
     opencv-contrib-python
     matplotlib
     kivy


### PR DESCRIPTION
This addresses the comments on the last PR, and limits the changes to just the three files necessary: setup.cfg, interpreter.py and keras.py.

Tested on the Pi 5 and Pi Zero 2

Here's a summary of the changes:

Summary
This change allows Donkeycar to run on Raspberry Pi using the lightweight tflite-runtime package (~5MB) instead of full TensorFlow (~500MB+) for inference.

What changed
1. Dependency change (setup.cfg)
--Pi installations now use tflite-runtime instead of tensorflow-aarch64
--This dramatically reduces install size and memory usage on Pi

2. Conditional imports (interpreter.py, keras.py)
--TensorFlow imports are now wrapped in try/except blocks
--If TensorFlow isn't installed, the code gracefully falls back to None
--A new helper function get_tflite_interpreter() tries to load the interpreter from tflite-runtime, ai-edge-litert, or full TensorFlow (in that order)

3. Removed TensorFlow-dependent type hints
--Some function signatures had type hints like -> tf.TensorShape that were evaluated at import time
--These were removed so the modules can be imported without TensorFlow

4. Fixed inference path (keras.py)
--The run() method was calling output_shapes() which required TensorFlow
--Changed to use self.interpreter.input_keys directly, which works with any interpreter

Usage
PC (training): pip install -e ".[pc]" — installs full TensorFlow
Pi (inference): pip install -e ".[pi]" — installs lightweight tflite-runtime
Models are trained and converted to .tflite on PC, then deployed to Pi for inference.