### PR TITLE
Fix tubplot crash with RNN/3D sequence models

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -471,8 +471,13 @@ class ShowPredictionPlots(BaseCommand):
                 tub_record, lambda x: normalize_image(x))
             pilot_angle, pilot_throttle = \
                 model.inference_from_dict(input_dict)
-            user_angle = tub_record.underlying['user/angle']
-            user_throttle = tub_record.underlying['user/throttle']
+            # For sequence models (RNN/3D), tub_record is a list of
+            # TubRecord objects; use the last element for ground truth
+            # (matching y_transform behavior).
+            record = tub_record[-1] if isinstance(tub_record, list) \
+                else tub_record
+            user_angle = record.underlying['user/angle']
+            user_throttle = record.underlying['user/throttle']
             user_angles.append(user_angle)
             user_throttles.append(user_throttle)
             pilot_angles.append(pilot_angle)


### PR DESCRIPTION
## Summary

- Fixes `AttributeError: 'list' object has no attribute 'underlying'` when running `donkey tubplot` with RNN or 3D CNN model types
- For sequence models, `TubDataset.get_records()` returns lists of `TubRecord` via the `Collator`, but `plot_predictions()` assumed each record was a single `TubRecord`
- Extracts the last element from the sequence to get ground-truth values, matching the `y_transform` behavior used during training

## Test plan

- [ ] Run `donkey tubplot --tub=data/ --model=<rnn_model> --type=rnn --noshow` and verify it produces the prediction plot without errors
- [ ] Run `donkey tubplot --tub=data/ --model=<3d_model> --type=3d --noshow` and verify it produces the prediction plot without errors
- [ ] Run `donkey tubplot` with a standard `linear` model to verify no regression

Fixes #1185