### PR TITLE
Fix OAK-D RGB output not respecting IMAGE_W/IMAGE_H by using preview stream

### DIFF
--- a/donkeycar/parts/oak_d.py
+++ b/donkeycar/parts/oak_d.py
@@ -138,7 +138,9 @@ class OakD(object):
         res = depthai.ColorCameraProperties.SensorResolution.THE_1080_P
 
         cam_rgb.setResolution(res)
-        cam_rgb.setVideoSize(width, height)
+        # Set preview size to match model input
+        cam_rgb.setPreviewSize(self.image_w, self.image_h)
+        cam_rgb.setInterleaved(False)
 
         xout_rgb = self.pipeline.create(depthai.node.XLinkOut)
         xout_rgb.setStreamName("rgb")


### PR DESCRIPTION
The OAK-D RGB camera output did not respect IMAGE_W and IMAGE_H settings when using the default video stream. This caused mismatches between configured resolution, web UI display, and model input expectations.

This change switches the pipeline from the video stream to the preview stream, which correctly applies setPreviewSize() in hardware. As a result, the camera output now matches the configured dimensions, improves consistency between training and inference, and reduces unnecessary resizing overhead.

I verified this behavior by comparing images saved to disk and transferred to a local machine with the live preview shown in the web UI. After this change, the saved images match the preview output and respect the configured resolution.