### PR TITLE
Replace import gym with gymnasium and update step() return handling

### DIFF
--- a/donkeycar/parts/dgym.py
+++ b/donkeycar/parts/dgym.py
@@ -1,6 +1,9 @@
 import os
 import time
-import gymnasium as gym
+try:
+    import gymnasium as gym
+except ImportError:  # pragma: no cover
+    import gym
 import gym_donkeycar
 
 

--- a/donkeycar/parts/dgym.py
+++ b/donkeycar/parts/dgym.py
@@ -1,6 +1,6 @@
 import os
 import time
-import gym
+import gymnasium as gym
 import gym_donkeycar
 
 
@@ -64,10 +64,10 @@ class DonkeyGymEnv(object):
     def update(self):
         while self.running:
             if self.delay > 0.0:
-                current_frame, _, _, current_info = self.env.step(self.action)
+                current_frame, _, _, _, current_info = self.env.step(self.action)
                 self.delay_buffer(current_frame, current_info)
             else:
-                self.frame, _, _, self.info = self.env.step(self.action)
+                self.frame, _, _, _, self.info = self.env.step(self.action)
 
     def run_threaded(self, steering, throttle, brake=None):
         if steering is None or throttle is None:


### PR DESCRIPTION
- Switched import from 'import gym' to 'import gymnasium as gym'
- Updated env.step() handling to support 5-tuple return (obs, reward, terminated, truncated, info)
- Fixes compatibility with newer gymnasium-based Donkey Simulator