### PR TITLE
Add optional ROI crop and mask denoising to the CV LineFollower

### DIFF
--- a/donkeycar/parts/line_follower.py
+++ b/donkeycar/parts/line_follower.py
@@ -32,6 +32,18 @@ class LineFollower:
 
         self.pid_st = pid
 
+        # Optional robustness controls. Both default to a no-op via getattr so
+        # existing myconfig.py files and the current behavior are unchanged.
+        #
+        # CROP_TOP_FRACTION > 0 ignores any masked pixels above this fraction of
+        # the image height, so line-colored clutter high in the frame (people,
+        # banners, walls) cannot bias the detected line position.
+        self.crop_top_fraction = getattr(cfg, 'CROP_TOP_FRACTION', 0.0)
+        # MASK_MORPH_KERNEL > 0 (odd) denoises the mask with a morphological
+        # open then close, using an elliptical kernel of this size to remove
+        # speckle and fill small gaps before the histogram is taken.
+        self.mask_morph_kernel = getattr(cfg, 'MASK_MORPH_KERNEL', 0)
+
 
     def get_i_color(self, cam_img):
         '''
@@ -48,6 +60,22 @@ class LineFollower:
 
         # make a mask of the colors in our range we are looking for
         mask = cv2.inRange(img_hsv, self.color_thr_low, self.color_thr_hi)
+
+        # optionally ignore the part of the scan band that lies above the ROI
+        # crop line, so line-colored clutter in the upper frame is excluded
+        if self.crop_top_fraction > 0.0:
+            crop_row = int(self.crop_top_fraction * cam_img.shape[0])
+            rows_above = max(0, min(mask.shape[0], crop_row - iSlice))
+            if rows_above:
+                mask[:rows_above, :] = 0
+
+        # optionally denoise the mask with a morphological open then close
+        if self.mask_morph_kernel > 0:
+            kernel = cv2.getStructuringElement(
+                cv2.MORPH_ELLIPSE,
+                (self.mask_morph_kernel, self.mask_morph_kernel))
+            mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel)
+            mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)
 
         # which index of the range has the highest amount of yellow?
         hist = np.sum(mask, axis=0)

--- a/donkeycar/templates/cfg_cv_control.py
+++ b/donkeycar/templates/cfg_cv_control.py
@@ -582,6 +582,17 @@ CONFIDENCE_THRESHOLD = 0.0015   # The fraction of total sampled pixels that must
                                 # If you keep getting `No line detected` logs in the console then you
                                 # may want to lower the threshold.
 
+# LineFollower - optional ROI + denoising (both default to a no-op, so leaving
+# them unset keeps the classic single-band behavior unchanged)
+CROP_TOP_FRACTION = 0.0  # if > 0, ignore masked pixels above this fraction of the
+                         # image height so line-colored clutter high in the frame
+                         # (people, banners, walls) cannot bias detection. e.g. 0.5
+                         # ignores the top half. Only affects rows inside the scan
+                         # band, so a band already below the line is untouched.
+MASK_MORPH_KERNEL = 0    # if > 0 (use an odd value such as 5), denoise the mask
+                         # with a morphological open+close using an elliptical
+                         # kernel of this size to drop speckle and fill small gaps.
+
 # LineFollower - throttle step controller; increase throttle on straights, descrease on turns
 THROTTLE_MAX = 0.3    # maximum throttle value the controller will produce
 THROTTLE_MIN = 0.15   # minimum throttle value the controller will produce

--- a/donkeycar/tests/test_line_follower.py
+++ b/donkeycar/tests/test_line_follower.py
@@ -1,0 +1,90 @@
+"""Tests for the optional ROI-crop and mask-denoising controls on LineFollower.
+
+Both controls default to a no-op, so the first test also pins that a config
+without the new keys keeps the classic single-band behavior.
+"""
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from simple_pid import PID
+
+from donkeycar.parts.line_follower import LineFollower
+
+YELLOW = (255, 255, 0)  # RGB; the part converts with COLOR_RGB2HSV
+
+
+def make_cfg(**overrides):
+    """A minimal cfg with the keys LineFollower reads. New keys are omitted on
+    purpose so getattr() defaults are exercised unless a test opts in."""
+    cfg = SimpleNamespace(
+        OVERLAY_IMAGE=False,
+        SCAN_Y=0,
+        SCAN_HEIGHT=240,
+        COLOR_THRESHOLD_LOW=(0, 50, 50),
+        COLOR_THRESHOLD_HIGH=(50, 255, 255),
+        TARGET_PIXEL=None,
+        TARGET_THRESHOLD=10,
+        CONFIDENCE_THRESHOLD=0.001,
+        THROTTLE_INITIAL=0.15,
+        THROTTLE_STEP=0.05,
+        THROTTLE_MAX=0.3,
+        THROTTLE_MIN=0.15,
+    )
+    for key, value in overrides.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def follower(**overrides):
+    return LineFollower(PID(Kp=-0.01, Ki=0.0, Kd=-0.0001), make_cfg(**overrides))
+
+
+def blank(height=240, width=320):
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+def test_default_config_detects_line_and_is_backward_compatible():
+    # cfg has no CROP_TOP_FRACTION / MASK_MORPH_KERNEL -> getattr defaults apply.
+    image = blank()
+    image[150:180, 196:205, :] = YELLOW  # stripe near column 200
+    index, confidence, _mask = follower().get_i_color(image)
+    assert 195 <= index <= 205
+    assert confidence > 0
+
+
+def test_crop_excludes_stronger_upper_clutter():
+    image = blank()
+    image[0:100, 48:53, :] = YELLOW      # tall clutter high in the frame (col ~50)
+    image[150:180, 196:205, :] = YELLOW  # shorter real line low in the frame (col ~200)
+
+    # Without a crop, the taller clutter wins the histogram.
+    index_off, _c, _m = follower().get_i_color(image)
+    assert 45 <= index_off <= 55
+
+    # A crop at half height zeroes the clutter rows, so the real line wins.
+    index_on, _c, _m = follower(CROP_TOP_FRACTION=0.5).get_i_color(image)
+    assert 195 <= index_on <= 205
+
+
+def test_morphology_removes_isolated_speckle_but_keeps_the_line():
+    image = blank()
+    image[150:180, 196:205, :] = YELLOW  # solid line
+    image[10, 10, :] = YELLOW            # one isolated speckle pixel
+
+    _i, _c, mask_off = follower().get_i_color(image)
+    _i, _c, mask_on = follower(MASK_MORPH_KERNEL=5).get_i_color(image)
+
+    assert mask_off[10, 10] > 0              # speckle present without denoising
+    assert mask_on[10, 10] == 0              # open() removes the lone pixel
+    assert mask_on[150:180, 196:205].sum() > 0  # the line survives
+
+
+def test_none_image_returns_safe_zero_command():
+    steering, throttle, *_rest = follower().run(None)
+    assert steering == 0
+    assert throttle == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem
The computer-vision `LineFollower` (`donkeycar/parts/line_follower.py`) takes a single
horizontal scan band, HSV-thresholds it, and steers toward the column with the most
line-colored pixels. Two things degrade it in real use:

- Line-colored clutter high in the frame (people, banners, walls, tape from an adjacent
  lane) that falls inside a tall scan band can pull the detected line position off the
  real line.
- Speckle in the HSV mask (compression noise, texture) adds noise to the column histogram.

## What this changes
Two **optional, default-off** controls on `LineFollower`, read via `getattr` so existing
`myconfig.py` files and current behavior are unchanged:

- `CROP_TOP_FRACTION` (default `0.0`): ignore masked pixels above this fraction of the
  image height, so line-colored clutter high in the frame cannot bias the detected line.
- `MASK_MORPH_KERNEL` (default `0`): morphological open+close on the mask to remove
  speckle and fill small gaps before the histogram is taken.

Both are documented in `templates/cfg_cv_control.py`. When left unset the mask, histogram,
and steering are byte-for-byte identical to today (each control is guarded by `if > 0`).

## How it was tested
- Added `donkeycar/tests/test_line_follower.py` (4 tests, all passing): a config without
  the new keys stays backward-compatible and still detects a line; a crop excludes
  stronger upper-frame clutter so the real (lower) line wins the histogram; morphology
  removes an isolated speckle while preserving the line; the `None`-image guard still
  returns a safe zero command.
- Manual test with the `cv_control` template: add `CROP_TOP_FRACTION = 0.5` and
  `MASK_MORPH_KERNEL = 5` to `myconfig.py`, run `python manage.py drive`, and confirm the
  overlay ignores upper-frame clutter and the mask is cleaner; with both unset, behavior
  is unchanged.

## Notes
- Backward compatible: no config migration; defaults are a no-op.
- Refs #1241.
- A docs PR to `autorope/donkeydocs` will follow.
