### PR TITLE
Explainable AI (XAI) Toolkit Expansion for donkeycar

### DIFF
--- a/donkeycar/management/base.py
+++ b/donkeycar/management/base.py
@@ -88,11 +88,14 @@ class CreateCar(BaseCommand):
         myconfig_template_path = os.path.join(TEMPLATES_PATH, 'myconfig.py')
         train_template_path = os.path.join(TEMPLATES_PATH, 'train.py')
         calibrate_template_path = os.path.join(TEMPLATES_PATH, 'calibrate.py')
+        gradcam_template_path = os.path.join(TEMPLATES_PATH,
+                                             'run_gradcam_analysis.py')
         car_app_path = os.path.join(path, 'manage.py')
         car_config_path = os.path.join(path, 'config.py')
         mycar_config_path = os.path.join(path, 'myconfig.py')
         train_app_path = os.path.join(path, 'train.py')
         calibrate_app_path = os.path.join(path, 'calibrate.py')
+        gradcam_app_path = os.path.join(path, 'run_gradcam_analysis.py')
 
         if os.path.exists(car_app_path) and not overwrite:
             print('Car app already exists. Delete it and rerun createcar to replace.')
@@ -120,6 +123,13 @@ class CreateCar(BaseCommand):
             print("Copying calibrate script. Adjust these before starting your car.")
             shutil.copyfile(calibrate_template_path, calibrate_app_path)
             os.chmod(calibrate_app_path, stat.S_IRWXU)
+
+        if os.path.exists(gradcam_app_path) and not overwrite:
+            print('run_gradcam_analysis.py already exists. Delete it and rerun createcar to replace.')
+        else:
+            print("Copying explainability analysis launcher script.")
+            shutil.copyfile(gradcam_template_path, gradcam_app_path)
+            os.chmod(gradcam_app_path, stat.S_IRWXU)
 
         if not os.path.exists(mycar_config_path):
             print("Copying my car config overrides")

--- a/donkeycar/management/makemovie.py
+++ b/donkeycar/management/makemovie.py
@@ -1,65 +1,13 @@
-import tempfile
-
-from tensorflow.python.keras import activations
-from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.models import load_model
-import tensorflow as tf
 import cv2
 from matplotlib import cm
 
-
 import donkeycar as dk
 from donkeycar.parts.tub_v2 import Tub
+from donkeycar.parts.salient import VanillaGradientSaliency
 from donkeycar.utils import *
 
 
 DEG_TO_RAD = math.pi / 180.0
-
-
-def apply_modifications(model, custom_objects=None):
-    """Applies modifications to the model layers to create a new Graph. For
-    example, simply changing `model.layers[idx].activation = new activation`
-    does not change the graph. The entire graph needs to be updated with
-    modified inbound and outbound tensors because of change in layer building
-    function.
-
-    Args:
-        model: The `keras.models.Model` instance.
-
-    Returns:
-        The modified model with changes applied. Does not mutate the original
-        `model`.
-    """
-    # The strategy is to save the modified model and load it back. This is
-    # done because setting the activation in a Keras layer doesnt actually
-    # change the graph. We have to iterate the entire graph and change the
-    # layer inbound and outbound nodes with modified tensors. This is doubly
-    # complicated in Keras 2.x since multiple inbound and outbound nodes are
-    # allowed with the Graph API.
-    model_path = os.path.join(tempfile.gettempdir(),
-                              next(tempfile._get_candidate_names()) + '.h5')
-    try:
-        model.save(model_path)
-        return load_model(model_path, custom_objects=custom_objects)
-    finally:
-        os.remove(model_path)
-
-
-def normalize(array, min_value=0., max_value=1.):
-    """Normalizes the numpy array to (min_value, max_value)
-
-    Args:
-        array: The numpy array
-        min_value: The min value in normalized array (Default value = 0)
-        max_value: The max value in normalized array (Default value = 1)
-
-    Returns:
-        The array normalized to range between (min_value, max_value)
-    """
-    arr_min = np.min(array)
-    arr_max = np.max(array)
-    normalized = (array - arr_min) / (arr_max - arr_min + K.epsilon())
-    return (max_value - min_value) * normalized + min_value
 
 
 class MakeMovie(object):
@@ -127,7 +75,8 @@ class MakeMovie(object):
             self.keras_part = get_model_by_type(args.type, cfg=self.cfg)
             self.keras_part.load(args.model)
             if args.salient:
-                self.do_salient = self.init_salient(self.keras_part.interpreter.model)
+                self.do_salient = self.init_salient(self.keras_part.interpreter.model,
+                                                    categorical=(args.type == 'categorical'))
 
         print('making movie', args.out, 'from', num_frames, 'images')
         clip = mpy.VideoClip(self.make_frame, duration=((num_frames - 1) / self.cfg.DRIVE_LOOP_HZ))
@@ -212,59 +161,15 @@ class MakeMovie(object):
                 cv2.line(img_drawon, p1, p2, (200, 200, 200), 2)
             x += dx
 
-    def init_salient(self, model):
-        # Utility to search for layer index by name. 
-        # Alternatively we can specify this as -1 since it corresponds to the last layer.
-        output_name = []
-        layer_idx = []
-        for i, layer in enumerate(model.layers):
-            if "dropout" not in layer.name.lower() and "out" in layer.name.lower():
-                output_name.append(layer.name)
-                layer_idx.append(i)
-
-        if output_name == []:
+    def init_salient(self, model, categorical=False):
+        self.saliency = VanillaGradientSaliency(model, categorical=categorical)
+        if not self.saliency.found_output_layers:
             print("Failed to find the model layer named with 'out'. Skipping salient.")
             return False
-
         print("####################")
-        print("Visualizing activations on layer:", output_name)
+        print("Visualizing gradient saliency on output layers")
         print("####################")
-        
-        # ensure we have linear activation
-        for li in layer_idx:
-            model.layers[li].activation = activations.linear
-        # build salient model and optimizer
-        sal_model = apply_modifications(model)
-        self.sal_model = sal_model
         return True
-
-    def compute_visualisation_mask(self, img):
-        img = img.reshape((1,) + img.shape)
-        images = tf.Variable(img, dtype=float)
-
-        if self.model_type == 'linear':
-            with tf.GradientTape(persistent=True) as tape:
-                tape.watch(images)
-                pred_list = self.sal_model(images, training=False)
-        elif self.model_type == 'categorical':
-            with tf.GradientTape(persistent=True) as tape:
-                tape.watch(images)
-                pred = self.sal_model(images, training=False)
-                pred_list = []
-                for p in pred:
-                    maxindex = tf.math.argmax(p[0])
-                    pred_list.append(p[0][maxindex])
-                    
-        grads = 0
-        for p in pred_list:
-            grad = tape.gradient(p, images)
-            grads += tf.math.square(grad)
-        grads = tf.math.sqrt(grads)
-
-        channel_idx = 1 if K.image_data_format() == 'channels_first' else -1
-        grads = np.sum(grads, axis=channel_idx)
-        res = normalize(grads)[0]
-        return res
 
     def draw_salient(self, img):
 
@@ -279,7 +184,7 @@ class MakeMovie(object):
             img = grey_img.reshape(grey_img.shape + (1,))
 
         norm_img = normalize_image(img)
-        salient_mask = self.compute_visualisation_mask(norm_img)
+        salient_mask = self.saliency.saliency_map(norm_img)
         salient_mask_stacked = cm.inferno(salient_mask)[:,:,0:3]
         salient_mask_stacked = cv2.GaussianBlur(salient_mask_stacked,(3,3),cv2.BORDER_DEFAULT)
         blend = cv2.addWeighted(img.astype('float32'), alpha, salient_mask_stacked.astype('float32'), beta, 0)

--- a/donkeycar/parts/analysis_launcher.html
+++ b/donkeycar/parts/analysis_launcher.html
@@ -1,0 +1,482 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Run Explainability Analysis</title>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: #f5f6f8; color: #24292f;
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  header {
+    background: #fff; border-bottom: 1px solid #d8dee4;
+    padding: 10px 18px;
+  }
+  header h1 { font-size: 16px; margin: 0; }
+  header .meta { font-size: 12px; color: #57606a; margin-top: 2px; }
+  main { max-width: 640px; margin: 14px auto; padding: 0 14px; }
+  .panel {
+    background: #fff; border: 1px solid #d8dee4; border-radius: 6px;
+    padding: 16px 18px; margin-bottom: 14px;
+  }
+  label { display: block; font-size: 13px; font-weight: 600; margin: 14px 0 4px; }
+  label:first-child { margin-top: 0; }
+  input[type=text], input[type=number] {
+    width: 100%; padding: 6px 8px; font: inherit; font-size: 13px;
+    border: 1px solid #d0d7de; border-radius: 6px;
+  }
+  .radio-row { display: flex; flex-wrap: wrap; row-gap: 8px; column-gap: 14px;
+              align-items: center; font-size: 13px; }
+  .radio-row label { display: inline-flex; align-items: center; gap: 5px;
+                     font-weight: 400; margin: 0; white-space: nowrap;
+                     flex: 0 0 auto; }
+  #mode-value.mode-value { width: 70px; margin-left: 2px; flex: 0 0 auto; }
+  .checkbox-row { font-size: 13px; display: flex; align-items: center; gap: 6px; }
+  .checkbox-row label { font-weight: 400; margin: 0; }
+  .hint { font-size: 11px; color: #8b949e; margin-top: 4px; }
+  button {
+    font: inherit; font-size: 14px; font-weight: 600; padding: 8px 20px;
+    border: none; border-radius: 6px; background: #0969da; color: #fff;
+    cursor: pointer; margin-top: 18px;
+  }
+  button:hover { background: #0757ba; }
+  button:disabled { background: #8b949e; cursor: not-allowed; }
+  #progress-panel { display: none; }
+  #progress-bar-wrap {
+    background: #eef1f4; border-radius: 6px; height: 10px; overflow: hidden;
+    margin: 10px 0 6px;
+  }
+  #progress-bar {
+    background: #0969da; height: 100%; width: 0%; transition: width 0.3s;
+  }
+  #progress-text { font-size: 13px; color: #57606a; }
+  #error-box {
+    display: none; background: #fff1f0; border: 1px solid #ffccc7;
+    color: #cf1322; padding: 10px 12px; border-radius: 6px; font-size: 13px;
+    margin-top: 10px;
+  }
+  #calib-warning-box {
+    display: none; background: #fff8e6; border: 1px solid #ffe08a;
+    color: #7a5900; padding: 10px 12px; border-radius: 6px; font-size: 13px;
+    margin-top: 10px;
+  }
+  datalist { display: none; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Run Explainability Analysis</h1>
+  <div class="meta">Grad-CAM attention/uncertainty, feature-space novelty, and pixel-gradient saliency for a recorded drive.</div>
+</header>
+
+<main>
+  <div class="panel" id="form-panel">
+    <label for="tub">Tub path</label>
+    <input type="text" id="tub" list="tubs-list" placeholder="data/">
+    <datalist id="tubs-list"></datalist>
+
+    <label for="model">Model path</label>
+    <input type="text" id="model" list="models-list" placeholder="models/mypilot.h5">
+    <datalist id="models-list"></datalist>
+    <div class="hint" id="model-pipeline-hint"></div>
+
+    <label for="transformations-override">Transformations override (optional)</label>
+    <input type="text" id="transformations-override"
+           placeholder="e.g. CROP, CANNY -- leave blank to use this launcher's config">
+    <div class="hint" id="transformations-override-hint">This launcher was
+      started with one fixed config, but every model above may have been
+      trained with a DIFFERENT TRANSFORMATIONS/POST_TRANSFORMATIONS pipeline
+      -- nothing here connects a model file back to the config it needs, so
+      analysing it with the wrong one silently computes every heat map on
+      pixels the model never saw. By default this is caught for you: the run
+      is refused if it doesn't match the model's saved training pipeline
+      (shown above once you pick a model). Only fill this in to deliberately
+      analyse a model under a DIFFERENT pipeline than it was trained with
+      (an intentional what-if) -- doing so replaces POST_TRANSFORMATIONS for
+      this run only and skips that check, since you're now doing it on
+      purpose.</div>
+
+    <label>Frames to analyse</label>
+    <div class="radio-row">
+      <label title="Analyse the K frames with the highest steering-uncertainty (variance). A fixed number of frames is analysed no matter how long the drive is.">
+        <input type="radio" name="mode" value="top_k" checked> top-K most uncertain</label>
+      <label title="Analyse every frame whose uncertainty is at or above this percentile of the whole drive (e.g. 90 = the most uncertain 10% of frames). How many frames that turns out to be depends on the drive itself.">
+        <input type="radio" name="mode" value="percentile"> percentile &ge;</label>
+      <label title="Analyse every single frame in the tub. Only practical for short drives -- long drives will take a long time and produce a large output folder.">
+        <input type="radio" name="mode" value="all"> all frames</label>
+      <input type="number" id="mode-value" class="mode-value" value="50" min="1">
+    </div>
+    <div class="hint" id="mode-value-hint">top-K: how many frames to analyse (1&ndash;total frames in the tub).</div>
+
+    <label for="limit">Limit / range of frames considered (optional)</label>
+    <input type="text" id="limit" placeholder="e.g. 500, or a range like 1000-2000 -- leave blank to use the whole tub">
+    <div class="hint" id="limit-hint">Only looks at part of the drive before
+      picking which frames to analyse above &mdash; use this to try a quick,
+      fast run, or to zoom into a specific part of the drive. A single number
+      (e.g. 500) looks at just the first N frames; a range (e.g. 1000-2000)
+      looks at only that span. Leave blank to use the whole tub.</div>
+
+    <div class="checkbox-row" style="margin-top: 14px;">
+      <input type="checkbox" id="auto-calibrate">
+      <label for="auto-calibrate">Auto-calibrate this model first if it has no calibration yet</label>
+    </div>
+    <div class="hint">Needed for confidence %% / novelty %%; adds a one-time
+      full-drive replay (only the first time you analyse this model &mdash;
+      later runs reuse the saved calibration). Checked automatically when the
+      model above has no saved calibration yet.</div>
+
+    <div id="calib-tub-section" style="display: none; margin-top: 14px;">
+      <label for="calib-tub" id="calib-tub-label">Calibration tub (training data)</label>
+      <input type="text" id="calib-tub" list="tubs-list"
+             placeholder="auto-detected from this model's training record, if known">
+      <div class="hint" id="calib-tub-hint">Calibration must be run against the
+        tub(s) this model was actually TRAINED on &mdash; not necessarily the
+        tub above, which is often a separate inference/test drive. Calibrating
+        against the wrong data makes confidence/novelty %% meaningless (novelty
+        would end up measuring "unlike this other drive" instead of "unlike
+        what the model learned"). Auto-filled when this model's training tub
+        is on record; edit it, or leave blank and it falls back to the tub
+        above with a visible warning.</div>
+    </div>
+
+    <div class="checkbox-row" style="margin-top: 14px;">
+      <input type="checkbox" id="export-frames">
+      <label for="export-frames">Export every camera frame (self-contained output, larger folder)</label>
+    </div>
+    <div class="hint">Off (default): the output folder only has images for
+      the analysed frames above, plus the drive's numbers (confidence/
+      novelty/etc) for every frame -- the viewer shows the camera feed for
+      other frames by reading straight from the tub, so the tub must stay
+      where it is. On: also copies every camera frame into the output folder
+      (~5&ndash;8 KB each), so the whole analysis folder can be moved, zipped,
+      or viewed on another machine without the original tub.</div>
+
+    <button id="run-btn" onclick="runAnalysis()">Run Analysis</button>
+    <div id="error-box"></div>
+  </div>
+
+  <div class="panel" id="progress-panel">
+    <div id="calib-warning-box"></div>
+    <div id="progress-text">Starting&hellip;</div>
+    <div id="progress-bar-wrap"><div id="progress-bar"></div></div>
+    <button id="continue-btn" onclick="location.href='/'"
+            style="display:none;">Continue to viewer</button>
+  </div>
+</main>
+
+<script>
+(function () {
+  'use strict';
+  const $ = id => document.getElementById(id);
+
+  fetch('/api/scan').then(r => r.json()).then(d => {
+    // Suggestions only -- the field itself stays empty (its placeholder
+    // shows the expected format) until the user types or picks one, even
+    // when there's only a single match on disk.
+    const fill = (listId, values) => {
+      $(listId).innerHTML = values.map(v => `<option value="${v}">`).join('');
+    };
+    fill('tubs-list', d.tubs || []);
+    fill('models-list', d.models || []);
+  }).catch(() => {});
+
+  // ---- tub frame count (drives the hint text + top-K/limit validation) ----
+  let totalFrames = null;
+  function refreshTubInfo() {
+    const tub = $('tub').value.trim();
+    totalFrames = null;
+    if (!tub) { updateModeHint(); updateLimitHint(); return; }
+    fetch('/api/tub_info?tub=' + encodeURIComponent(tub))
+      .then(r => r.json())
+      .then(d => { totalFrames = d.n_records ?? null; })
+      .catch(() => { totalFrames = null; })
+      .finally(() => { updateModeHint(); updateLimitHint(); });
+  }
+  $('tub').addEventListener('change', refreshTubInfo);
+  $('tub').addEventListener('blur', refreshTubInfo);
+
+  // ---- calibration tub: auto-fill from this model's training record -------
+  // (courtesy default only -- never overwrites a value the user already
+  // typed, and the user can always clear/edit it to specify a different tub.)
+  let calibTubUserEdited = false;
+  $('calib-tub').addEventListener('input', () => { calibTubUserEdited = true; });
+
+  // ---- auto-calibrate checkbox: default on only when the selected model
+  // has no saved calibration yet (courtesy default only -- never overwrites
+  // a value the user already toggled by hand). The "Calibration tub" field
+  // is only relevant when auto-calibrate is on, so keep it hidden otherwise.
+  let autoCalibrateUserEdited = false;
+  function updateCalibVisibility() {
+    $('calib-tub-section').style.display =
+      $('auto-calibrate').checked ? '' : 'none';
+  }
+  $('auto-calibrate').addEventListener('change', () => {
+    autoCalibrateUserEdited = true;
+    updateCalibVisibility();
+  });
+  updateCalibVisibility();
+
+  function refreshTrainingTubs() {
+    const model = $('model').value.trim();
+    const hint = $('calib-tub-hint');
+    const DEFAULT_HINT = 'Calibration must be run against the tub(s) this ' +
+      'model was actually TRAINED on — not necessarily the tub above, ' +
+      'which is often a separate inference/test drive. Calibrating against ' +
+      'the wrong data makes confidence/novelty % meaningless (novelty would ' +
+      'end up measuring "unlike this other drive" instead of "unlike what ' +
+      'the model learned"). Auto-filled when this model\'s training tub is ' +
+      'on record; edit it, or leave blank and it falls back to the tub ' +
+      'above with a visible warning.';
+    if (!model) { hint.textContent = DEFAULT_HINT; return; }
+    fetch('/api/training_tubs?model=' + encodeURIComponent(model))
+      .then(r => r.json())
+      .then(d => {
+        if (d.tubs && d.tubs.length) {
+          if (!calibTubUserEdited) {
+            $('calib-tub').value = d.tubs.join(', ');
+          }
+          hint.textContent = 'Auto-detected from this model\'s training ' +
+            'record: ' + d.tubs.join(', ') + '. Edit if this isn\'t right.';
+        } else {
+          hint.textContent = 'No training-tub record found for this model ' +
+            '(it may not have been trained with `donkey train`, or ' +
+            'models/database.json is missing) — type the tub(s) this model ' +
+            'was actually trained on, or leave blank to fall back to the ' +
+            'tub above (with a visible warning).';
+        }
+      })
+      .catch(() => { hint.textContent = DEFAULT_HINT; });
+  }
+  $('model').addEventListener('change', refreshTrainingTubs);
+  $('model').addEventListener('blur', refreshTrainingTubs);
+
+  // ---- model field: show the pipeline this model was actually trained
+  // with (from its .preprocessing.json sidecar), so it's visible before
+  // deciding whether an override is needed at all. ----------------------
+  function refreshModelPipeline() {
+    const model = $('model').value.trim();
+    const hint = $('model-pipeline-hint');
+    if (!model) { hint.textContent = ''; return; }
+    fetch('/api/model_info?model=' + encodeURIComponent(model))
+      .then(r => r.json())
+      .then(d => {
+        if (d.pipeline_steps && d.pipeline_steps.length) {
+          hint.textContent = 'Trained with: ' + d.pipeline_steps.join(', ');
+        } else if (d.pipeline_steps === null) {
+          hint.textContent = 'No preprocessing record for this model (older '
+            + 'model, or none was ever saved) -- cannot verify the '
+            + 'transformations pipeline automatically for it.';
+        } else {
+          hint.textContent = 'Trained with no TRANSFORMATIONS/'
+            + 'POST_TRANSFORMATIONS (raw camera frames).';
+        }
+        if (!autoCalibrateUserEdited && typeof d.has_calibration === 'boolean') {
+          $('auto-calibrate').checked = !d.has_calibration;
+          updateCalibVisibility();
+        }
+      })
+      .catch(() => { hint.textContent = ''; });
+  }
+  $('model').addEventListener('change', refreshModelPipeline);
+  $('model').addEventListener('blur', refreshModelPipeline);
+
+  // Returns null (meaning: don't state a range at all) until a tub has been
+  // entered AND its frame count successfully resolved -- showing a fake
+  // "1-total frames" placeholder before then reads as a real constraint.
+  function frameRangeText() {
+    return totalFrames ? `1–${totalFrames} (this tub has ${totalFrames} frames)`
+                       : null;
+  }
+
+  // ---- "Frames to analyse" mode: show/hide + relabel the value box --------
+  function updateModeHint() {
+    const mode = document.querySelector('input[name=mode]:checked').value;
+    const valueBox = $('mode-value');
+    const hint = $('mode-value-hint');
+    if (mode === 'all') {
+      valueBox.style.display = 'none';
+      hint.textContent = 'Every frame in the tub will be analysed.';
+    } else if (mode === 'percentile') {
+      valueBox.style.display = '';
+      valueBox.min = 0; valueBox.max = 100;
+      if (!valueBox.value || valueBox.value > 100) valueBox.value = 90;
+      hint.textContent = 'percentile: 0–100 (e.g. 90 analyses the most ' +
+        'uncertain 10% of frames).';
+    } else {
+      valueBox.style.display = '';
+      valueBox.min = 1;
+      valueBox.removeAttribute('max');
+      if (!valueBox.value) valueBox.value = 50;
+      const range = frameRangeText();
+      hint.textContent = 'top-K: how many frames to analyse' +
+        (range ? ' (' + range + ').' : '.');
+    }
+  }
+  function updateLimitHint() {
+    const range = frameRangeText();
+    $('limit-hint').textContent =
+      'Only looks at part of the drive before picking which frames to ' +
+      'analyse above — use this to try a quick, fast run, or to zoom into ' +
+      'a specific part of the drive. A single number (e.g. 500) looks at ' +
+      'just the first N frames; a range (e.g. 1000-2000) looks at only ' +
+      'that span' + (range ? ' (valid frames: ' + range + ')' : '') +
+      '. Leave blank to use the whole tub.';
+  }
+  document.querySelectorAll('input[name=mode]').forEach(
+    r => r.addEventListener('change', updateModeHint));
+  updateModeHint();
+
+  const STAGE_LABEL = {
+    starting: 'Starting…',
+    calibrate: 'Calibrating model (one-time) — replaying drive for confidence/novelty %',
+    calibrate_ood: 'Calibrating model (one-time) — building novelty feature bank',
+    variance: 'Replaying drive — computing MC-Dropout uncertainty',
+    novelty: 'Replaying drive — computing feature-space novelty',
+    tta: 'Replaying drive — computing test-time-augmentation stability',
+    gradcam: 'Rendering Grad-CAM / novelty / saliency overlays',
+  };
+
+  window.runAnalysis = function () {
+    const tub = $('tub').value.trim();
+    const model = $('model').value.trim();
+    $('error-box').style.display = 'none';
+    if (!tub || !model) {
+      $('error-box').textContent = 'Tub and model paths are both required.';
+      $('error-box').style.display = 'block';
+      return;
+    }
+    const mode = document.querySelector('input[name=mode]:checked').value;
+    const valueStr = $('mode-value').value.trim();
+    const limitStr = $('limit').value.trim();
+
+    if (mode !== 'all') {
+      const value = Number(valueStr);
+      if (valueStr === '' || !Number.isFinite(value)) {
+        return showError('Enter a number for "' +
+          (mode === 'percentile' ? 'percentile' : 'top-K') + '".');
+      }
+      if (mode === 'percentile' && (value < 0 || value > 100)) {
+        return showError('Percentile must be between 0 and 100.');
+      }
+      if (mode === 'top_k') {
+        const max = totalFrames || Infinity;
+        if (value < 1 || value > max) {
+          return showError('top-K must be between 1 and ' +
+            (totalFrames || 'the number of frames in the tub') + '.');
+        }
+      }
+    }
+    // Limit accepts either a single count ("500" -> first 500 frames) or a
+    // range ("1000-2000" -> just that span), parsed into start/limit here.
+    let rangeStart = null, rangeLimit = null;
+    if (limitStr !== '') {
+      const max = totalFrames || Infinity;
+      if (limitStr.includes('-')) {
+        const parts = limitStr.split('-').map(s => s.trim());
+        const from = Number(parts[0]), to = Number(parts[1]);
+        if (parts.length !== 2 || !Number.isFinite(from) || !Number.isFinite(to)) {
+          return showError('A frame range must look like "1000-2000".');
+        }
+        if (from < 0 || to <= from) {
+          return showError('The range\'s end must be greater than its start.');
+        }
+        if (to > max) {
+          return showError('The range\'s end must be at most ' +
+            (totalFrames || 'the number of frames in the tub') + '.');
+        }
+        rangeStart = from;
+        rangeLimit = to - from;
+      } else {
+        const n = Number(limitStr);
+        if (!Number.isFinite(n) || n < 1 || n > max) {
+          return showError('Limit must be a number between 1 and ' +
+            (totalFrames || 'the number of frames in the tub') +
+            ', or a range like "1000-2000".');
+        }
+        rangeLimit = n;
+      }
+    }
+
+    const body = {
+      tub: tub,
+      model: model,
+      mode: mode,
+      value: mode === 'all' ? '' : valueStr,
+      start: rangeStart,
+      limit: rangeLimit,
+      export_frames: $('export-frames').checked,
+      auto_calibrate: $('auto-calibrate').checked,
+      calib_tub: $('calib-tub').value.trim(),
+      transformations_override: $('transformations-override').value.trim(),
+    };
+
+    $('run-btn').disabled = true;
+    $('form-panel').style.opacity = '0.6';
+    $('progress-panel').style.display = 'block';
+    $('progress-text').textContent = 'Starting…';
+    $('progress-bar').style.width = '2%';
+
+    fetch('/api/run', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(body),
+    }).then(r => r.json()).then(d => {
+      if (!d.ok) {
+        showError(d.error || 'Failed to start analysis.');
+        return;
+      }
+      pollProgress();
+    }).catch(e => showError(String(e)));
+  };
+
+  function showError(msg) {
+    $('run-btn').disabled = false;
+    $('form-panel').style.opacity = '1';
+    $('error-box').textContent = msg;
+    $('error-box').style.display = 'block';
+  }
+
+  function pollProgress() {
+    fetch('/api/progress').then(r => r.json()).then(p => {
+      if (p.error) {
+        showError(p.error);
+        return;
+      }
+      // Show as soon as it appears (mid-run), not only once everything is
+      // done -- this is a correctness caveat, not a transient status.
+      if (p.calibration_warning) {
+        const box = $('calib-warning-box');
+        box.textContent = '⚠ ' + p.calibration_warning;
+        box.style.display = 'block';
+      }
+
+      const label = STAGE_LABEL[p.stage] || p.stage || 'Working…';
+      const pct = p.total ? Math.round(100 * p.current / p.total) : 2;
+      $('progress-text').textContent =
+        label + (p.total ? ` (${p.current}/${p.total})` : '');
+      $('progress-bar').style.width = Math.max(2, pct) + '%';
+
+      if (p.done) {
+        if (p.out_dir) {
+          $('progress-bar').style.width = '100%';
+          if (p.calibration_warning) {
+            // Don't whisk the user away before they've read the warning --
+            // require an explicit click through instead of auto-redirecting.
+            $('progress-text').textContent = 'Done (see warning above).';
+            $('continue-btn').style.display = 'inline-block';
+          } else {
+            $('progress-text').textContent = 'Done! Opening viewer…';
+            setTimeout(() => { window.location.href = '/'; }, 600);
+          }
+        }
+        return;
+      }
+      setTimeout(pollProgress, 1000);
+    }).catch(() => setTimeout(pollProgress, 2000));
+  }
+})();
+</script>
+</body>
+</html>

--- a/donkeycar/parts/gradcam_uncertainty.py
+++ b/donkeycar/parts/gradcam_uncertainty.py
@@ -1,0 +1,945 @@
+"""
+Offline Grad-CAM "uncertainty map" tool (Feature 3 of the uncertainty toolkit).
+
+For frames of a recorded tub, this tool runs Grad-CAM once per MC-Dropout
+pass (same N stochastic passes as the live confidence signal) and computes
+the *pixel-wise variance* of the N attention maps. Regions where the model's
+attention is inconsistent across dropout sub-networks are rendered as a
+heatmap overlay -- a spatial answer to "where was the model uncertain?".
+
+This is offline-only by design: each analysed frame costs one batched
+forward + backward pass (N Grad-CAMs share a single gradient tape), which is
+fine for post-drive analysis but too heavy for the 20Hz drive loop.
+
+Frame selection (feasibility): by default only the top-K most uncertain
+frames are analysed, ranked by the steering variance either logged in the
+tub (``pilot/smoothed_variance``, written when driving with
+XAI_CONFIDENCE_ENABLED enabled)
+or recomputed by replaying the tub through the MC-Dropout part. ``--all``
+forces every frame (use only for short drives).
+
+If the model's calibration also has novelty (Mahalanobis distance) stats --
+see ``donkeycar.parts.mc_calibrate`` / ``donkeycar.parts.novelty`` -- a
+per-frame novelty distance/score is added to every timeline entry (cheap, a
+single forward pass, computed for ALL frames), and a third, independent
+spatial "novelty map" overlay is rendered for the analysed frames, showing
+*where* in the image the features look unlike anything in training data --
+a different question from the attention/uncertainty overlays above.
+
+Each analysed frame also gets two pixel-level overlays (see
+``donkeycar.parts.salient``): vanilla-gradient saliency (a single raw input
+gradient -- noisy) and Integrated Gradients (path-integrated, axiomatic,
+cleaner). Both take gradients against full-resolution input pixels rather than
+the coarse conv2d_5 grid -- complementary lenses to the Grad-CAM maps above.
+A Grad-CAM++ attention map (sharper, multi-region variant of the mean
+attention) is rendered too.
+
+Output (consumed by the Feature 4 viewer):
+    <out>/
+      data.json            -- timeline of variance/confidence/novelty for ALL
+                              frames, plus an entry per analysed frame
+      images/<idx>_orig.jpg      -- camera frame
+      images/<idx>_unc.png       -- uncertainty-map overlay (attention variance)
+      images/<idx>_attn.png      -- mean-attention overlay (where it looked)
+      images/<idx>_attnpp.png    -- Grad-CAM++ attention overlay (sharper)
+      images/<idx>_novelty.png   -- novelty overlay (where features are
+                                   unlike training data); only if the model's
+                                   calibration has novelty stats
+      images/<idx>_saliency.png  -- vanilla-gradient pixel saliency overlay
+      images/<idx>_ig.png        -- Integrated Gradients pixel attribution
+
+Usage:
+    python -m donkeycar.parts.gradcam_uncertainty \
+        --tub data/ --model models/mypilot.h5 [--top-k 50] [--all] \
+        [--percentile 90] [--limit N] [--start N] [--passes 15] \
+        [--ig-steps 32] [--out dir]
+
+Caveats: linear model only (same scope as the live signal); the variance map
+inherits MC-Dropout's blind spots -- it measures disagreement between dropout
+sub-networks, not distance from the training distribution. The novelty map
+is the complementary signal (distance from training distribution) and
+inherits its own blind spots -- see donkeycar.parts.novelty's module
+docstring (diagonal-covariance approximation, position-independent spatial
+pooling). The saliency map is noisier and less spatially decisive than
+Grad-CAM -- see donkeycar.parts.salient's module docstring.
+"""
+import argparse
+import json
+import logging
+import os
+import time
+
+import numpy as np
+import tensorflow as tf
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+class GradCamUncertainty:
+    """
+    Computes N stochastic Grad-CAM maps per frame (dropout active, one map
+    per MC-Dropout pass) and reduces them to a mean-attention map and a
+    pixel-wise variance ("uncertainty") map.
+
+    All N maps are produced in a single batched forward+backward pass: the
+    image is replicated N times, dropout gives each batch row an independent
+    sub-network, and the gradient of the summed steering output w.r.t. the
+    conv features yields each row's own Grad-CAM weights (rows are
+    independent, so d(sum steer_i)/d(feat_j) == d(steer_j)/d(feat_j)).
+    """
+
+    def __init__(self, model, num_passes=15, conv_layer_name=None):
+        self.model = model
+        self.num_passes = int(num_passes)
+
+        if conv_layer_name:
+            conv_layer = model.get_layer(conv_layer_name)
+        else:
+            conv_layer = self._last_conv_layer(model)
+        logger.info(f'GradCamUncertainty: using conv layer '
+                    f'"{conv_layer.name}" {conv_layer.output.shape}, '
+                    f'N={self.num_passes}')
+
+        # Steering is the first model output (n_outputs0 on the linear model).
+        self.grad_model = tf.keras.Model(
+            model.inputs, [conv_layer.output, model.outputs[0]])
+
+    @staticmethod
+    def _last_conv_layer(model):
+        for layer in reversed(model.layers):
+            if isinstance(layer, tf.keras.layers.Conv2D):
+                return layer
+        raise ValueError('No Conv2D layer found in model; Grad-CAM needs a '
+                         'convolutional architecture.')
+
+    def attention_maps(self, norm_img):
+        """
+        :param norm_img: float32 image, [0,1], shape (H, W, C)
+        :return: np array (N, h, w) of per-pass Grad-CAM maps, each
+                 normalised to [0, 1] by its own max (so the variance across
+                 maps measures *shape* disagreement, not magnitude).
+        """
+        batch = tf.convert_to_tensor(
+            np.repeat(norm_img[np.newaxis, ...], self.num_passes, axis=0))
+
+        with tf.GradientTape() as tape:
+            features, steering = self.grad_model(batch, training=True)
+            target = tf.reduce_sum(steering)
+        grads = tape.gradient(target, features)          # (N, h, w, c)
+
+        # Grad-CAM: channel weights = spatially-pooled gradients.
+        weights = tf.reduce_mean(grads, axis=(1, 2), keepdims=True)
+        cams = tf.nn.relu(tf.reduce_sum(weights * features, axis=-1))
+        cams = cams.numpy()                              # (N, h, w)
+
+        # Per-map max-normalisation; guard all-zero maps.
+        maxes = cams.reshape(self.num_passes, -1).max(axis=1)
+        maxes[maxes == 0] = 1.0
+        return cams / maxes[:, None, None]
+
+    def attention_maps_pp(self, norm_img):
+        """
+        Grad-CAM++ variant of :meth:`attention_maps`. Same batched N-pass
+        structure and same ``grad_model``; only the per-location weighting
+        changes.
+
+        Plain Grad-CAM pools the gradient with a flat spatial *average*, so
+        every location in a channel counts equally -- which can wash out the
+        map when several separate regions each matter (e.g. both lane lines).
+        Grad-CAM++ replaces that average with a *weighted* one: each location's
+        gradient is scaled by an ``alpha`` coefficient built from higher-order
+        gradient terms, so locations that individually push the prediction
+        hardest count for more. The result is sharper and more complete when
+        attention is genuinely multi-region.
+
+        Derivation note (regression output): the textbook Grad-CAM++ alphas
+        assume a classification score of the form ``exp(logit)``, whose 2nd/3rd
+        derivatives supply the higher-order terms. Our steering head is a raw
+        linear regression, so those analytic derivatives are zero and a literal
+        port would degenerate back to plain Grad-CAM. We therefore use the
+        common practical approximation (as in the reference Grad-CAM++
+        implementations): estimate the higher-order terms from powers of the
+        *first-order* gradient and the activations directly --
+        ``alpha = g^2 / (2 g^2 + (sum_ab A_ab) g^3)`` -- which stays
+        non-degenerate because the steering gradient w.r.t. conv2d_5 varies
+        across space (the flatten+dense head is position-dependent).
+
+        :param norm_img: float32 image, [0,1], shape (H, W, C)
+        :return: np array (N, h, w) of per-pass Grad-CAM++ maps, each
+                 max-normalised to [0, 1] (like :meth:`attention_maps`).
+        """
+        batch = tf.convert_to_tensor(
+            np.repeat(norm_img[np.newaxis, ...], self.num_passes, axis=0))
+
+        with tf.GradientTape() as tape:
+            features, steering = self.grad_model(batch, training=True)
+            target = tf.reduce_sum(steering)
+        grads = tape.gradient(target, features)          # (N, h, w, c)
+
+        grads2 = grads ** 2
+        grads3 = grads ** 3
+        # sum of activations per channel (the (sum_ab A_ab) term), broadcast
+        # back over the spatial grid.
+        global_sum = tf.reduce_sum(features, axis=(1, 2), keepdims=True)
+        denom = 2.0 * grads2 + global_sum * grads3
+        denom = tf.where(tf.abs(denom) > 1e-10, denom, tf.ones_like(denom))
+        alphas = grads2 / denom
+        # Per-channel weights: alpha-weighted sum of the positive gradients.
+        weights = tf.reduce_sum(alphas * tf.nn.relu(grads),
+                                axis=(1, 2), keepdims=True)
+        cams = tf.nn.relu(tf.reduce_sum(weights * features, axis=-1))
+        cams = cams.numpy()                              # (N, h, w)
+
+        maxes = cams.reshape(self.num_passes, -1).max(axis=1)
+        maxes[maxes == 0] = 1.0
+        return cams / maxes[:, None, None]
+
+    def attention_pp_map(self, img_arr):
+        """
+        Mean Grad-CAM++ attention map for a frame, upsampled to image size and
+        normalised to [0,1] -- the ++ analogue of the mean-attention map that
+        :meth:`uncertainty_map` returns as ``mean_map``.
+
+        :param img_arr: uint8 [0,255] camera frame (H, W, C)
+        :return: (H, W) float map in [0,1].
+        """
+        from donkeycar.utils import normalize_image
+        norm = normalize_image(img_arr).astype(np.float32)
+        cams = self.attention_maps_pp(norm)
+        mean_map = cams.mean(axis=0)
+
+        h, w = img_arr.shape[:2]
+        up = _resize_map(mean_map, w, h)
+        if up.max() > 0:
+            up = up / up.max()
+        return up
+
+    def uncertainty_map(self, img_arr):
+        """
+        :param img_arr: uint8 [0,255] camera frame (H, W, C)
+        :return: (mean_map, var_map) both float (H, W) upsampled to image
+                 size; mean_map in [0,1], var_map normalised to [0,1] with
+                 its raw peak value returned as third element.
+        """
+        from donkeycar.utils import normalize_image
+        norm = normalize_image(img_arr).astype(np.float32)
+        cams = self.attention_maps(norm)
+
+        mean_map = cams.mean(axis=0)
+        var_map = cams.var(axis=0)
+        raw_peak = float(var_map.max())
+
+        h, w = img_arr.shape[:2]
+        mean_up = _resize_map(mean_map, w, h)
+        var_up = _resize_map(var_map, w, h)
+        if raw_peak > 0:
+            var_up = var_up / var_up.max()
+        if mean_up.max() > 0:
+            mean_up = mean_up / mean_up.max()
+        return mean_up, var_up, raw_peak
+
+    def novelty_map(self, img_arr, mean, var, active_dims=None, eps=1e-6,
+                    extractor=None):
+        """
+        Spatial Mahalanobis-distance "novelty" map: how far each grid
+        location's feature vector is from the training distribution (see
+        donkeycar.parts.novelty). Needs no dropout stochasticity and no
+        gradient -- a single plain forward pass -- since novelty is a
+        distance-from-training-distribution measure, not an agreement measure.
+
+        Features come from the GENERIC ImageNet encoder, the same space the
+        live novelty score is measured in, evaluated on the RAW frame. The
+        steering model's own conv features were used here originally, but
+        that space is task-collapsed (a network trained only to predict
+        steering discards the texture/colour that tells grass from track),
+        and it sees transformed pixels, so the heat map and the percentage
+        beside it were answering different questions.
+
+        :param img_arr:  uint8 [0,255] RAW camera frame (H, W, C)
+        :param mean, var, active_dims, eps: the fitted 'novelty_ood_spatial'
+                                            calibration block's stats.
+        :param extractor: a donkeycar.parts.ood.SpatialEncoderExtractor.
+        :return: (map01, raw_peak) -- map01 is (H, W) upsampled to image
+                 size and normalised to [0,1]; raw_peak is the pre-
+                 normalisation peak distance (for the readout/debugging).
+        """
+        from donkeycar.parts.novelty import mahalanobis_diag
+
+        feat = extractor.extract_grid(img_arr)            # (gh, gw, c)
+
+        dist_grid = mahalanobis_diag(feat, mean, var, active_dims, eps)
+        raw_peak = float(dist_grid.max())
+
+        h, w = img_arr.shape[:2]
+        up = _resize_map(dist_grid, w, h)
+        if raw_peak > 0:
+            up = up / up.max()
+        return up, raw_peak
+
+
+def _resize_map(map2d, width, height):
+    """Bilinear upsample a float map to (height, width)."""
+    img = Image.fromarray(map2d.astype(np.float32), mode='F')
+    return np.asarray(img.resize((width, height), Image.BILINEAR))
+
+
+def _jet(x):
+    """Simple jet colormap: float map [0,1] -> float RGB (H, W, 3)."""
+    r = np.clip(1.5 - np.abs(4 * x - 3), 0, 1)
+    g = np.clip(1.5 - np.abs(4 * x - 2), 0, 1)
+    b = np.clip(1.5 - np.abs(4 * x - 1), 0, 1)
+    return np.stack([r, g, b], axis=-1)
+
+
+def overlay_heatmap(img_arr, map01, strength=0.6):
+    """
+    Blend a [0,1] heat map over a uint8 image; the map value doubles as the
+    per-pixel alpha so cold regions stay as plain camera image.
+    """
+    base = img_arr.astype(np.float32) / 255.0
+    heat = _jet(map01)
+    alpha = (map01 * strength)[..., None]
+    out = base * (1 - alpha) + heat * alpha
+    return (out * 255).astype(np.uint8)
+
+
+def _model_input_processor(cfg):
+    """
+    Build the raw-frame -> model-input mapping for this config.
+
+    TRANSFORMATIONS (crop, trapeze, colour-space, high-pass, ...) apply at
+    both training and inference, so anything measuring the MODEL's behaviour
+    has to see transformed pixels or it is describing a network state that
+    never occurs while driving. Mask-style transforms keep image dimensions,
+    so getting this wrong produces no error -- just wrong numbers and
+    misleading heat maps. Mirrors BatchSequence.image_processor in
+    pipeline/training.py (minus the training-only augmentation step).
+
+    Returns an identity function when nothing is configured.
+    """
+    tfm = list(getattr(cfg, 'TRANSFORMATIONS', None) or [])
+    post = list(getattr(cfg, 'POST_TRANSFORMATIONS', None) or [])
+    if not tfm and not post:
+        return lambda img: img
+    from donkeycar.parts.image_transformations import ImageTransformations
+    transformation = ImageTransformations(cfg, 'TRANSFORMATIONS')
+    post_transformation = ImageTransformations(cfg, 'POST_TRANSFORMATIONS')
+    return lambda img: post_transformation.run(transformation.run(img))
+
+
+def _model_input_differs(img, disp):
+    """True if the transformation pipeline actually changed the pixels, so
+    an unchanged pipeline doesn't double every frame on disk for nothing."""
+    if img is None or disp is None:
+        return False
+    if img.shape != disp.shape:
+        return True
+    return not np.array_equal(img, disp)
+
+
+def _as_displayable(img):
+    """Coerce a model input to something a browser can render as a jpg.
+
+    Transformations are free to emit shapes a viewer can't show directly,
+    e.g. single-channel output (RGB2GRAY, CANNY). Those are displayed as-is
+    rather than being reinterpreted, which is the honest thing to show --
+    it IS what the network receives.
+    """
+    arr = np.asarray(img)
+    if arr.dtype != np.uint8:
+        finite = np.isfinite(arr)
+        lo = float(arr[finite].min()) if finite.any() else 0.0
+        hi = float(arr[finite].max()) if finite.any() else 1.0
+        span = max(hi - lo, 1e-6)
+        arr = np.clip((arr - lo) / span * 255.0, 0, 255).astype(np.uint8)
+    if arr.ndim == 2:
+        return np.dstack([arr] * 3)
+    if arr.ndim == 3 and arr.shape[2] == 1:
+        return np.dstack([arr[:, :, 0]] * 3)
+    if arr.ndim == 3 and arr.shape[2] > 3:
+        return arr[:, :, :3]
+    return arr
+
+
+def _fit_map_to(map2d, img_arr):
+    """Resize a heat map to an image's dimensions, for the case where the
+    model input and the frame we draw on aren't the same size (e.g. a RESIZE
+    transformation). A no-op in the common mask-transform case."""
+    h, w = img_arr.shape[:2]
+    if map2d.shape[:2] == (h, w):
+        return map2d
+    return _resize_map(map2d, w, h)
+
+
+def _collect_variances(records, pilot, cfg, num_passes, alpha,
+                       progress_callback=None):
+    """
+    Get a per-frame smoothed steering-variance list, preferring values
+    logged in the tub (drives recorded with XAI_CONFIDENCE_ENABLED
+    enabled), else replaying the frames through the MC-Dropout part.
+
+    Entries are ``None`` for frames whose value is genuinely unknown (logged
+    by a drive where the pilot wasn't running for part of it); callers must
+    treat those as missing rather than as a variance of zero.
+
+    :param pilot:             an already-loaded KerasLinear, so a single
+                              analysis run doesn't deserialise the model once
+                              per collection stage.
+    :param progress_callback: optional ``callback(stage, current, total)``,
+                              called as frames are processed (stage='variance').
+                              Used by the GUI launcher to show progress; safe
+                              to omit for CLI use.
+    """
+    logged = [r.underlying.get('pilot/smoothed_variance') for r in records]
+    n_logged = sum(v is not None for v in logged)
+    if n_logged >= 0.5 * len(records) and n_logged > 0:
+        logger.info(f'Using logged uncertainty for {n_logged}/{len(records)} '
+                    f'frames.')
+        if progress_callback:
+            progress_callback('variance', len(records), len(records))
+        # Frames the pilot wasn't running for stay None (unknown), NOT 0.0 --
+        # 0.0 is the lowest possible variance, i.e. an assertion of maximum
+        # confidence, which would both misreport them in the timeline and
+        # guarantee they are never picked by --top-k.
+        return list(logged)
+
+    logger.info(f'No logged uncertainty in tub; replaying {len(records)} '
+                f'frames through MC-Dropout (N={num_passes})...')
+    from donkeycar.parts.mc_dropout import MCDropoutConfidence
+    part = MCDropoutConfidence(pilot, num_passes=num_passes, alpha=alpha)
+    to_model = _model_input_processor(cfg)   # confidence probes the model
+    smoothed = []
+    total = len(records)
+    for i, record in enumerate(records):
+        smoothed.append(part.run(to_model(record.image()))[4])
+        if (i + 1) % 200 == 0:
+            logger.info(f'  {i + 1}/{total} frames')
+        if progress_callback:
+            progress_callback('variance', i + 1, total)
+    return smoothed
+
+
+def _collect_novelty(records, model_path, cfg, calib, progress_callback=None):
+    """
+    Get a per-frame smoothed novelty (Mahalanobis) distance list, preferring
+    values logged in the tub, else replaying through FeatureNoveltyDetector.
+    Returns a list of raw floats (distances, NOT scores) the same length as
+    `records`, or None if no 'novelty_ood' calibration is available at all
+    (nothing to score against). Distances are in the generic-encoder feature
+    space, so they must be scored with the 'novelty_ood' anchors.
+
+    :param progress_callback: optional ``callback(stage, current, total)``,
+                              called as frames are processed (stage='novelty').
+    """
+    if calib is None or calib.get('novelty_ood') is None:
+        return None
+
+    logged = [r.underlying.get('pilot/smoothed_novelty_distance')
+             for r in records]
+    n_logged = sum(v is not None for v in logged)
+    if n_logged >= 0.5 * len(records) and n_logged > 0:
+        logger.info(f'Using logged novelty distance for {n_logged}/'
+                    f'{len(records)} frames.')
+        if progress_callback:
+            progress_callback('novelty', len(records), len(records))
+        # None means unknown (pilot wasn't running for that frame), not a
+        # distance of zero -- see _collect_variances.
+        return list(logged)
+
+    logger.info(f'No logged novelty distance in tub; replaying '
+                f'{len(records)} frames through FeatureNoveltyDetector...')
+    from donkeycar.parts.mc_calibrate import default_calib_path
+    from donkeycar.parts.novelty import FeatureNoveltyDetector
+    # No pilot needed: novelty scores with its own generic ImageNet encoder,
+    # and FeatureNoveltyDetector's `pilot` argument is unused.
+    part = FeatureNoveltyDetector(calibration_path=default_calib_path(model_path))
+    smoothed = []
+    total = len(records)
+    for i, record in enumerate(records):
+        # RAW frame on purpose -- novelty measures scene familiarity in a
+        # frozen ImageNet encoder, and TRANSFORMATIONS strip the colour and
+        # texture that encoder depends on. Matches the live wiring in
+        # templates/complete.py and the calibration in mc_calibrate.py.
+        smoothed.append(part.run(record.image())[2])
+        if (i + 1) % 200 == 0:
+            logger.info(f'  {i + 1}/{total} frames')
+        if progress_callback:
+            progress_callback('novelty', i + 1, total)
+    return smoothed
+
+
+def _collect_tta(records, pilot, model_path, cfg, calib,
+                 progress_callback=None):
+    """
+    Get a per-frame smoothed TTA (test-time augmentation) steering-variance
+    list, preferring values logged in the tub, else replaying through
+    TTAStabilityDetector. Returns a list the same length as `records` (with
+    ``None`` for frames whose value is unknown), or None if the model's
+    calibration has no 'tta' block.
+
+    :param pilot:             an already-loaded KerasLinear (see
+                              ``_collect_variances``).
+    :param progress_callback: optional ``callback(stage, current, total)``,
+                              called as frames are processed (stage='tta').
+    """
+    if calib is None or calib.get('tta') is None:
+        return None
+
+    logged = [r.underlying.get('pilot/smoothed_tta_variance') for r in records]
+    n_logged = sum(v is not None for v in logged)
+    if n_logged >= 0.5 * len(records) and n_logged > 0:
+        logger.info(f'Using logged TTA variance for {n_logged}/'
+                    f'{len(records)} frames.')
+        if progress_callback:
+            progress_callback('tta', len(records), len(records))
+        # None means unknown (pilot wasn't running for that frame), not a
+        # variance of zero -- see _collect_variances.
+        return list(logged)
+
+    logger.info(f'No logged TTA variance in tub; replaying {len(records)} '
+                f'frames through TTAStabilityDetector...')
+    from donkeycar.parts.mc_calibrate import default_calib_path
+    from donkeycar.parts.tta import TTAStabilityDetector
+    part = TTAStabilityDetector(
+        pilot, calibration_path=default_calib_path(model_path),
+        num_samples=getattr(cfg, 'XAI_TTA_SAMPLES', 8),
+        alpha=getattr(cfg, 'XAI_TTA_ALPHA', 0.2),
+        strength=getattr(cfg, 'XAI_TTA_STRENGTH', 0.2), seed=0)
+    to_model = _model_input_processor(cfg)   # TTA probes the model
+    smoothed = []
+    total = len(records)
+    for i, record in enumerate(records):
+        smoothed.append(part.run(to_model(record.image()))[2])
+        if (i + 1) % 200 == 0:
+            logger.info(f'  {i + 1}/{total} frames')
+        if progress_callback:
+            progress_callback('tta', i + 1, total)
+    return smoothed
+
+
+def analyze_tub(cfg, tub_path, model_path, out_dir, num_passes=15, alpha=0.2,
+                top_k=50, percentile=None, analyze_all=False, limit=None,
+                start=None, export_frames=False, ig_steps=32,
+                progress_callback=None, verify_preprocessing=True):
+    """
+    Run the full Feature 3 pipeline on one tub. Returns the data.json dict.
+
+    :param start:             skip this many records from the start of the
+                              tub before considering any frames -- combined
+                              with ``limit``, lets you scope to a specific
+                              range of the drive (e.g. ``start=1000,
+                              limit=1000`` looks at records 1000-1999).
+                              None/0 (default) starts from the first record.
+    :param limit:             only consider this many records after ``start``.
+                              None (default) considers the rest of the tub.
+    :param ig_steps:          number of Riemann-sum steps for the Integrated
+                              Gradients overlay (offline pixel attribution).
+    :param progress_callback: optional ``callback(stage, current, total)``,
+                              called throughout the three stages in order
+                              ('variance', 'novelty', 'gradcam'). Used by the
+                              GUI launcher (``donkeycar.parts.uncertainty_viewer``)
+                              to show live progress; harmless to omit for CLI use.
+    :param verify_preprocessing: raise if ``cfg``'s TRANSFORMATIONS /
+                              POST_TRANSFORMATIONS / ROI_CROP_*
+                              don't match what ``model_path`` was actually
+                              trained with (per its ``.preprocessing.json``
+                              sidecar). ``cfg`` here comes from ``--config``
+                              (CLI) or the launcher's config, and nothing
+                              otherwise ties it to the model being analysed --
+                              every heat map and the ``model_input`` layer
+                              would be silently computed on the wrong pixels.
+                              Set False only when the caller has deliberately
+                              chosen a different pipeline than the model was
+                              trained with (e.g. the launcher's transformations
+                              override) and knows that.
+    """
+    from donkeycar.parts.keras import KerasLinear
+    from donkeycar.parts.mc_calibrate import (default_calib_path,
+                                              load_calibration,
+                                              variance_to_confidence,
+                                              novelty_distance_to_score)
+    from donkeycar.parts.salient import (VanillaGradientSaliency,
+                                         IntegratedGradients)
+    from donkeycar.pipeline.types import TubDataset
+
+    t0 = time.time()
+    model_path = os.path.expanduser(model_path)
+    tub_path = os.path.expanduser(tub_path)
+
+    # Load the pilot once and share it across every stage below -- each
+    # collection stage used to deserialise the same .h5 again for itself.
+    pilot = KerasLinear()
+    pilot.load(model_path)
+
+    # Reconcile config image size with the model's own input shape BEFORE
+    # building the dataset -- records are resized per cfg, so a mismatch here
+    # surfaces later as an unreadable Keras shape error mid-forward-pass.
+    # This deliberately treats the model file as the authority and rewrites
+    # cfg (warning loudly), so a model can be analysed without tracking down
+    # the exact config.py it was trained with.
+    from donkeycar.parts.mc_calibrate import check_model_image_size
+    check_model_image_size(model_path, cfg, model=pilot.interpreter.model)
+
+    if verify_preprocessing:
+        from donkeycar.parts.image_transformations import \
+            check_preprocessing_metadata
+        # Resolution is excluded because the call above just SET cfg's
+        # IMAGE_W/IMAGE_H from this very model -- comparing them here could
+        # only ever agree, so leaving them in would look like a check while
+        # being incapable of failing. check_model_image_size already reports
+        # any disagreement it reconciled. Everything the model file cannot
+        # self-describe (the crop geometry and the transformation step list)
+        # is still enforced strictly.
+        check_preprocessing_metadata(
+            cfg, model_path, context="this analysis's config",
+            skip_keys=('image_width', 'image_height'))
+
+    dataset = TubDataset(config=cfg, tub_paths=[tub_path])
+    records = dataset.get_records()
+    if start or limit:
+        s = start or 0
+        e = (s + limit) if limit else None
+        records = records[s:e]
+    if not records:
+        raise ValueError(f'No records found in {tub_path}')
+
+    # Per-frame uncertainty timeline (logged or replayed). Entries can be
+    # None where the tub has no value for that frame.
+    variances = _collect_variances(records, pilot, cfg, num_passes, alpha,
+                                   progress_callback=progress_callback)
+
+    # Confidence % (and novelty stats, if present) from the model's calibration.
+    calib = None
+    calib_path = default_calib_path(model_path)
+    if os.path.exists(calib_path):
+        calib = load_calibration(calib_path)
+        logger.info(f'Loaded calibration {calib_path}')
+    else:
+        logger.warning(f'No calibration at {calib_path}; timeline will have '
+                       f'variance only.')
+
+    def conf(v):
+        if calib is None or v is None:
+            return None
+        return variance_to_confidence(v, calib)
+
+    # Per-frame novelty (out-of-distribution) timeline -- cheap, every frame,
+    # independent of the Grad-CAM frame selection below. None if the model's
+    # calibration has no novelty stats at all (older calibration).
+    novelty_distances = _collect_novelty(records, model_path, cfg, calib,
+                                         progress_callback=progress_callback)
+
+    def nov_score(d):
+        if calib is None or calib.get('novelty_ood') is None or d is None:
+            return None
+        return novelty_distance_to_score(d, calib['novelty_ood'])
+
+    # Per-frame TTA (test-time augmentation) stability timeline -- cheap-ish,
+    # every frame, independent of the Grad-CAM frame selection. None if the
+    # model's calibration has no 'tta' block.
+    tta_variances = _collect_tta(records, pilot, model_path, cfg, calib,
+                                 progress_callback=progress_callback)
+
+    def tta_stability(var):
+        if calib is None or calib.get('tta') is None or var is None:
+            return None
+        from donkeycar.parts.mc_calibrate import tta_variance_to_stability
+        return tta_variance_to_stability(var, calib['tta'])
+
+    # Record WHY any signal is absent, so the viewer can say so instead of
+    # just silently omitting a line from the graph. A missing signal and a
+    # signal that happens to be flat look identical otherwise.
+    from donkeycar.parts.mc_calibrate import missing_calibration_reason
+    signals_unavailable = []
+    for key, label, signal in (('confidence', 'Confidence', 'confidence'),
+                               ('novelty_score', 'Novelty', 'novelty'),
+                               ('tta_stability', 'TTA stability', 'tta')):
+        reason = missing_calibration_reason(calib_path, signal)
+        if reason:
+            signals_unavailable.append(
+                {'key': key, 'label': label, 'reason': reason})
+            logger.info(f'{label} will not appear in the timeline: {reason}')
+
+    timeline = []
+    for i, (record, v) in enumerate(zip(records, variances)):
+        nd = novelty_distances[i] if novelty_distances is not None else None
+        tv = tta_variances[i] if tta_variances is not None else None
+        timeline.append({
+            'index': record.underlying.get('_index'),
+            'timestamp_ms': record.underlying.get('_timestamp_ms'),
+            'variance': float(v) if v is not None else None,
+            'confidence': conf(v),
+            'novelty_distance': nd,
+            'novelty_score': nov_score(nd),
+            'tta_variance': tv,
+            'tta_stability': tta_stability(tv),
+            # image filename inside the tub's images/ dir, so the viewer can
+            # show the camera frame for non-analysed frames when the tub is
+            # available locally.
+            'tub_image': record.underlying.get('cam/image_array'),
+        })
+
+    # Optionally export every camera frame so the analysis dir is fully
+    # self-contained (playback works with just this folder, no tub needed --
+    # useful when copying results off a cluster). ~5-8 KB per frame.
+    if export_frames:
+        frames_dir = os.path.join(out_dir, 'frames')
+        os.makedirs(frames_dir, exist_ok=True)
+        logger.info(f'Exporting {len(records)} camera frames to {frames_dir}')
+        for record, entry in zip(records, timeline):
+            name = f"{entry['index']:06d}.jpg"
+            Image.fromarray(record.image()).save(
+                os.path.join(frames_dir, name))
+            entry['image'] = f'frames/{name}'
+
+    # Select frames to analyse. Frames with an unknown variance are ranked
+    # and thresholded on nothing at all -- they are simply not candidates for
+    # the uncertainty-driven modes, rather than being treated as variance 0
+    # (which would rank them as the MOST certain frames in the drive).
+    known = [i for i, v in enumerate(variances) if v is not None]
+    if len(known) < len(records):
+        logger.warning(
+            f'{len(records) - len(known)}/{len(records)} frames have no '
+            f'uncertainty value (the pilot was not running for them); they '
+            f'stay in the timeline but are excluded from frame selection.')
+    if analyze_all:
+        selected = list(range(len(records)))
+    elif percentile is not None:
+        if not known:
+            raise ValueError('No frame has an uncertainty value, so a '
+                             'percentile cannot be computed. Use --all, or '
+                             'analyse a tub recorded with the pilot running.')
+        thresh = float(np.percentile([variances[i] for i in known], percentile))
+        selected = [i for i in known if variances[i] >= thresh]
+        logger.info(f'{len(selected)} frames at/above p{percentile} '
+                    f'(variance >= {thresh:.6f})')
+    else:
+        # most uncertain first, among the frames that have a value
+        order = sorted(known, key=lambda i: variances[i], reverse=True)
+        selected = order[:top_k]
+    logger.info(f'Analysing {len(selected)} of {len(records)} frames.')
+
+    # Build the Grad-CAM and vanilla-gradient-saliency engines on the raw
+    # Keras model (two independent, complementary attribution methods), reusing
+    # the pilot loaded at the top rather than deserialising it again.
+    from donkeycar.utils import normalize_image
+    engine = GradCamUncertainty(pilot.interpreter.model, num_passes=num_passes)
+    saliency_engine = VanillaGradientSaliency(pilot.interpreter.model)
+    ig_engine = IntegratedGradients(pilot.interpreter.model, steps=ig_steps)
+
+    # Spatial novelty stats, if this model's calibration has them. Needs the
+    # generic encoder (kept unpooled) rather than the steering model, so the
+    # heat map is measured in the same space as the novelty percentage.
+    novelty_spatial = calib.get('novelty_ood_spatial') if calib else None
+    ns_extractor = None
+    if novelty_spatial is not None:
+        try:
+            from donkeycar.parts.ood import SpatialEncoderExtractor
+            ns_extractor = SpatialEncoderExtractor(
+                novelty_spatial.get('encoder', 'mobilenet_v2'),
+                input_hw=tuple(novelty_spatial['input_hw']),
+                alpha=novelty_spatial.get('alpha', 1.0))
+            ns_mean = np.array(novelty_spatial['mean'])
+            ns_var = np.array(novelty_spatial['var'])
+            ns_active = np.array(novelty_spatial['active_dims'])
+            ns_eps = novelty_spatial['eps']
+        except Exception as e:
+            logger.warning(f'Could not build the spatial novelty encoder '
+                           f'({e}); the novelty heat map will be skipped.')
+            novelty_spatial = None
+    elif calib is not None:
+        logger.info('No "novelty_ood_spatial" block in this calibration '
+                    '(built before the encoder-space map, or the encoder was '
+                    'unavailable); novelty heat map will be skipped.')
+
+    images_dir = os.path.join(out_dir, 'images')
+    os.makedirs(images_dir, exist_ok=True)
+
+    frames = {}
+    to_model = _model_input_processor(cfg)
+    model_input_available = False
+    for n, i in enumerate(sorted(selected)):
+        record = records[i]
+        # Two images per frame, on purpose:
+        #   disp  -- the raw camera frame, what a human recognises.
+        #   img   -- what the model is actually fed (transformed). Every
+        #            gradient/attribution is computed against this, or it
+        #            would be explaining behaviour on input the model never
+        #            sees while driving.
+        # Heat maps therefore come back in img's coordinates. Every
+        # transformation available here preserves the frame's geometry (CROP
+        # and TRAPEZE mask rather than resize), so a map drawn on the raw
+        # frame lands on the right pixels; it is also saved drawn directly on
+        # img (the '_mi' variants) whenever the transformation changed the
+        # pixels, so the model's own view can be inspected.
+        disp = record.image()
+        img = to_model(disp)
+        idx = record.underlying.get('_index', i)
+
+        model_view = _as_displayable(img)
+        # Only worth a second copy of every map when the model input actually
+        # differs; otherwise the two overlays would be identical images.
+        want_mi = _model_input_differs(img, disp)
+        model_input_available = model_input_available or want_mi
+
+        def save_map(map_model_space, suffix, key, entry):
+            """Save one heat map twice: on the raw frame, and drawn directly
+            on the model input."""
+            raw_map = _fit_map_to(map_model_space, disp)
+            name = f'{idx:06d}_{suffix}.png'
+            Image.fromarray(overlay_heatmap(disp, raw_map)).save(
+                os.path.join(images_dir, name))
+            entry[key] = f'images/{name}'
+            if want_mi:
+                mi_map = _fit_map_to(map_model_space, model_view)
+                mi_name = f'{idx:06d}_{suffix}_mi.png'
+                Image.fromarray(overlay_heatmap(model_view, mi_map)).save(
+                    os.path.join(images_dir, mi_name))
+                entry[key + '_mi'] = f'images/{mi_name}'
+
+        mean_map, var_map, raw_peak = engine.uncertainty_map(img)
+        orig_name = f'{idx:06d}_orig.jpg'
+        Image.fromarray(disp).save(os.path.join(images_dir, orig_name))
+
+        frame_entry = {
+            'orig': f'images/{orig_name}',
+            'variance': (float(variances[i])
+                         if variances[i] is not None else None),
+            'confidence': conf(variances[i]),
+            'attention_variance_peak': raw_peak,
+        }
+        save_map(var_map, 'unc', 'overlay', frame_entry)
+        save_map(mean_map, 'attn', 'attention', frame_entry)
+
+        # The model input itself, saved whenever it differs from the raw
+        # frame, so the transformation pipeline can be eyeballed directly.
+        if want_mi:
+            model_input_name = f'{idx:06d}_model_input.jpg'
+            Image.fromarray(model_view).save(
+                os.path.join(images_dir, model_input_name))
+            frame_entry['model_input'] = f'images/{model_input_name}'
+
+        # Grad-CAM++ attention (sharper, multi-region variant of 'attention').
+        save_map(engine.attention_pp_map(img), 'attnpp', 'attention_pp',
+                 frame_entry)
+
+        if novelty_spatial is not None:
+            # RAW frame: novelty is measured on untransformed pixels, matching
+            # the live detector and the timeline's novelty %. Its map is
+            # therefore already in raw coordinates - it must NOT be projected,
+            # and there is no model-input variant to show.
+            nov_map, nov_peak = engine.novelty_map(
+                disp, ns_mean, ns_var, ns_active, ns_eps,
+                extractor=ns_extractor)
+            nov_map = _fit_map_to(nov_map, disp)
+            nov_name = f'{idx:06d}_novelty.png'
+            Image.fromarray(overlay_heatmap(disp, nov_map)).save(
+                os.path.join(images_dir, nov_name))
+            frame_entry['novelty'] = f'images/{nov_name}'
+            frame_entry['novelty_map_peak'] = nov_peak
+
+        norm_img = normalize_image(img).astype(np.float32)
+        save_map(saliency_engine.saliency_map(norm_img), 'saliency',
+                 'saliency', frame_entry)
+        # Integrated Gradients: cleaner, axiomatic pixel attribution.
+        save_map(ig_engine.saliency_map(norm_img), 'ig',
+                 'integrated_gradients', frame_entry)
+
+        frames[str(idx)] = frame_entry
+        if (n + 1) % 10 == 0:
+            logger.info(f'  analysed {n + 1}/{len(selected)} frames')
+        if progress_callback:
+            progress_callback('gradcam', n + 1, len(selected))
+
+    data = {
+        'model': os.path.basename(model_path),
+        'tub': tub_path,
+        'num_passes': num_passes,
+        'alpha': alpha,
+        'n_records': len(records),
+        'n_analyzed': len(selected),
+        'frames_exported': bool(export_frames),
+        # True when TRANSFORMATIONS actually changed the pixels, so a
+        # '<layer>_mi' variant drawn on the model input also exists.
+        'model_input_available': model_input_available,
+        'created': time.strftime('%Y-%m-%d %H:%M:%S'),
+        'note': ('Attention-variance maps from MC-Dropout Grad-CAM. '
+                 'Relative per-model signal, not a calibrated probability.'),
+        'timeline': timeline,
+        'frames': frames,
+        'signals_unavailable': signals_unavailable,
+    }
+    with open(os.path.join(out_dir, 'data.json'), 'w') as f:
+        json.dump(data, f)
+    dataset.close()
+    logger.info(f'Done in {time.time() - t0:.1f}s -> {out_dir} '
+                f'({len(selected)} frames analysed)')
+    return data
+
+
+def main(args=None):
+    import donkeycar as dk
+
+    parser = argparse.ArgumentParser(
+        prog='gradcam_uncertainty',
+        description='Offline Grad-CAM uncertainty maps for a recorded tub.')
+    parser.add_argument('--tub', required=True, help='tub path to analyse')
+    parser.add_argument('--model', required=True, help='path to .h5 model')
+    parser.add_argument('--config', default=None, help='path to config.py')
+    parser.add_argument('--out', default=None,
+                        help='output dir (default <tub>/gradcam_analysis)')
+    parser.add_argument('--passes', type=int, default=None,
+                        help='MC-Dropout passes (default cfg or 15)')
+    parser.add_argument('--top-k', type=int, default=50,
+                        help='analyse the K most uncertain frames (default)')
+    parser.add_argument('--percentile', type=float, default=None,
+                        help='instead analyse frames >= this variance '
+                             'percentile (e.g. 90)')
+    parser.add_argument('--ig-steps', type=int, default=None,
+                        help='Integrated Gradients Riemann steps '
+                             '(default cfg XAI_IG_STEPS or 32)')
+    parser.add_argument('--all', action='store_true',
+                        help='analyse every frame (short drives only)')
+    parser.add_argument('--limit', type=int, default=None,
+                        help='only consider N records (from --start, or the '
+                             'beginning of the tub)')
+    parser.add_argument('--start', type=int, default=None,
+                        help='skip this many records from the start of the '
+                             'tub before considering any frames -- combine '
+                             'with --limit for a specific range, e.g. '
+                             '--start 1000 --limit 1000 for records 1000-1999')
+    parser.add_argument('--export-frames', action='store_true',
+                        help='also copy every camera frame into the output '
+                             'dir so playback in the viewer works without '
+                             'the tub present (self-contained results)')
+    parsed = parser.parse_args(args)
+
+    from donkeycar.parts.image_transformations import \
+        load_config_and_myconfig
+    cfg = load_config_and_myconfig(parsed.config)
+
+    num_passes = parsed.passes or getattr(cfg, 'XAI_CONFIDENCE_PASSES', 15)
+    alpha = getattr(cfg, 'XAI_CONFIDENCE_ALPHA', 0.2)
+    ig_steps = parsed.ig_steps or getattr(cfg, 'XAI_IG_STEPS', 32)
+    out_dir = parsed.out or os.path.join(os.path.expanduser(parsed.tub),
+                                         'gradcam_analysis')
+
+    data = analyze_tub(cfg, parsed.tub, parsed.model, out_dir,
+                       num_passes=num_passes, alpha=alpha,
+                       top_k=parsed.top_k, percentile=parsed.percentile,
+                       analyze_all=parsed.all, limit=parsed.limit,
+                       start=parsed.start,
+                       export_frames=parsed.export_frames, ig_steps=ig_steps)
+    print(f"\nGrad-CAM uncertainty analysis complete:")
+    print(f"  frames in drive : {data['n_records']}")
+    print(f"  frames analysed : {data['n_analyzed']}")
+    print(f"  output          : {out_dir}")
+    print(f"\nView it with:")
+    print(f"  python -m donkeycar.parts.uncertainty_viewer "
+          f"--analysis {out_dir}")
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/donkeycar/parts/image_transformations.py
+++ b/donkeycar/parts/image_transformations.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import os
 from typing import List
 from donkeycar.config import Config
 from donkeycar.parts import cv as cv_parts
@@ -14,9 +16,12 @@ class ImageTransformations:
         Part that constructs a list of image transformers
         and run them in sequence to produce a transformed image
         """
-        transformations = getattr(config, transformation, [])
+        # NOTE: build a NEW list rather than `+=`, which would extend (and so
+        # permanently corrupt) the config's own TRANSFORMATIONS list in place.
+        transformations = list(getattr(config, transformation, []) or [])
         if post_transformation:
-            transformations += getattr(config, post_transformation, [])
+            transformations = transformations + list(
+                getattr(config, post_transformation, []) or [])
         self.transformations = [image_transformer(name, config) for name in
                                 transformations]
         logger.info(f'Creating ImageTransformations {transformations}')
@@ -29,6 +34,225 @@ class ImageTransformations:
         for transformer in self.transformations:
             image = transformer.run(image)
         return image
+
+
+def _pipeline_steps(cfg, include_augmentations=False):
+    """
+    Return the ordered list of pipeline step names actually executed by
+    donkeycar.pipeline.training.BatchSequence.image_processor -
+    TRANSFORMATIONS, then AUGMENTATIONS (training only), then
+    POST_TRANSFORMATIONS - so logging/metadata always reflect the real
+    execution order rather than the raw config attributes.
+    """
+    steps = list(getattr(cfg, 'TRANSFORMATIONS', []) or [])
+    if include_augmentations:
+        steps += list(getattr(cfg, 'AUGMENTATIONS', []) or [])
+    steps += list(getattr(cfg, 'POST_TRANSFORMATIONS', []) or [])
+    return steps
+
+
+def log_preprocessing_config(cfg, context: str, include_augmentations=False):
+    """
+    Print the resolved image size, transformation/augmentation config and
+    the actual ordered pipeline for a given context ('training',
+    'validation' or 'vehicle'), so a train/inference preprocessing mismatch
+    shows up in the logs instead of only as bad driving behaviour.
+    """
+    logger.info(
+        f"[{context}] IMAGE_W={getattr(cfg, 'IMAGE_W', None)} "
+        f"IMAGE_H={getattr(cfg, 'IMAGE_H', None)} "
+        f"TRANSFORMATIONS={getattr(cfg, 'TRANSFORMATIONS', [])} "
+        f"POST_TRANSFORMATIONS={getattr(cfg, 'POST_TRANSFORMATIONS', [])} "
+        f"ROI_CROP_TOP={getattr(cfg, 'ROI_CROP_TOP', None)} "
+        f"ROI_CROP_BOTTOM={getattr(cfg, 'ROI_CROP_BOTTOM', None)} "
+        f"ROI_CROP_LEFT={getattr(cfg, 'ROI_CROP_LEFT', None)} "
+        f"ROI_CROP_RIGHT={getattr(cfg, 'ROI_CROP_RIGHT', None)}")
+    steps = ['Raw Image'] + \
+        _pipeline_steps(cfg, include_augmentations) + ['Model']
+    logger.info(f"[{context}] pipeline: {' -> '.join(steps)}")
+
+
+def build_preprocessing_metadata(cfg) -> dict:
+    """
+    Snapshot of the preprocessing settings that must be identical between
+    training and driving (or, for gradcam_uncertainty.py, training and
+    offline analysis). Used both as the sidecar json saved next to a trained
+    model and as the "current config" side of the comparison done by
+    check_preprocessing_metadata().
+    """
+    steps = _pipeline_steps(cfg, include_augmentations=False)
+    crop_active = 'CROP' in steps
+    return {
+        "image_width": getattr(cfg, 'IMAGE_W', None),
+        "image_height": getattr(cfg, 'IMAGE_H', None),
+        "roi_crop_top": getattr(cfg, 'ROI_CROP_TOP', 0) if crop_active else 0,
+        "roi_crop_bottom": getattr(cfg, 'ROI_CROP_BOTTOM', 0)
+                           if crop_active else 0,
+        "roi_crop_left": getattr(cfg, 'ROI_CROP_LEFT', 0)
+                         if crop_active else 0,
+        "roi_crop_right": getattr(cfg, 'ROI_CROP_RIGHT', 0)
+                          if crop_active else 0,
+        # The ROI_CROP_* fields above only ever describe the CROP mask, and
+        # can't distinguish CANNY, colour-space conversions or TRAPEZE from
+        # each other, or catch a step LIST changing. pipeline_steps is the
+        # actual ordered TRANSFORMATIONS + POST_TRANSFORMATIONS list, so any
+        # such change is caught too.
+        "pipeline_steps": steps,
+    }
+
+
+def load_config_and_myconfig(config_path=None):
+    """
+    Load a Config the way the offline analysis tools (gradcam_uncertainty.py,
+    uncertainty_viewer.py) need it: the full set of base settings, plus this
+    project's real overrides from myconfig.py, reliably - regardless of
+    which file ``config_path`` happens to point at.
+
+    Why this exists rather than just calling donkeycar.config.load_config()
+    directly: that function's own myconfig.py lookup is a literal string
+    ``config_path.replace("config.py", "myconfig.py")`` on the WHOLE path.
+    That only works when the base file is literally named "config.py"
+    sitting next to a myconfig.py - the standard ``donkey createcar``
+    layout. It silently breaks in two cases that are completely ordinary
+    for this project, where the real base/override pair is
+    donkeycar/templates/cfg_complete.py + donkeycar/templates/myconfig.py,
+    not a repo-root config.py/myconfig.py:
+
+      1. Falling back to the bundled cfg_complete.py (no ./config.py found,
+         nothing passed via --config): "cfg_complete.py" doesn't contain the
+         substring "config.py", so the .replace() is a no-op and myconfig.py
+         is never even looked for. This is what a bare
+         ``python run_gradcam_analysis.py`` hits.
+      2. Pointing --config directly at myconfig.py: "myconfig.py" DOES
+         contain "config.py" as a substring (it's the last 9 characters), so
+         the .replace() fires and produces the nonexistent "mymyconfig.py" -
+         and myconfig.py alone lacks base settings like IMAGE_DEPTH/
+         BATCH_SIZE that only cfg_complete.py defines, so the result is an
+         incomplete config either way.
+
+    This does not touch donkeycar.config.load_config() itself, since that
+    would change behaviour for every caller (train, drive, ...) rather than
+    just the two analysis-tool entry points that actually hit this.
+    """
+    import donkeycar as dk
+
+    bundled_base = os.path.join(os.path.dirname(dk.__file__),
+                                'templates', 'cfg_complete.py')
+
+    if config_path is None:
+        if os.path.exists('config.py'):
+            config_path = 'config.py'
+        else:
+            logger.warning(f'No ./config.py; using the bundled base config at '
+                           f'{bundled_base}.')
+            config_path = bundled_base
+    config_path = os.path.abspath(config_path)
+
+    if os.path.basename(config_path) == 'myconfig.py':
+        # config_path IS the overrides-only file - load the full bundled
+        # base first so IMAGE_DEPTH/BATCH_SIZE/etc aren't silently missing,
+        # then apply config_path's own content on top of it.
+        cfg = dk.load_config(bundled_base)
+        overrides = Config()
+        overrides.from_pyfile(config_path)
+        cfg.from_object(overrides)
+    else:
+        cfg = dk.load_config(config_path)
+
+    # Redo the myconfig.py sibling lookup with a real path join instead of
+    # the broken string-replace described above. In the standard config.py
+    # layout this re-applies what load_config() already merged in (harmless
+    # - from_object() is idempotent); in both cases above it's what actually
+    # makes myconfig.py's overrides take effect at all.
+    sibling = os.path.join(os.path.dirname(config_path), 'myconfig.py')
+    if os.path.isfile(sibling) and os.path.abspath(sibling) != config_path:
+        logger.info(f'Applying overrides from {sibling}')
+        overrides = Config()
+        overrides.from_pyfile(sibling)
+        cfg.from_object(overrides)
+
+    return cfg
+
+
+def _sidecar_path_for(model_path: str) -> str:
+    base, _ext = os.path.splitext(model_path)
+    return base + ".preprocessing.json"
+
+
+def save_preprocessing_metadata(cfg, model_path: str) -> str:
+    """ Write the resolved preprocessing metadata next to a just-trained
+        model, e.g. models/mypilot.h5 -> models/mypilot.preprocessing.json """
+    sidecar_path = _sidecar_path_for(model_path)
+    with open(sidecar_path, 'w') as f:
+        json.dump(build_preprocessing_metadata(cfg), f, indent=2)
+    logger.info(f"Saved preprocessing metadata to {sidecar_path}")
+    return sidecar_path
+
+
+def check_preprocessing_metadata(cfg, model_path: str,
+                                 context: str = "vehicle",
+                                 skip_keys=()) -> None:
+    """
+    Compare model_path's preprocessing sidecar (if any) against the given
+    config. Raises RuntimeError describing every mismatched field if any
+    differ, so a stale/mismatched crop, transformation step or resolution
+    stops whatever is about to consume the model instead of silently
+    producing wrong output. If no sidecar exists (e.g. a model trained
+    before this check existed), this only logs a warning and continues.
+
+    :param context: how to describe the caller in the error/warning text -
+        "vehicle" (default, for drive-time use) or e.g. "this analysis's
+        config" for gradcam_uncertainty.py. Purely cosmetic.
+    :param skip_keys: fields to leave out of the comparison because the
+        caller reconciles them itself. The offline analysis tools pass
+        ('image_width', 'image_height'): they call
+        mc_calibrate.check_model_image_size() first, which takes the model
+        file as the authority on its own input size, rewrites cfg to match
+        and says so - a documented convenience so a model can be analysed
+        without hunting down the exact config.py it was trained with.
+        Comparing those two fields afterwards would be meaningless (cfg was
+        just set FROM the model), so they are excluded explicitly rather
+        than left in to silently always-agree.
+    """
+    sidecar_path = _sidecar_path_for(model_path)
+    if not os.path.exists(sidecar_path):
+        logger.warning(
+            f"No preprocessing metadata found at {sidecar_path} - cannot "
+            f"verify that {model_path} matches {context}'s TRANSFORMATIONS"
+            f"/POST_TRANSFORMATIONS/ROI_CROP_* configuration.")
+        return
+
+    with open(sidecar_path) as f:
+        saved = json.load(f)
+    current = {key: value for key, value
+               in build_preprocessing_metadata(cfg).items()
+               if key not in skip_keys}
+
+    # Only enforce fields the sidecar actually recorded. Keys can be added to
+    # build_preprocessing_metadata() over time (pipeline_steps postdates
+    # the original schema) - a sidecar
+    # written before that addition simply never captured it, which is not
+    # evidence of a real mismatch, so it must not be treated as one.
+    unverifiable = [key for key in current if key not in saved]
+    if unverifiable:
+        logger.warning(
+            f"{sidecar_path} predates tracking {unverifiable} - cannot "
+            f"verify {'those fields' if len(unverifiable) > 1 else 'that field'} "
+            f"match {context}. Retrain to refresh the sidecar and get full "
+            f"verification.")
+
+    mismatches = [
+        f"  {key}: model was trained with {saved.get(key)!r}, "
+        f"current {context} has {current.get(key)!r}"
+        for key in current if key in saved and saved.get(key) != current.get(key)
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "Preprocessing mismatch between the trained model "
+            f"({sidecar_path}) and {context}:\n" +
+            "\n".join(mismatches) +
+            f"\nRefusing to proceed - retrain the model with {context}, "
+            f"or update {context} to match the model.")
 
 
 def image_transformer(name: str, config):

--- a/donkeycar/parts/mc_calibrate.py
+++ b/donkeycar/parts/mc_calibrate.py
@@ -1,0 +1,1160 @@
+"""
+Calibration for the MC-Dropout uncertainty signal.
+
+The raw / smoothed steering variance produced by
+``donkeycar.parts.mc_dropout.MCDropoutConfidence`` is not interpretable on its
+own -- its scale depends on the trained model and the track/domain. This module
+turns that variance into a *relative, per-model* "confidence %" by:
+
+  1. Replaying a recorded tub through the MC-Dropout part to collect a
+     distribution of ``smoothed_variance`` values.
+  2. Computing percentile thresholds (default 50 / 80 / 97) from that
+     distribution.
+  3. Building a monotonic piecewise-linear map from variance -> confidence %,
+     anchored on those percentiles, and saving it next to the model as
+     ``<model>.calib.json``.
+
+At drive time, ``variance_to_confidence()`` maps the live smoothed variance to
+a displayed percentage using those anchors.
+
+WHICH TUB you calibrate against matters. The whole idea is "how does this
+frame compare to the training distribution" -- so calibration should be run
+against the tub(s) the model was actually trained on, not e.g. a later
+inference/test drive (that would make "novelty" mean "unlike this other
+drive" rather than "unlike what the model learned", and would make
+"confidence %" relative to the wrong baseline entirely). ``find_training_tubs()``
+looks this up automatically from DonkeyCar's own training-run database when
+available; see its docstring and the GUI launcher's auto-calibrate feature
+(``donkeycar.parts.uncertainty_viewer``) for how this is used in practice.
+
+IMPORTANT: this is a relative, per-model calibration, NOT a formally calibrated
+Bayesian probability. A displayed "90%" means "this frame's uncertainty is low
+*relative to this model's own baseline drive*", nothing more.
+
+The same replay pass also fits calibration statistics for the complementary
+feature-space novelty (out-of-distribution) signal -- see
+``donkeycar.parts.novelty``. Features come from a generic ImageNet encoder
+(``donkeycar.parts.ood``) run on the RAW frame, a diagonal Gaussian is fit,
+and percentile-anchored novelty-score maps are stored as ``novelty_ood``
+(pooled, drives the live %) and ``novelty_ood_spatial`` (per-location, drives
+the offline heat map) blocks in the same ``calib.json``. Both are purely
+additive -- older calibrations without these keys still work, novelty just
+displays as unavailable. ``novelty_distance_to_score()`` is the novelty
+analogue of ``variance_to_confidence()``.
+"""
+import json
+import logging
+import os
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Percentiles used to define the confidence tiers. p50 (median) anchors "high
+# confidence", p80 the normal/reduced boundary, p97 the reduced/critical one.
+DEFAULT_PERCENTILES = (50, 80, 97)
+
+# Confidence % assigned at each anchor (plus the distribution min/max ends).
+# Monotonically decreasing: low variance -> high confidence.
+_ANCHOR_CONFIDENCE = {
+    'min': 99.0,
+    'p50': 90.0,
+    'p80': 65.0,
+    'p97': 25.0,
+    'max': 5.0,
+}
+
+# Novelty % assigned at each Mahalanobis-distance percentile anchor.
+# Monotonically INCREASING (opposite direction from confidence): low
+# distance from the training distribution -> low novelty (familiar), high
+# distance -> high novelty (unfamiliar).
+_ANCHOR_NOVELTY = {
+    'min': 2.0,
+    'p50': 10.0,
+    'p80': 45.0,
+    'p97': 80.0,
+    'max': 98.0,
+}
+
+# Frames per OOD-encoder forward batch. The extractor resizes and converts the
+# whole list it is handed into one float32 array, so an unchunked call over a
+# large tub allocates far more than the uint8 frames themselves.
+_OOD_CHUNK = 256
+
+
+def build_calibration(smoothed_variances, num_passes, alpha,
+                      percentiles=DEFAULT_PERCENTILES, model_path=None,
+                      tta_variances=None, tta_num_samples=None,
+                      tta_strength=None, tta_alpha=None,
+                      ood_features=None, ood_encoder=None, ood_input_size=None,
+                      ood_alpha=1.0, ood_encoder_file=None,
+                      ood_anchor_distances=None,
+                      ood_spatial_features=None, ood_spatial_input_hw=None,
+                      augmentation_info=None, transformation_info=None):
+    """
+    Turn a collected distribution of smoothed variances into a calibration
+    dict (JSON-serialisable). Optionally also fits novelty-detection
+    (Mahalanobis distance) statistics from per-frame feature vectors:
+
+    :param ood_features:    optional (n_samples, feat_dim) generic-encoder
+                            features -- fits the live novelty statistics.
+    :param ood_anchor_distances: optional pre-computed distances to fit the
+                            ``novelty_ood`` percentile anchors on, in place of
+                            the raw per-frame distances of ``ood_features``
+                            itself -- see ``_build_novelty_block`` for why
+                            (the live detector scores an EMA-smoothed,
+                            interval-throttled distance, not the raw one).
+                            Has no effect on ``novelty_ood_spatial``, which
+                            has no smoothing/interval concept.
+    :param ood_spatial_features: optional (n_samples, feat_dim) array of
+                            PER-LOCATION generic-encoder features, pooling
+                            every grid location across every sampled frame
+                            into one distribution -- fits the offline spatial
+                            novelty map (see donkeycar.parts.novelty for the
+                            position-independence trade-off).
+    :param tta_variances:   optional list of per-frame test-time-augmentation
+                            steering variances -- fits the ``tta`` stability
+                            calibration block (see donkeycar.parts.tta).
+    :param augmentation_info: optional provenance dict recording whether the
+                            novelty baselines were widened with training-style
+                            augmented frames (see ``calibrate_from_tub``).
+                            Stored as-is under the ``augmentation`` key so a
+                            calibration can be told apart from a clean-only
+                            one after the fact; omitted when None, keeping
+                            older calibration files valid.
+    """
+    v = np.asarray(smoothed_variances, dtype=np.float64)
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        raise ValueError('No variance samples collected for calibration.')
+
+    p50, p80, p97 = (float(np.percentile(v, p)) for p in percentiles)
+    vmin, vmax = float(v.min()), float(v.max())
+
+    # Build monotonic anchor points (variance ascending) for np.interp. We
+    # nudge duplicates so the x-values are strictly increasing.
+    xs = [vmin, p50, p80, p97, vmax]
+    ys = [_ANCHOR_CONFIDENCE['min'], _ANCHOR_CONFIDENCE['p50'],
+          _ANCHOR_CONFIDENCE['p80'], _ANCHOR_CONFIDENCE['p97'],
+          _ANCHOR_CONFIDENCE['max']]
+    xs = _make_strictly_increasing(xs)
+
+    calib = {
+        'model': os.path.basename(model_path) if model_path else None,
+        'num_passes': int(num_passes),
+        'alpha': float(alpha),
+        'n_frames': int(v.size),
+        'percentiles': {'p50': p50, 'p80': p80, 'p97': p97},
+        'variance_stats': {'min': vmin, 'max': vmax,
+                           'mean': float(v.mean()), 'std': float(v.std())},
+        'tiers': {
+            'normal_below': p80,
+            'reduced_below': p97,
+            'critical_at_or_above': p97,
+        },
+        'confidence_anchors': {'variance': xs, 'confidence': ys},
+        'note': ('Relative per-model uncertainty calibration, NOT a formally '
+                 'calibrated probability.'),
+    }
+
+    if ood_spatial_features is not None:
+        # Per-location generic-encoder vectors, pooled across every location
+        # and frame into ONE distribution -- position-independent, same idea
+        # as the old conv2d_5 block but in the encoder's feature space, so
+        # the offline heat map and the live novelty score finally agree.
+        calib['novelty_ood_spatial'] = _build_ood_spatial_block(
+            ood_spatial_features, ood_encoder, ood_spatial_input_hw,
+            ood_alpha, percentiles)
+    if tta_variances is not None:
+        calib['tta'] = _build_tta_block(
+            tta_variances, tta_num_samples, tta_strength, tta_alpha,
+            percentiles)
+    if ood_features is not None:
+        calib['novelty_ood'] = _build_ood_block(
+            ood_features, ood_encoder, ood_input_size, ood_alpha,
+            ood_encoder_file, percentiles,
+            anchor_distances=ood_anchor_distances)
+    if augmentation_info is not None:
+        calib['augmentation'] = augmentation_info
+    if transformation_info is not None:
+        calib['transformations'] = transformation_info
+
+    return calib
+
+
+def _build_tta_block(tta_variances, num_samples, strength, alpha,
+                     percentiles=DEFAULT_PERCENTILES):
+    """
+    Build the TTA (test-time augmentation) stability calibration block from a
+    distribution of per-frame TTA steering variances. Mirrors the confidence
+    calibration exactly (descending variance -> stability % map), with its own
+    anchors, so ``tta_variance_to_stability`` reads standing within this
+    model's own TTA-variance distribution.
+    """
+    v = np.asarray(tta_variances, dtype=np.float64)
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        raise ValueError('No TTA variance samples collected for calibration.')
+
+    p50, p80, p97 = (float(np.percentile(v, p)) for p in percentiles)
+    vmin, vmax = float(v.min()), float(v.max())
+    xs = _make_strictly_increasing([vmin, p50, p80, p97, vmax])
+    # Reuse the confidence anchor levels: low variance -> high stability.
+    ys = [_ANCHOR_CONFIDENCE['min'], _ANCHOR_CONFIDENCE['p50'],
+          _ANCHOR_CONFIDENCE['p80'], _ANCHOR_CONFIDENCE['p97'],
+          _ANCHOR_CONFIDENCE['max']]
+
+    return {
+        'num_samples': int(num_samples),
+        'strength': float(strength),
+        'alpha': float(alpha),
+        'n_frames': int(v.size),
+        'percentiles': {'p50': p50, 'p80': p80, 'p97': p97},
+        'variance_stats': {'min': vmin, 'max': vmax,
+                           'mean': float(v.mean()), 'std': float(v.std())},
+        'stability_anchors': {'variance': xs, 'stability': ys},
+        'note': ('Robustness of the prediction to photometric input '
+                 'perturbation. Relative per-model signal, not a probability.'),
+    }
+
+
+def _build_ood_block(ood_features, encoder_name, input_size, alpha,
+                     encoder_file, percentiles=DEFAULT_PERCENTILES,
+                     anchor_distances=None):
+    """
+    Build the live-novelty calibration block from GENERIC-ENCODER features
+    (see donkeycar.parts.ood for why this replaces the task-collapsed
+    steering-model features). Reuses the same diagonal-Gaussian /
+    percentile-anchor machinery as the legacy novelty block, plus the encoder
+    metadata the drive-time detector needs to rebuild/validate the matching
+    extractor.
+
+    :param anchor_distances: see ``_build_novelty_block``.
+    """
+    block = _build_novelty_block(
+        np.asarray(ood_features, dtype=np.float64), percentiles,
+        anchor_distances=anchor_distances)
+    block.update({
+        'encoder': encoder_name,
+        'input_size': int(input_size),
+        'alpha': float(alpha),
+        'feat_dim': int(np.asarray(ood_features).shape[1]),
+        'encoder_file': encoder_file,
+    })
+    return block
+
+
+def _build_ood_spatial_block(features, encoder_name, input_hw, alpha,
+                             percentiles=DEFAULT_PERCENTILES):
+    """
+    Build the OFFLINE spatial-novelty block from per-location generic-encoder
+    features. Same diagonal-Gaussian / percentile-anchor machinery as the
+    live block, plus the encoder geometry the analysis tool needs to rebuild
+    a matching extractor.
+    """
+    block = _build_novelty_block(
+        np.asarray(features, dtype=np.float64), percentiles)
+    block.update({
+        'encoder': encoder_name,
+        'input_hw': [int(input_hw[0]), int(input_hw[1])],
+        'alpha': float(alpha),
+        'feat_dim': int(np.asarray(features).shape[1]),
+        'note': ('Per-location distances in the SAME generic-encoder feature '
+                 'space as novelty_ood, measured on the RAW (untransformed) '
+                 'frame.'),
+    })
+    return block
+
+
+def _build_novelty_block(feature_matrix, percentiles=DEFAULT_PERCENTILES,
+                         anchor_distances=None):
+    """
+    Fit a diagonal Gaussian to `feature_matrix` (n_samples, d) and build a
+    percentile-anchored distance -> novelty-score map, mirroring the
+    confidence calibration's structure but ascending (low distance -> low
+    score, high distance -> high score).
+
+    :param anchor_distances: optional pre-computed distances to fit the
+        percentile anchors (and the reported distance_stats) on, INSTEAD of
+        the raw per-vector distances of `feature_matrix` -- mean/var/
+        active_dims/eps are still always fit from `feature_matrix` itself.
+
+        Use this for the live ('novelty_ood') block: FeatureNoveltyDetector
+        never scores a frame's raw instantaneous distance, it scores the
+        EMA-smoothed, interval-throttled one (see its ``run()``). A smoothed
+        sequence has a narrower spread than the raw one it's smoothing from
+        -- measured on a real logged drive, raw distances had p97 ~= 5239 and
+        std ~= 987, vs smoothed p97 ~= 2919 and std ~= 452 (roughly half) --
+        so anchors fit on raw distances place real smoothed readings well
+        below the percentile they're meant to mark: on that same drive, 4% of
+        frames crossed the 65% "critical" novelty tier when scored against
+        raw-fitted anchors, but 0% did when scored the way the code actually
+        scores them (smoothed distance against those same anchors). Passing
+        the calibration replay's own smoothed-distance sequence here (see
+        ``calibrate_from_tub``) makes the anchors describe the quantity that
+        is actually looked up, so the percentiles mean what they say.
+
+        Left as None (the default) for the offline spatial map
+        ('novelty_ood_spatial'), which has no smoothing or interval concept
+        at all -- every grid location of every frame is scored on its own
+        instantaneous distance, so its anchors are correctly fit on raw ones.
+    """
+    from donkeycar.parts.novelty import fit_diagonal_gaussian, mahalanobis_diag
+
+    stats = fit_diagonal_gaussian(feature_matrix)
+    mean = np.array(stats['mean'])
+    var = np.array(stats['var'])
+    active = np.array(stats['active_dims'])
+    eps = stats['eps']
+
+    raw_distances = mahalanobis_diag(feature_matrix, mean, var, active, eps)
+    distances = (np.asarray(anchor_distances, dtype=np.float64)
+                if anchor_distances is not None else raw_distances)
+
+    p50, p80, p97 = (float(np.percentile(distances, p)) for p in percentiles)
+    dmin, dmax = float(distances.min()), float(distances.max())
+
+    xs = _make_strictly_increasing([dmin, p50, p80, p97, dmax])
+    ys = [_ANCHOR_NOVELTY['min'], _ANCHOR_NOVELTY['p50'],
+          _ANCHOR_NOVELTY['p80'], _ANCHOR_NOVELTY['p97'],
+          _ANCHOR_NOVELTY['max']]
+
+    return {
+        'mean': stats['mean'],
+        'var': stats['var'],
+        'active_dims': stats['active_dims'],
+        'eps': eps,
+        'distance_stats': {'min': dmin, 'max': dmax,
+                           'mean': float(distances.mean()),
+                           'std': float(distances.std())},
+        'score_anchors': {'distance': xs, 'score': ys},
+    }
+
+
+def _replay_ema(raw_values, timestamps, alpha, interval):
+    """
+    Reproduce, over an already-computed sequence of raw values, exactly the
+    "hold between updates, EMA-fold on update" logic that
+    MCDropoutConfidence/FeatureNoveltyDetector/TTAStabilityDetector apply
+    live in their own ``run()`` -- for novelty specifically, which (unlike
+    confidence/TTA) is never replayed through its live Part object during
+    calibration; its features are extracted in one batch instead (see
+    ``calibrate_from_tub``), so there is no ``run()`` call sequence to hook a
+    ``now=`` override into. This function is that logic, standalone.
+
+    :param raw_values:  ordered per-frame raw values (e.g. Mahalanobis
+                        distances), earliest first.
+    :param timestamps:  parallel real-world timestamps in seconds (same
+                        length as raw_values, from the tub's own recorded
+                        ``_timestamp_ms``), or None to update on every entry
+                        (as if interval were 0 regardless of the `interval`
+                        argument) -- used when a tub predates timestamp
+                        logging, since replaying at whatever speed this
+                        process happens to run at has no relationship to the
+                        tub's real recorded pace.
+    :param alpha:       EMA smoothing factor, same meaning as at drive time.
+    :param interval:    minimum seconds between updates; 0 updates every
+                        entry.
+    :return:            float64 array the same length as raw_values, holding
+                        the smoothed value in force at each entry's time --
+                        i.e. what a live detector's ``run()`` would have
+                        returned at that instant.
+    """
+    raw_values = np.asarray(raw_values, dtype=np.float64)
+    out = np.empty_like(raw_values)
+    smoothed = None
+    last_update_ts = None
+    for i, v in enumerate(raw_values):
+        ts = timestamps[i] if timestamps is not None else None
+        held = (interval > 0 and last_update_ts is not None and ts is not None
+               and (ts - last_update_ts) < interval)
+        if not held:
+            smoothed = v if smoothed is None else (
+                alpha * v + (1.0 - alpha) * smoothed)
+            last_update_ts = ts
+        out[i] = smoothed
+    return out
+
+
+def _record_timestamps_sec(records):
+    """
+    Each record's recorded wall-clock timestamp in seconds (from
+    ``_timestamp_ms``), for replaying MC-Dropout/TTA/novelty updates at the
+    SAME real-time cadence the tub was actually driven at -- rather than at
+    however fast this replay loop happens to run, which has no relationship
+    to XAI_*_INTERVAL at all (a fast replay would hold almost every frame; a
+    slow one would barely hold any).
+
+    :return: list of float seconds, same length/order as `records`, or None
+        if any record is missing the timestamp (older tub) -- callers should
+        fall back to interval=0 (update every frame, the historical default)
+        rather than silently mis-time updates against wall-clock instead.
+    """
+    ts_ms = [r.underlying.get('_timestamp_ms') for r in records]
+    if any(t is None for t in ts_ms):
+        return None
+    return [t / 1000.0 for t in ts_ms]
+
+
+def _make_strictly_increasing(xs, eps=1e-9):
+    """np.interp requires strictly increasing x; nudge any flat/duplicate x."""
+    out = list(xs)
+    for i in range(1, len(out)):
+        if out[i] <= out[i - 1]:
+            out[i] = out[i - 1] + eps
+    return out
+
+
+def variance_to_confidence(variance, calib):
+    """
+    Map a (smoothed) variance to a displayed confidence % in [min..max anchor],
+    using the calibration's anchor points. Monotonically decreasing.
+    """
+    anchors = calib['confidence_anchors']
+    xs = anchors['variance']
+    ys = anchors['confidence']
+    # np.interp needs increasing xs and clamps outside the range automatically.
+    # ys is decreasing, which np.interp handles fine.
+    return float(np.interp(variance, xs, ys))
+
+
+def novelty_distance_to_score(distance, novelty_calib_block):
+    """
+    Map a Mahalanobis distance to a displayed novelty % in [min..max anchor],
+    using a novelty calibration block (calib['novelty_ood'] or
+    calib['novelty_ood_spatial']). Monotonically increasing: low distance (looks
+    like training data) -> low novelty %, high distance -> high novelty %.
+    """
+    anchors = novelty_calib_block['score_anchors']
+    return float(np.interp(distance, anchors['distance'], anchors['score']))
+
+
+def tta_variance_to_stability(variance, tta_calib_block):
+    """
+    Map a (smoothed) TTA steering variance to a displayed stability % using the
+    tta block's anchors (calib['tta']). Same descending-interp machinery as
+    ``variance_to_confidence`` -- low variance (prediction is robust to input
+    perturbation) -> high stability %, high variance -> low stability %.
+    """
+    anchors = tta_calib_block['stability_anchors']
+    return float(np.interp(variance, anchors['variance'], anchors['stability']))
+
+
+def find_training_tubs(cfg, model_path):
+    """
+    Look up which tub(s) `model_path` was actually trained on, via
+    DonkeyCar's own ``PilotDatabase`` (``<MODELS_PATH>/database.json``,
+    written automatically by ``donkey train``). Returns a list of tub paths,
+    or None if no matching entry exists (the model wasn't trained via
+    ``donkey train``, or the database has since been moved/deleted/pruned).
+
+    This matters because calibration is supposed to establish "what does
+    normal (training) data look like" -- calibrating against some OTHER tub
+    (e.g. a post-training inference/test drive) undermines the whole point,
+    especially for novelty detection: a frame only ever looks "normal"
+    relative to whatever tub it happens to be compared against. If the
+    calibration tub isn't the training tub, "novelty" quietly becomes
+    "unlike this other drive" instead of "unlike what the model learned."
+    """
+    from donkeycar.pipeline.database import PilotDatabase
+    try:
+        db = PilotDatabase(cfg)
+    except Exception as e:
+        logger.debug(f'find_training_tubs: could not open PilotDatabase '
+                     f'({e})')
+        return None
+    name = os.path.splitext(os.path.basename(model_path))[0]
+    entry = db.get_entry(name)
+    if entry is None or not entry.get('Tubs'):
+        return None
+    return [t.strip() for t in entry['Tubs'].split(',') if t.strip()]
+
+
+def default_calib_path(model_path):
+    """Calibration file sits next to the model: <model>.calib.json"""
+    return os.path.splitext(model_path)[0] + '.calib.json'
+
+
+def default_encoder_path(model_path):
+    """OOD-encoder sidecar sits next to the model:
+    <model>.novelty_encoder.h5. Saved at calibration time so a Pi driving
+    offline never needs to download the encoder's ImageNet weights."""
+    return os.path.splitext(model_path)[0] + '.novelty_encoder.h5'
+
+
+def save_calibration(calib, path):
+    with open(path, 'w') as f:
+        json.dump(calib, f, indent=2)
+    logger.info(f'Saved calibration to {path}')
+
+
+def load_calibration(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+# Which top-level calibration block each live signal actually needs. A
+# calib.json can exist while still lacking the block for a given signal --
+# e.g. one written before that signal existed -- so callers must check for
+# the BLOCK, not merely for the file.
+_SIGNAL_BLOCKS = {
+    'confidence': 'confidence_anchors',
+    'novelty': 'novelty_ood',
+    'tta': 'tta',
+}
+
+
+def missing_calibration_reason(calib_path, signal):
+    """
+    Why ``signal`` can't display a % from ``calib_path``, or None if it can.
+
+    Returns a short human-readable reason string suitable for showing in the
+    dashboard's "not calibrated" banner. Distinguishes the two cases that
+    look identical to a user but need different fixes:
+      * the calibration file doesn't exist at all, versus
+      * the file exists but predates (or was built without) this signal.
+
+    :param calib_path: path to a ``<model>.calib.json``.
+    :param signal:     one of 'confidence', 'novelty', 'tta'.
+    :return:           reason string, or None when the block is present.
+    """
+    if not os.path.exists(calib_path):
+        return f"{os.path.basename(calib_path)} doesn't exist yet"
+    key = _SIGNAL_BLOCKS.get(signal)
+    if key is None:
+        return None
+    try:
+        calib = load_calibration(calib_path)
+    except Exception as e:
+        return f"{os.path.basename(calib_path)} could not be read ({e})"
+    if key not in calib:
+        return (f"{os.path.basename(calib_path)} has no '{key}' data "
+                f"(it was built by an older version of this toolkit)")
+    return None
+
+
+def transformation_drift(calib_path, cfg):
+    """
+    Warn text if cfg's TRANSFORMATIONS no longer match what was calibrated.
+
+    TRANSFORMATIONS apply at both training and inference, so they change what
+    the model sees -- and therefore what every calibrated threshold means.
+    Adding a CROP after calibrating silently invalidates the whole file, and
+    because mask-style transforms keep image dimensions unchanged, nothing
+    errors to announce it.
+
+    Returns None when they agree, when the calibration predates this field
+    (nothing to compare against), or when the file can't be read -- a
+    missing-calibration problem is reported separately by
+    ``missing_calibration_reason``.
+    """
+    if not os.path.exists(calib_path):
+        return None
+    try:
+        calib = load_calibration(calib_path)
+    except Exception:
+        return None
+    block = calib.get('transformations')
+    if block is None:
+        return None      # older calibration; nothing recorded to compare
+    was = (list(block.get('transformations') or []),
+           list(block.get('post_transformations') or []))
+    now = (list(getattr(cfg, 'TRANSFORMATIONS', None) or []),
+           list(getattr(cfg, 'POST_TRANSFORMATIONS', None) or []))
+    if was == now:
+        return None
+    return (f"image TRANSFORMATIONS changed since calibration "
+            f"(calibrated with {was[0] or 'none'}"
+            f"{' + ' + str(was[1]) if was[1] else ''}, now running "
+            f"{now[0] or 'none'}"
+            f"{' + ' + str(now[1]) if now[1] else ''}). The model now sees "
+            f"different pixels than these thresholds were measured on -- "
+            f"re-run mc_calibrate")
+
+
+def check_model_image_size(model_path, cfg, model=None):
+    """
+    Reconcile cfg's IMAGE_W/IMAGE_H with the shape the model actually wants.
+
+    Tub frames are resized per cfg, so a model trained at a different
+    resolution than the loaded config produces a raw Keras shape-mismatch
+    error deep in a forward pass -- unreadable, and easy to hit whenever the
+    bundled template defaults are used instead of the car's own config.py.
+    The model file is the authority on its own input shape, so prefer it and
+    say loudly what happened rather than failing cryptically later.
+
+    Mutates cfg in place when they disagree. Returns (h, w) actually used.
+
+    :param model: an already-loaded Keras model to read the shape from. Pass
+        it whenever the caller has one, so this doesn't deserialise the whole
+        .h5 a second time just to read a single input shape.
+    """
+    # Deferred like the rest of this module's TF use, to keep import light.
+    import tensorflow as tf
+    try:
+        if model is None:
+            model = tf.keras.models.load_model(model_path, compile=False)
+        shape = model.inputs[0].shape
+        want_h, want_w = int(shape[1]), int(shape[2])
+    except Exception as e:
+        # Genuinely couldn't read a shape (odd architecture, unreadable file).
+        # Warn rather than hide it -- silently proceeding with a possibly-wrong
+        # size is what produced the unreadable downstream error in the first
+        # place.
+        logger.warning(f'Could not read input shape from {model_path} ({e}); '
+                       f'leaving IMAGE_W/IMAGE_H as configured.')
+        return (getattr(cfg, 'IMAGE_H', None), getattr(cfg, 'IMAGE_W', None))
+
+    cfg_h = getattr(cfg, 'IMAGE_H', None)
+    cfg_w = getattr(cfg, 'IMAGE_W', None)
+    if (cfg_h, cfg_w) != (want_h, want_w):
+        logger.warning(
+            f'Image size mismatch: {os.path.basename(model_path)} expects '
+            f'{want_w}x{want_h} (WxH) but the loaded config says '
+            f'{cfg_w}x{cfg_h}. Using the model\'s {want_w}x{want_h}. If that '
+            f'is wrong, point --config at the config.py this model was '
+            f'trained with.')
+        cfg.IMAGE_H = want_h
+        cfg.IMAGE_W = want_w
+    return (want_h, want_w)
+
+
+def calibrate_from_tub(cfg, tub_paths, model_path, num_passes=None,
+                       alpha=None, limit=None, percentiles=DEFAULT_PERCENTILES,
+                       out_path=None, progress_callback=None, augment=None):
+    """
+    Replay a tub through the MC-Dropout part, collect smoothed variances plus
+    (for novelty detection) per-frame dense_2/conv2d_5 feature vectors, build
+    and save a calibration file. Returns (calib_dict, out_path).
+
+    :param progress_callback: optional ``callback(stage, current, total)``,
+                              called during the per-frame replay
+                              (stage='calibrate') and around the OOD encoder's
+                              batched extraction step (stage='calibrate_ood').
+                              Used by the GUI launcher's auto-calibrate step to
+                              show progress; harmless to omit for CLI use.
+    :param augment:           whether to widen the *novelty* baselines with
+                              training-style augmented frames (see below).
+                              ``None`` (default) reads
+                              ``XAI_CALIBRATE_WITH_AUGMENTATIONS`` from cfg.
+
+    AUGMENTATION-AWARE NOVELTY BASELINES
+    ------------------------------------
+    Novelty is a distance-from-training-distribution measure, so its baseline
+    has to describe the inputs the model was actually *trained* on. Training
+    applies ``cfg.AUGMENTATIONS`` (brightness / blur)
+    only inside ``BatchSequence.image_processor`` when ``is_train=True``, so a
+    baseline fit on raw tub frames alone describes a *narrower* input
+    distribution than the model was trained for. A perfectly ordinary
+    brighter or blurrier frame then scores as highly novel at runtime and -- with
+    ``XAI_THROTTLE_SCALING_ENABLED`` -- needlessly throttles the car down in
+    exactly the conditions augmentation was added to survive.
+
+    Unlike the confidence/TTA percentiles (which are re-collected through the
+    retrained model every time and so rescale themselves), the novelty
+    baseline cannot self-correct: the live signal measures distance in a
+    *frozen* ImageNet encoder's feature space (see ``donkeycar.parts.ood``),
+    which never sees a training epoch. So it is fixed here instead.
+
+    When ``cfg.AUGMENTATIONS`` is non-empty, a strided subset of frames is
+    additionally passed through the same ``ImageAugmentation`` pipeline used
+    in training, ``XAI_CALIBRATE_AUG_PASSES`` times each (re-randomised per
+    pass, since each ``run()`` samples fresh parameters), and those feature
+    vectors are pooled with the clean ones before fitting. The resulting
+    Gaussian covers the training-time input envelope rather than just its
+    clean centre.
+
+    Deliberately scoped to the novelty statistics only:
+
+      * The MC-Dropout variance and TTA replays are left untouched. Both parts
+        carry an EMA over a *time-ordered* frame sequence; splicing augmented
+        frames into that stream would corrupt the smoothing. Their outputs are
+        therefore bit-for-bit identical to before this option existed.
+      * With no ``AUGMENTATIONS`` configured the augmenter is skipped
+        entirely, so calibrations for un-augmented models are also unchanged.
+
+    REPLAY CADENCE MATCHES XAI_*_INTERVAL
+    --------------------------------------
+    Confidence/novelty/TTA each rate-limit their live updates via their own
+    ``XAI_*_INTERVAL`` (0.3-0.5s by default) -- between updates, driving holds
+    the last value rather than recomputing it every frame. This replay now
+    reproduces that: confidence and TTA are driven through their live Part
+    objects with ``now=`` set from each frame's recorded ``_timestamp_ms``
+    (not wall-clock time, which has no relationship to how fast this replay
+    loop happens to run), so ``MCDropoutConfidence``/``TTAStabilityDetector``
+    hold between updates exactly as they would while driving. Novelty doesn't
+    go through its live Part during calibration at all (its features are
+    batch-extracted, see above), so the same hold-and-EMA-fold logic is
+    reproduced directly over its already-computed distances instead (see
+    ``_replay_ema``). Older tubs with no ``_timestamp_ms`` fall back to
+    measuring every frame (interval=0), the previous behaviour, since
+    replaying at whatever speed this process happens to run at would time
+    updates against nothing meaningful.
+    """
+    # Imported here so this module is cheap to import without TF.
+    from donkeycar.parts.keras import KerasLinear
+    from donkeycar.parts.mc_dropout import MCDropoutConfidence
+    from donkeycar.pipeline.types import TubDataset
+    from donkeycar.utils import normalize_image
+    import tensorflow as tf
+
+    num_passes = num_passes if num_passes is not None \
+        else getattr(cfg, 'XAI_CONFIDENCE_PASSES', 15)
+    alpha = alpha if alpha is not None \
+        else getattr(cfg, 'XAI_CONFIDENCE_ALPHA', 0.2)
+
+    logger.info(f'Loading model {model_path}')
+    pilot = KerasLinear()
+    pilot.load(model_path)
+
+    # Reconcile config image size with the model's own input shape BEFORE any
+    # frames are read, since records are resized per cfg. Reads the shape off
+    # the pilot just loaded rather than deserialising the .h5 again.
+    check_model_image_size(model_path, cfg, model=pilot.interpreter.model)
+
+    part = MCDropoutConfidence(pilot, num_passes=num_passes, alpha=alpha)
+
+    # TTA (test-time augmentation) stability calibration is built
+    # UNCONDITIONALLY, regardless of XAI_TTA_ENABLED. That config flag governs
+    # whether the signal runs live during driving; it is not a statement about
+    # what this calibration file should contain. Building the block always
+    # means a user can flip XAI_TTA_ENABLED on later and have it work
+    # immediately, instead of discovering a silently-missing block mid-drive
+    # and having to re-run this whole replay.
+    # always_measure=True is REQUIRED here: this part has no calibration yet
+    # (that's what we're building), and without the flag its run() would skip
+    # the M-pass batch and hand back 0.0 for every frame.
+    from donkeycar.parts.tta import TTAStabilityDetector
+    tta_samples = getattr(cfg, 'XAI_TTA_SAMPLES', 8)
+    tta_strength = getattr(cfg, 'XAI_TTA_STRENGTH', 0.2)
+    tta_alpha = getattr(cfg, 'XAI_TTA_ALPHA', 0.2)
+    tta_part = TTAStabilityDetector(
+        pilot, num_samples=tta_samples, alpha=tta_alpha,
+        strength=tta_strength, seed=0, always_measure=True)
+    logger.info(f'Also collecting TTA stability stats '
+                f'(M={tta_samples}, strength={tta_strength}).')
+
+    # NOTE: earlier versions also built a dense_2/conv2d_5 sub-model here to
+    # fit 'novelty_global' and 'novelty_spatial'. Both are gone: novelty is
+    # measured in a generic ImageNet encoder now (see donkeycar.parts.ood),
+    # nothing read novelty_global at all, and the spatial map has moved to
+    # that same encoder space. Dropping them removes a forward pass per frame.
+
+    tub_paths = [os.path.expanduser(p) for p in tub_paths]
+    dataset = TubDataset(config=cfg, tub_paths=tub_paths)
+    records = dataset.get_records()
+    if limit:
+        records = records[:limit]
+    logger.info(f'Replaying {len(records)} frames to collect variance '
+                f'distribution (N={num_passes}, alpha={alpha})...')
+
+    # Replay at the SAME update cadence XAI_*_INTERVAL gives live driving,
+    # not "every single frame" -- calibration previously always measured
+    # every frame regardless of the configured interval, so its smoothed
+    # values were folded far more often (over a correspondingly shorter
+    # real-time window per fold) than a live drive with the default non-zero
+    # intervals ever produces, which the calibrated anchors then implicitly
+    # assumed. Driven off the tub's OWN recorded timestamps, not wall-clock
+    # time, since this replay loop's own speed has no relationship to how
+    # fast the frames were actually driven.
+    timestamps = _record_timestamps_sec(records)
+    if timestamps is None:
+        logger.warning('Tub records have no _timestamp_ms (older tub); '
+                       'cannot replay at the configured XAI_*_INTERVAL '
+                       'cadence, so calibration will measure every frame '
+                       '(interval=0) regardless of what driving uses.')
+        conf_interval = novelty_interval = tta_interval = 0.0
+    else:
+        conf_interval = getattr(cfg, 'XAI_CONFIDENCE_INTERVAL', 0.0)
+        novelty_interval = getattr(cfg, 'XAI_NOVELTY_INTERVAL', 0.0)
+        tta_interval = getattr(cfg, 'XAI_TTA_INTERVAL', 0.0)
+    part.interval = float(conf_interval)
+    tta_part.interval = float(tta_interval)
+
+    # Generic-encoder novelty (OOD) features -- the fix for the steering
+    # model's feature space being task-collapsed (see donkeycar.parts.ood).
+    # Collected on a strided subset to bound cost and batched after the loop.
+    # A failure here (e.g. no internet to fetch encoder weights) degrades
+    # gracefully: the calib simply omits the 'novelty_ood' block and live
+    # novelty reports "unavailable" rather than breaking calibration.
+    ood_name = getattr(cfg, 'XAI_NOVELTY_ENCODER', 'mobilenet_v2')
+    ood_input = getattr(cfg, 'XAI_NOVELTY_ENCODER_INPUT', None)
+    ood_alpha = getattr(cfg, 'XAI_NOVELTY_ENCODER_ALPHA', 1.0)
+    ood_extractor = None
+    try:
+        from donkeycar.parts.ood import CPUEncoderExtractor
+        ood_extractor = CPUEncoderExtractor(ood_name, ood_input, ood_alpha)
+    except Exception as e:
+        logger.warning(f'Could not build OOD encoder ({e}); novelty_ood block '
+                       f'will be skipped -- live novelty will be unavailable.')
+    ood_stride = max(1, len(records) // 3000) if ood_extractor else 1
+    ood_imgs = []
+    # Parallel to ood_imgs (same stride, same order) -- feeds the smoothed
+    # novelty anchor calculation below.
+    ood_timestamps = []
+
+    # Augmentation-aware novelty baseline (see the docstring). Self-gating:
+    # an empty AUGMENTATIONS list means no augmenter and no behaviour change.
+    aug_list = getattr(cfg, 'AUGMENTATIONS', None) or []
+    if augment is None:
+        augment = getattr(cfg, 'XAI_CALIBRATE_WITH_AUGMENTATIONS', True)
+    aug_passes = int(getattr(cfg, 'XAI_CALIBRATE_AUG_PASSES', 2))
+    augmenter = None
+    if augment and aug_list and aug_passes > 0:
+        try:
+            from donkeycar.pipeline.augmentations import ImageAugmentation
+            augmenter = ImageAugmentation(cfg, 'AUGMENTATIONS')
+        except Exception as e:
+            logger.warning(f'Could not build the training augmentation '
+                           f'pipeline ({e}); novelty baselines will be fit on '
+                           f'clean frames only, which can read as falsely '
+                           f'novel under the conditions it covers.')
+    # Strided so the extra samples stay bounded regardless of tub size: a
+    # diagonal Gaussian only needs enough samples per dimension, not one per
+    # frame. Clean frames still outnumber augmented ones, which matches
+    # training (augmentations apply with probability p, not always).
+    aug_max_samples = int(getattr(cfg, 'XAI_CALIBRATE_AUG_MAX_SAMPLES', 1500))
+    aug_stride = 1
+    if augmenter is not None:
+        aug_stride = max(1, (len(records) * aug_passes) //
+                         max(1, aug_max_samples))
+        logger.info(f'Novelty baselines will also include augmented frames '
+                    f'({aug_list}, {aug_passes} pass(es), every '
+                    f'{aug_stride} frame(s)) so the conditions the model '
+                    f'was trained for do not read as novel.')
+    # TRANSFORMATIONS (crop, trapeze, colour-space, high-pass, ...) apply at
+    # BOTH training and inference, so the model only ever sees transformed
+    # pixels. Replaying raw tub frames here would fit every baseline to a
+    # distribution the model never actually encounters -- and because
+    # mask-style transforms (CROP/TRAPEZE) preserve image dimensions, that
+    # mismatch produces no error at all, just silently wrong thresholds.
+    # Order below mirrors BatchSequence.image_processor in pipeline/training.py
+    # exactly: transform -> augment -> post_transform.
+    from donkeycar.parts.image_transformations import ImageTransformations
+    transformation = ImageTransformations(cfg, 'TRANSFORMATIONS')
+    post_transformation = ImageTransformations(cfg, 'POST_TRANSFORMATIONS')
+    tfm_list = list(getattr(cfg, 'TRANSFORMATIONS', None) or [])
+    post_tfm_list = list(getattr(cfg, 'POST_TRANSFORMATIONS', None) or [])
+    if tfm_list or post_tfm_list:
+        logger.info(f'Applying inference transformations to the replay so the '
+                    f'baselines match what the model actually sees: '
+                    f'{tfm_list} then {post_tfm_list}.')
+
+    def to_model_input(img, apply_augmentation=False):
+        """Raw tub frame -> exactly what the model is fed, matching training."""
+        x = transformation.run(img)
+        if apply_augmentation and augmenter is not None:
+            x = augmenter.run(x)
+        return post_transformation.run(x)
+
+    aug_ood_imgs = []
+    n_aug_samples = 0
+
+    smoothed = []
+    tta_variances = []
+    for i, record in enumerate(records):
+        img_raw = record.image()   # uint8, as recorded (pre-transformation)
+        img = to_model_input(img_raw)   # what the model is actually fed
+        # This frame's own recorded time, so part.run()'s interval-throttling
+        # is driven by the tub's real pace rather than wall-clock replay speed
+        # (None when the tub predates timestamp logging -- see conf_interval
+        # above, already forced to 0 in that case, so `now` is moot there).
+        now = timestamps[i] if timestamps is not None else None
+        # part.run -> (angle, throttle, confidence, raw_var, smoothed_var)
+        smooth_var = part.run(img, now=now)[4]
+        smoothed.append(smooth_var)
+
+        # The OOD encoder deliberately gets the RAW frame, not the transformed
+        # one. Novelty asks "is this scene familiar?", which is a question
+        # about the world rather than about the model -- and transformations
+        # like CROP or a high-pass filter destroy exactly the colour/texture
+        # content the ImageNet encoder relies on to answer it. Must stay in
+        # step with the live detector's input in templates/complete.py.
+        if ood_extractor is not None and i % ood_stride == 0:
+            ood_imgs.append(img_raw)
+            ood_timestamps.append(now)
+
+        # Extra novelty samples only -- deliberately NOT fed to part.run /
+        # tta_part.run, whose EMAs assume a contiguous time-ordered stream.
+        if augmenter is not None and i % aug_stride == 0:
+            for _ in range(aug_passes):
+                # The OOD encoder gets the augmented RAW frame, matching its
+                # live input (novelty never sees transformed pixels).
+                if ood_extractor is not None:
+                    aug_ood_imgs.append(augmenter.run(img_raw))
+                n_aug_samples += 1
+
+        if tta_part is not None:
+            # tta_part.run -> (stability, raw_var, smoothed_var)
+            tta_variances.append(tta_part.run(img, now=now)[2])
+
+        if (i + 1) % 200 == 0:
+            logger.info(f'  {i + 1}/{len(records)} frames')
+        if progress_callback:
+            progress_callback('calibrate', i + 1, len(records))
+
+    tta_kwargs = dict(
+        tta_variances=tta_variances,
+        tta_num_samples=tta_samples,
+        tta_strength=tta_strength,
+        tta_alpha=tta_alpha)
+
+    ood_kwargs = {}
+    if ood_extractor is not None and ood_imgs:
+        if progress_callback:
+            progress_callback('calibrate_ood', 0, 1)
+        try:
+            all_ood_imgs = ood_imgs + aug_ood_imgs
+            logger.info(f'Extracting OOD encoder features from '
+                        f'{len(all_ood_imgs)} frames '
+                        f'({len(ood_imgs)} clean, stride {ood_stride}; '
+                        f'{len(aug_ood_imgs)} augmented)...')
+            # Chunked: the extractor stacks and preprocesses the whole list
+            # into one float32 batch, which at encoder resolution is far
+            # larger than the uint8 frames. The returned vectors are small,
+            # so chunking bounds peak memory without changing the result.
+            ood_features = np.concatenate(
+                [ood_extractor.extract_batch(all_ood_imgs[c:c + _OOD_CHUNK])
+                 for c in range(0, len(all_ood_imgs), _OOD_CHUNK)], axis=0)
+            encoder_path = default_encoder_path(model_path)
+            ood_extractor.model.save(encoder_path)
+
+            # Percentile-anchor the live ('novelty_ood') block on the
+            # EMA-smoothed, interval-throttled CLEAN distance sequence --
+            # what FeatureNoveltyDetector actually scores live -- not the raw
+            # per-frame distance of the whole (clean + augmented) pool. See
+            # _build_novelty_block's docstring for the measured effect of
+            # getting this wrong. fit_diagonal_gaussian is deterministic, so
+            # calling it here on the same ood_features _build_novelty_block
+            # will fit again downstream reproduces identical mean/var/
+            # active_dims/eps both times -- this is purely to get the clean
+            # subset's raw distances to fold in temporal order, no extra
+            # encoder forward pass, just numpy over vectors already in memory.
+            from donkeycar.parts.novelty import (fit_diagonal_gaussian,
+                                                  mahalanobis_diag)
+            n_clean = len(ood_imgs)
+            _stats = fit_diagonal_gaussian(ood_features)
+            _mean = np.array(_stats['mean'])
+            _var = np.array(_stats['var'])
+            _active = np.array(_stats['active_dims'])
+            _eps = _stats['eps']
+            clean_raw_distances = mahalanobis_diag(
+                ood_features[:n_clean], _mean, _var, _active, _eps)
+            novelty_alpha = getattr(cfg, 'XAI_NOVELTY_ALPHA', 0.2)
+            ood_anchor_distances = _replay_ema(
+                clean_raw_distances, ood_timestamps, novelty_alpha,
+                novelty_interval)
+
+            ood_kwargs = dict(
+                ood_features=ood_features, ood_encoder=ood_extractor.name,
+                ood_input_size=ood_extractor.input_size, ood_alpha=ood_alpha,
+                ood_encoder_file=os.path.basename(encoder_path),
+                ood_anchor_distances=ood_anchor_distances)
+            logger.info(f'Saved OOD encoder sidecar -> {encoder_path}')
+        except Exception as e:
+            logger.warning(f'OOD feature/block build failed ({e}); skipping '
+                           f'novelty_ood block.')
+
+        # Offline spatial-novelty baseline, in the SAME encoder space but
+        # keeping the per-location grid. Only the offline heat map uses this,
+        # so it can afford a bigger, aspect-preserving input than the live
+        # 128x128 square. Sampled from the clean frames already collected --
+        # no extra images held in memory.
+        try:
+            from donkeycar.parts.ood import (SpatialEncoderExtractor,
+                                             spatial_input_hw)
+            fh, fw = ood_imgs[0].shape[:2]
+            short_side = int(getattr(cfg, 'XAI_NOVELTY_SPATIAL_INPUT', 224))
+            input_hw = spatial_input_hw(fh, fw, short_side)
+            sp = SpatialEncoderExtractor(
+                getattr(cfg, 'XAI_NOVELTY_ENCODER', 'mobilenet_v2'),
+                input_hw=input_hw, alpha=ood_alpha)
+            # Cap the number of frames so this stays bounded on long tubs;
+            # every grid location of each frame becomes a training sample, so
+            # a few hundred frames already gives tens of thousands of vectors.
+            max_frames = int(getattr(cfg, 'XAI_NOVELTY_SPATIAL_MAX_FRAMES',
+                                     400))
+            step = max(1, len(ood_imgs) // max_frames)
+            sp_imgs = ood_imgs[::step][:max_frames]
+            logger.info(f'Extracting spatial OOD features from '
+                        f'{len(sp_imgs)} frames at {input_hw[0]}x'
+                        f'{input_hw[1]} (grid {sp.grid_hw})...')
+            grids = np.concatenate(
+                [sp.extract_grid_batch(sp_imgs[c:c + _OOD_CHUNK])
+                 for c in range(0, len(sp_imgs), _OOD_CHUNK)], axis=0)
+            vectors = grids.reshape(-1, grids.shape[-1])
+            # Cap the sample count before fitting. Every location of every
+            # frame is a vector, so this reaches tens of thousands quickly,
+            # and the distance computation materialises several
+            # (n_samples x feat_dim) float64 intermediates -- enough to
+            # exhaust memory on a laptop already holding TensorFlow. A
+            # diagonal Gaussian estimates each dimension independently, so a
+            # few thousand samples is statistically ample.
+            cap = int(getattr(cfg, 'XAI_NOVELTY_SPATIAL_MAX_VECTORS', 4000))
+            if len(vectors) > cap:
+                pick = np.random.default_rng(0).choice(
+                    len(vectors), size=cap, replace=False)
+                vectors = vectors[pick]
+            logger.info(f'Fitting spatial novelty baseline on {len(vectors)} '
+                        f'per-location vectors ({sp.feat_dim}-dim).')
+            ood_kwargs['ood_spatial_features'] = vectors
+            ood_kwargs['ood_spatial_input_hw'] = input_hw
+            # The encoder identity/width is shared by both novelty blocks, but
+            # it is only set above when the POOLED step succeeded. Fill it in
+            # here too, or a run where that step failed would write a spatial
+            # block with encoder=null and alpha=1.0 -- and the offline map
+            # would silently rebuild a differently-shaped encoder than the
+            # statistics were fitted with.
+            ood_kwargs.setdefault('ood_encoder', ood_extractor.name)
+            ood_kwargs.setdefault('ood_alpha', ood_alpha)
+        except Exception as e:
+            logger.warning(f'Spatial OOD block build failed ({e}); the '
+                           f'offline novelty heat map will be unavailable.')
+
+        if progress_callback:
+            progress_callback('calibrate_ood', 1, 1)
+
+    augmentation_info = {
+        'applied': augmenter is not None,
+        'augmentations': list(aug_list) if augmenter is not None else [],
+        'passes': aug_passes if augmenter is not None else 0,
+        'stride': aug_stride if augmenter is not None else None,
+        'n_augmented_samples': n_aug_samples,
+        'n_clean_samples': len(records),
+        'scope': 'novelty baselines only (confidence/TTA use clean frames)',
+    }
+    # Provenance so drive time can detect a config that has drifted since
+    # calibration -- e.g. a CROP added afterwards, which silently invalidates
+    # every threshold in here without changing image dimensions.
+    transformation_info = {
+        'transformations': tfm_list,
+        'post_transformations': post_tfm_list,
+        'applied_to': 'confidence, TTA and model-feature baselines',
+        'novelty_input': 'raw (untransformed) camera frame',
+    }
+    calib = build_calibration(smoothed, num_passes, alpha,
+                              percentiles=percentiles, model_path=model_path,
+                              augmentation_info=augmentation_info,
+                              transformation_info=transformation_info,
+                              **tta_kwargs, **ood_kwargs)
+    out_path = out_path or default_calib_path(model_path)
+    save_calibration(calib, out_path)
+    dataset.close()
+    return calib, out_path
+
+
+def _summary(calib):
+    p = calib['percentiles']
+    s = calib['variance_stats']
+    lines = [
+        f"  frames analysed : {calib['n_frames']}",
+        f"  N passes / alpha: {calib['num_passes']} / {calib['alpha']}",
+        f"  variance min/max: {s['min']:.6f} / {s['max']:.6f}",
+        f"  variance mean   : {s['mean']:.6f}",
+        f"  p50 / p80 / p97 : {p['p50']:.6f} / {p['p80']:.6f} / {p['p97']:.6f}",
+        "  tiers           : normal < p80, reduced < p97, critical >= p97",
+        "  example mapping :",
+    ]
+    for label, v in (('median (p50)', p['p50']), ('p80', p['p80']),
+                     ('p97', p['p97'])):
+        lines.append(f"      variance {v:.6f} -> "
+                     f"{variance_to_confidence(v, calib):5.1f}% confidence")
+
+    aug = calib.get('augmentation')
+    if aug:
+        if aug.get('applied'):
+            lines.append(f"  novelty baseline: clean + augmented "
+                         f"({aug['n_augmented_samples']} augmented samples "
+                         f"from {aug['augmentations']}, "
+                         f"{aug['passes']} pass(es))")
+        else:
+            lines.append("  novelty baseline: clean frames only "
+                         "(no AUGMENTATIONS configured)")
+
+    ood = calib.get('novelty_ood')
+    if ood:
+        n_active = int(np.sum(ood['active_dims']))
+        ds = ood['distance_stats']
+        lines.append(f"  novelty (LIVE) : {ood['encoder']} encoder "
+                     f"({ood['feat_dim']}-dim, input {ood['input_size']})")
+        lines.append(f"      active dims     : {n_active}/{len(ood['active_dims'])}")
+        lines.append(f"      distance min/max: {ds['min']:.1f} / {ds['max']:.1f}")
+
+    sp = calib.get('novelty_ood_spatial')
+    if sp:
+        n_active = int(np.sum(sp['active_dims']))
+        n_total = len(sp['active_dims'])
+        ds = sp['distance_stats']
+        hw = sp.get('input_hw', [])
+        lines.append(f"  novelty (OFFLINE map): same encoder, per-location "
+                     f"grid at {hw[0] if hw else '?'}x{hw[1] if hw else '?'}")
+        lines.append(f"      active dims     : {n_active}/{n_total}")
+        lines.append(f"      distance min/max: {ds['min']:.1f} / {ds['max']:.1f}")
+
+    tta = calib.get('tta')
+    if tta:
+        tp = tta['percentiles']
+        ts = tta['variance_stats']
+        lines.append(f"  TTA stability (M={tta['num_samples']}, "
+                     f"strength={tta['strength']}):")
+        lines.append(f"      variance min/max: {ts['min']:.6f} / {ts['max']:.6f}")
+        lines.append(f"      p50 / p80 / p97 : {tp['p50']:.6f} / "
+                     f"{tp['p80']:.6f} / {tp['p97']:.6f}")
+        for label, v in (('median (p50)', tp['p50']), ('p97', tp['p97'])):
+            lines.append(f"      variance {v:.6f} -> "
+                         f"{tta_variance_to_stability(v, tta):5.1f}% stability")
+    return "\n".join(lines)
+
+
+def main(args=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog='mc_calibrate',
+        description='Build an MC-Dropout confidence calibration from a tub.')
+    parser.add_argument('--tub', nargs='+', required=True,
+                        help='one or more tub paths to replay')
+    parser.add_argument('--model', required=True, help='path to the .h5 model')
+    parser.add_argument('--config', default=None,
+                        help='path to config.py (defaults to ./config.py, '
+                             'falling back to the bundled complete template)')
+    parser.add_argument('--limit', type=int, default=None,
+                        help='only use the first N frames')
+    parser.add_argument('--passes', type=int, default=None,
+                        help='override XAI_CONFIDENCE_PASSES')
+    parser.add_argument('--alpha', type=float, default=None,
+                        help='override XAI_CONFIDENCE_ALPHA')
+    parser.add_argument('--out', default=None,
+                        help='output calibration path '
+                             '(default <model>.calib.json)')
+    aug_group = parser.add_mutually_exclusive_group()
+    aug_group.add_argument('--augment', dest='augment', action='store_true',
+                           default=None,
+                           help='widen the novelty baselines with augmented '
+                                'frames (overrides '
+                                'XAI_CALIBRATE_WITH_AUGMENTATIONS)')
+    aug_group.add_argument('--no-augment', dest='augment',
+                           action='store_false',
+                           help='fit the novelty baselines on clean frames '
+                                'only, even if AUGMENTATIONS is configured')
+    parsed = parser.parse_args(args)
+
+    # Shared with the other analysis entry points: handles the ./config.py
+    # fallback to the bundled template AND reliably applies myconfig.py, which
+    # donkeycar.config.load_config's string-replace lookup silently misses for
+    # any base file not literally named "config.py".
+    from donkeycar.parts.image_transformations import load_config_and_myconfig
+    cfg = load_config_and_myconfig(parsed.config)
+
+    calib, out_path = calibrate_from_tub(
+        cfg, parsed.tub, parsed.model, num_passes=parsed.passes,
+        alpha=parsed.alpha, limit=parsed.limit, out_path=parsed.out,
+        augment=parsed.augment)
+
+    print('\nMC-Dropout calibration complete:')
+    print(_summary(calib))
+    print(f'\n  saved to: {out_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/donkeycar/parts/mc_dropout.py
+++ b/donkeycar/parts/mc_dropout.py
@@ -1,0 +1,347 @@
+"""
+MC-Dropout confidence estimation for DonkeyCar.
+
+This part wraps an already-loaded KerasLinear pilot and, on every drive-loop
+iteration, runs the model N times with dropout left *active* (Monte-Carlo
+Dropout). The spread of the N steering predictions is used as an uncertainty
+signal:
+
+  * ``mean_steering`` / ``mean_throttle`` -- the averaged prediction. This
+    becomes the command sent to the car (same behaviour as a normal single
+    pass, just averaged over the stochastic sub-networks).
+  * ``raw_variance``   -- variance of the N steering outputs for this frame.
+  * ``smoothed_variance`` -- exponential moving average of ``raw_variance``
+    over time, to damp frame-to-frame flicker.
+
+IMPORTANT (scope / caveats):
+  * This is a *relative*, per-model uncertainty signal, NOT a formally
+    calibrated Bayesian probability. Turning ``smoothed_variance`` into a
+    human-readable "confidence %" requires the separate calibration step
+    (percentile thresholds collected from a representative drive).
+  * Only the default linear architecture (``KerasLinear`` /
+    ``default_n_linear``) is supported in v1. That model contains Dropout
+    layers and *no* BatchNormalization, which is why calling it with
+    ``training=True`` cleanly re-enables dropout without side effects.
+  * MC-Dropout needs the full Keras interpreter. The TFLite / TensorRT
+    inference paths cannot keep dropout stochastic and are not supported.
+"""
+import logging
+import time
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.utils import normalize_image
+
+logger = logging.getLogger(__name__)
+
+
+class MCDropoutConfidence:
+    """
+    DonkeyCar Part. Drop-in replacement for a KerasLinear inference part that
+    additionally emits an uncertainty signal.
+
+    Run signature::
+
+        angle, throttle, confidence, raw_variance, smoothed_variance = \
+            part.run(img_arr)
+
+    ``confidence`` is a 0-100 %% derived from the calibration file, or None if
+    the model has no calibration yet.
+
+    :param pilot:       a loaded KerasPilot (KerasLinear). Its underlying Keras
+                        model is reused directly -- we do not reload weights.
+    :param num_passes:  number of stochastic forward passes (N). Wired to
+                        ``cfg.XAI_CONFIDENCE_PASSES``.
+    :param alpha:       EMA smoothing factor in [0, 1]. Higher = more
+                        responsive, lower = smoother. Wired to
+                        ``cfg.XAI_CONFIDENCE_ALPHA``.
+    :param calibration_path: path to a ``<model>.calib.json`` produced by
+                        ``donkeycar.parts.mc_calibrate``. Optional.
+    """
+
+    def __init__(self, pilot, num_passes=15, alpha=0.2, calibration_path=None,
+                 interval=0.0):
+        self.pilot = pilot
+        self.num_passes = int(num_passes)
+        self.alpha = float(alpha)
+        self.smoothed_variance = None  # lazily initialised on first frame
+
+        # Minimum seconds between stochastic (N-pass) uncertainty updates.
+        # 0 = update every frame. Between updates, a cheap single
+        # deterministic pass still produces a fresh steering command each
+        # loop iteration; only the uncertainty numbers are held.
+        # NOTE: the EMA alpha applies per *update*, so with a longer interval
+        # the variance is smoothed over fewer, more spaced-out samples.
+        self.interval = float(interval)
+        self.last_mc_time = None
+        self.raw_variance = 0.0
+
+        # Optional calibration: maps smoothed variance -> displayed confidence %.
+        # Without it, the part still emits variance but confidence is None.
+        self.calibration = None
+        if calibration_path:
+            try:
+                from donkeycar.parts.mc_calibrate import load_calibration
+                self.calibration = load_calibration(calibration_path)
+                logger.info(f'MCDropoutConfidence: loaded calibration from '
+                            f'{calibration_path}')
+            except Exception as e:
+                logger.warning(f'MCDropoutConfidence: could not load '
+                               f'calibration {calibration_path} ({e}); '
+                               f'confidence %% will be unavailable.')
+
+        # Reach the raw Keras model. The interpreter must be the plain Keras
+        # one -- TFLite/TensorRT interpreters have no callable Keras model and
+        # cannot keep dropout stochastic.
+        interpreter = getattr(pilot, 'interpreter', None)
+        self.model = getattr(interpreter, 'model', None)
+        if self.model is None or not callable(self.model):
+            raise ValueError(
+                'MCDropoutConfidence requires a Keras pilot with a callable '
+                'model (the default KerasInterpreter). TFLite/TensorRT '
+                'interpreters are not supported.')
+        self.input_keys = list(interpreter.input_keys)
+
+        # Sanity check: warn loudly if the model has no dropout, because then
+        # every "stochastic" pass is identical and the signal is meaningless.
+        n_dropout = sum(1 for layer in self.model.layers
+                        if 'dropout' in layer.__class__.__name__.lower())
+        if n_dropout == 0:
+            logger.warning(
+                'MCDropoutConfidence: the loaded model has NO dropout layers. '
+                'The uncertainty signal will be identically zero. Retrain '
+                'with a dropout-bearing architecture (e.g. the default '
+                'linear model).')
+        else:
+            logger.info(f'MCDropoutConfidence: found {n_dropout} dropout '
+                        f'layer(s); running N={self.num_passes} stochastic '
+                        f'passes per frame, EMA alpha={self.alpha}.')
+
+    def _stochastic_forward(self, img_arr, other_arr):
+        """
+        Run N forward passes with dropout active, batched into a single call.
+
+        We replicate the input N times along the batch axis and do ONE
+        ``model(..., training=True)`` call. Keras samples an independent
+        dropout mask per batch element, so the N rows of the output are N
+        genuine Monte-Carlo samples -- far cheaper than an N-iteration Python
+        loop (~5x faster for N=15 in local timing).
+
+        :return: (angle_samples, throttle_samples) as 1-D np arrays of len N.
+        """
+        norm_img = normalize_image(img_arr).astype(np.float32)
+        # Batch of N identical images: shape (N, H, W, C).
+        img_batch = np.repeat(norm_img[np.newaxis, ...], self.num_passes, axis=0)
+
+        values = [img_batch]
+        for arr in other_arr:
+            a = np.asarray(arr, dtype=np.float32)
+            values.append(np.repeat(a[np.newaxis, ...], self.num_passes, axis=0))
+
+        input_dict = {k: tf.convert_to_tensor(v)
+                      for k, v in zip(self.input_keys, values)}
+
+        outputs = self.model(input_dict, training=True)
+        # Linear model returns a list [angle (N,1), throttle (N,1)].
+        angle_samples = np.asarray(outputs[0]).reshape(-1)
+        throttle_samples = np.asarray(outputs[1]).reshape(-1)
+        return angle_samples, throttle_samples
+
+    def _confidence(self):
+        """Displayed confidence % from the smoothed variance, or None if the
+        model is uncalibrated."""
+        if self.calibration is None or self.smoothed_variance is None:
+            return None
+        from donkeycar.parts.mc_calibrate import variance_to_confidence
+        return variance_to_confidence(self.smoothed_variance, self.calibration)
+
+    def run(self, img_arr, *other_arr, now=None):
+        if img_arr is None:
+            # Nothing to predict on yet; emit a neutral default. Downstream
+            # code treats None gracefully.
+            return 0.0, 0.0, self._confidence(), 0.0, \
+                (self.smoothed_variance or 0.0)
+
+        # Rate limiting: between uncertainty updates, drive on a cheap single
+        # deterministic pass and hold the last uncertainty values.
+        # `now` lets a caller replaying a tub (mc_calibrate.calibrate_from_tub)
+        # drive this off the tub's own recorded timestamps instead of
+        # wall-clock time, so a replay reproduces the same update cadence
+        # XAI_CONFIDENCE_INTERVAL actually produces while driving, rather than
+        # sampling every frame regardless of how it's configured. None (the
+        # default, and every other caller) uses the real clock as before.
+        now = now if now is not None else time.time()
+        if (self.interval > 0 and self.last_mc_time is not None
+                and (now - self.last_mc_time) < self.interval):
+            angle, throttle = self.pilot.run(img_arr, *other_arr)
+            return (float(angle), float(throttle), self._confidence(),
+                    self.raw_variance, (self.smoothed_variance or 0.0))
+        self.last_mc_time = now
+
+        angle_samples, throttle_samples = \
+            self._stochastic_forward(img_arr, other_arr)
+
+        mean_steering = float(np.mean(angle_samples))
+        mean_throttle = float(np.mean(throttle_samples))
+        raw_variance = float(np.var(angle_samples))
+        self.raw_variance = raw_variance
+
+        # Exponential moving average of the variance.
+        if self.smoothed_variance is None:
+            self.smoothed_variance = raw_variance
+        else:
+            self.smoothed_variance = (
+                self.alpha * raw_variance
+                + (1.0 - self.alpha) * self.smoothed_variance)
+
+        return (mean_steering, mean_throttle, self._confidence(),
+                raw_variance, self.smoothed_variance)
+
+    def shutdown(self):
+        pass
+
+
+class ThrottleScaler:
+    """
+    Feature 2: scale the pilot throttle down as MC-Dropout confidence drops,
+    feature-space novelty rises, and/or TTA stability drops. The philosophy is
+    "hesitate, don't guess": this only ever reduces throttle magnitude and
+    NEVER touches steering.
+
+    Each signal has its own reduced/critical thresholds (confidence and TTA
+    stability are "high is good" signals, novelty a "high is bad" one -- see
+    ``donkeycar.parts.novelty`` / ``donkeycar.parts.tta`` for why the three are
+    complementary, not redundant). On any frame, each available signal is
+    converted to a scale in ``[min_scale, 1.0]`` independently, and the
+    **lower** (most conservative) is applied -- so a problem flagged by any one
+    signal alone is enough to ease off the throttle, matching the intent that
+    any failure mode (model disagreement, an unfamiliar scene, or fragility to
+    input noise) warrants caution. A signal that's unavailable (feature
+    disabled upstream, or model uncalibrated) is simply excluded from the
+    comparison -- enabling only one of the three still works, scaling on that
+    signal alone.
+
+    Per-signal tiers (mirrored across the three, thresholds configurable):
+      * confidence/TTA >= its reduced_threshold, or novelty <= its
+        reduced_threshold -> that signal contributes full scale (1.0).
+      * between its reduced/critical thresholds -> that signal's scale is
+        linearly interpolated between 1.0 and ``min_scale``.
+      * confidence/TTA < its critical_threshold, or novelty > its
+        critical_threshold -> that signal is "critical": contributes
+        ``min_scale``, and if *any* signal has been continuously critical for
+        ``stop_duration`` seconds, throttle is forced to zero (stop).
+
+    Passthrough (no change to throttle) when:
+      * throttle is None, or
+      * all of confidence, novelty and tta_stability are None.
+
+    Run signature::
+
+        scaled_throttle = part.run(throttle, confidence, novelty, tta_stability)
+
+    ``tta_stability`` is optional (defaults None) and, like confidence, is a
+    "high is good" signal. Any signal that is None (feature off / uncalibrated)
+    is excluded from the min-of-scales comparison rather than blocking it.
+
+    Intended to be added with ``run_condition='run_pilot'`` so it only affects
+    autopilot throttle, giving zero behaviour change to manual driving.
+    """
+
+    def __init__(self, confidence_reduced_threshold=65.0,
+                 confidence_critical_threshold=25.0,
+                 novelty_reduced_threshold=25.0,
+                 novelty_critical_threshold=65.0,
+                 tta_reduced_threshold=65.0,
+                 tta_critical_threshold=25.0,
+                 min_scale=0.4, stop_duration=1.0):
+        self.confidence_reduced_threshold = float(confidence_reduced_threshold)
+        self.confidence_critical_threshold = float(confidence_critical_threshold)
+        self.novelty_reduced_threshold = float(novelty_reduced_threshold)
+        self.novelty_critical_threshold = float(novelty_critical_threshold)
+        self.tta_reduced_threshold = float(tta_reduced_threshold)
+        self.tta_critical_threshold = float(tta_critical_threshold)
+        self.min_scale = float(min_scale)
+        self.stop_duration = float(stop_duration)
+        self.critical_since = None   # timestamp critical tier began, else None
+        self._warned_no_signal = False
+        logger.info(f'ThrottleScaler: confidence reduced<'
+                    f'{confidence_reduced_threshold}% critical<'
+                    f'{confidence_critical_threshold}%, novelty reduced>'
+                    f'{novelty_reduced_threshold}% critical>'
+                    f'{novelty_critical_threshold}%, TTA-stability reduced<'
+                    f'{tta_reduced_threshold}% critical<'
+                    f'{tta_critical_threshold}%, min_scale={min_scale}, '
+                    f'stop_after={stop_duration}s')
+
+    def _signal_scale(self, value, reduced_threshold, critical_threshold,
+                      ascending):
+        """
+        Convert one signal's raw value to (scale, is_critical). `ascending`
+        selects the "high is bad" (novelty) direction vs "high is good"
+        (confidence) direction. Returns (None, False) if value is None.
+        """
+        if value is None:
+            return None, False
+        if ascending:
+            if value <= reduced_threshold:
+                return 1.0, False
+            if value <= critical_threshold:
+                span = critical_threshold - reduced_threshold
+                frac = (value - reduced_threshold) / span if span > 0 else 0.0
+                return 1.0 - (1.0 - self.min_scale) * frac, False
+            return self.min_scale, True
+        else:
+            if value >= reduced_threshold:
+                return 1.0, False
+            if value >= critical_threshold:
+                span = reduced_threshold - critical_threshold
+                frac = (value - critical_threshold) / span if span > 0 else 0.0
+                return self.min_scale + (1.0 - self.min_scale) * frac, False
+            return self.min_scale, True
+
+    def run(self, throttle, confidence, novelty, tta_stability=None):
+        if throttle is None:
+            return throttle
+
+        conf_scale, conf_critical = self._signal_scale(
+            confidence, self.confidence_reduced_threshold,
+            self.confidence_critical_threshold, ascending=False)
+        nov_scale, nov_critical = self._signal_scale(
+            novelty, self.novelty_reduced_threshold,
+            self.novelty_critical_threshold, ascending=True)
+        # TTA stability is a "high is good" signal, same direction as confidence.
+        tta_scale, tta_critical = self._signal_scale(
+            tta_stability, self.tta_reduced_threshold,
+            self.tta_critical_threshold, ascending=False)
+
+        scales = [s for s in (conf_scale, nov_scale, tta_scale)
+                  if s is not None]
+        if not scales:
+            # No usable signal -> do not interfere with driving.
+            if not self._warned_no_signal:
+                logger.warning('ThrottleScaler: no signal available (is '
+                               'XAI_CONFIDENCE_ENABLED/XAI_NOVELTY_ENABLED/'
+                               'XAI_TTA_ENABLED on, and the model '
+                               'calibrated?); throttle passed through '
+                               'unchanged.')
+                self._warned_no_signal = True
+            self.critical_since = None
+            return throttle
+
+        scale = min(scales)
+        any_critical = conf_critical or nov_critical or tta_critical
+
+        if any_critical:
+            now = time.time()
+            if self.critical_since is None:
+                self.critical_since = now
+            if now - self.critical_since >= self.stop_duration:
+                return 0.0
+        else:
+            self.critical_since = None
+
+        return throttle * scale
+
+    def shutdown(self):
+        pass

--- a/donkeycar/parts/novelty.py
+++ b/donkeycar/parts/novelty.py
@@ -1,0 +1,318 @@
+"""
+Feature-space novelty (out-of-distribution) detection.
+
+MC-Dropout variance (``donkeycar.parts.mc_dropout``) measures whether the
+model's dropout sub-networks *agree* with each other -- an ambiguity signal.
+It does NOT measure whether the current input looks anything like the data
+the model was trained on: a scene the network has never seen can still get a
+confident, low-variance (wrong) answer if its sub-networks happen to agree.
+This module adds the complementary signal: how far the current frame is from
+the training distribution, via Mahalanobis distance in a feature space.
+
+WHICH feature space matters a lot. The live ``FeatureNoveltyDetector`` now
+measures distance in a GENERIC image encoder's features (see
+``donkeycar.parts.ood``), NOT the steering model's own ``dense_2`` layer. The
+steering model is trained only to predict an angle, so it discards the scene
+content (texture/colour/semantics) that distinguishes grass from track --
+measuring novelty there barely responded to genuinely different scenes. The
+generic encoder keeps that content, so the same Mahalanobis math actually
+separates scenes. This module still owns the distance math; the feature
+source moved to ``donkeycar.parts.ood``.
+
+Consumers:
+  * ``FeatureNoveltyDetector`` -- a live Part computing one scalar novelty
+    score per frame from generic-encoder features (one encoder forward pass;
+    no MC-Dropout stochasticity needed since this isn't measuring agreement).
+  * ``donkeycar.parts.gradcam_uncertainty`` -- reuses ``mahalanobis_diag``
+    directly on the steering model's ``conv2d_5`` features (pooled across
+    space) to render a spatial "where is this unfamiliar" heatmap for offline
+    analysis. NOTE: this offline spatial map still uses the steering model's
+    features and so inherits the task-collapse limitation above; it is a
+    lower-priority, coarse localisation aid, not the primary novelty signal.
+
+Caveats (read before trusting the numbers):
+  * **Diagonal covariance only.** Feature dimensions are treated as
+    independent (per-dimension mean/variance, not a full covariance
+    matrix). Cheap and numerically robust, but ignores correlations
+    between features -- a combination of individually-normal feature
+    values could still be jointly unusual and go undetected.
+  * **Position-independent spatial pooling.** The spatial (conv2d_5)
+    statistics pool every grid location across every calibration frame
+    into one distribution, discarding *where* in the image a feature
+    normally appears. This is simple and cheap, but can mask novelty in
+    channels that have legitimate positional structure (e.g. a channel
+    that reliably fires near the top of the frame for sky/horizon) --
+    pooling folds that within-frame positional swing into the channel's
+    "normal" variance, raising the bar for detecting genuine novelty
+    there. A per-location (or coarse-grid) statistics model would fix
+    this at the cost of real complexity; not done here.
+  * **Dead-dimension handling.** A near-constant (e.g. dead ReLU) feature
+    dimension has ~zero variance; naively dividing by it would let a
+    single dimension dominate the whole distance. Dimensions are flagged
+    "inactive" at calibration time (via a variance floor, relative to the
+    typical variance across all dimensions) and excluded from the sum
+    entirely, rather than papering over it with a global epsilon alone.
+  * **Complementary, not a replacement, for MC-Dropout confidence.** A
+    frame can be low-novelty (looks like training data) yet still
+    high-variance (the model is internally torn about what to do), or
+    the reverse (novel-looking, but the sub-networks still happen to
+    agree). Read both signals together, not as substitutes.
+  * **Model scope**: like the rest of this toolkit, only the default
+    linear architecture (``KerasLinear``) with a callable Keras
+    interpreter is supported -- not TFLite/TensorRT (their graphs cannot
+    be reached by name to build the feature sub-model), and not other
+    architectures (this module assumes layers named ``dense_2`` /
+    ``conv2d_5`` from the default linear model).
+"""
+import logging
+import os
+import time
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.utils import normalize_image
+
+logger = logging.getLogger(__name__)
+
+
+def mahalanobis_diag(vec, mean, var, active_dims=None, eps=1e-6):
+    """
+    Diagonal-covariance Mahalanobis distance: sum((x_i - mean_i)^2 / (var_i + eps))
+    over the active dimensions only.
+
+    :param vec:         (..., d) array -- a single feature vector or a batch/
+                        grid of them (any leading shape), last axis = features.
+    :param mean:        (d,) array, per-dimension mean of the reference
+                        (training) distribution.
+    :param var:         (d,) array, per-dimension variance of the reference
+                        distribution.
+    :param active_dims: optional (d,) boolean array. Dimensions where False
+                        are excluded from the sum entirely (see module
+                        docstring on dead-dimension handling). Defaults to
+                        all dimensions active.
+    :param eps:         small constant added to variance for numerical safety
+                        on the *active* dimensions (dead/near-zero-variance
+                        dimensions should be excluded via active_dims instead
+                        of relying on eps alone).
+    :return:            scalar distance, or (...,) array of distances if vec
+                        has leading batch/grid dimensions.
+    """
+    vec = np.asarray(vec, dtype=np.float64)
+    mean = np.asarray(mean, dtype=np.float64)
+    var = np.asarray(var, dtype=np.float64)
+    if active_dims is None:
+        active_dims = np.ones(mean.shape[0], dtype=bool)
+    else:
+        active_dims = np.asarray(active_dims, dtype=bool)
+
+    diff_sq = (vec - mean) ** 2
+    denom = var + eps
+    terms = diff_sq / denom
+    terms = terms * active_dims       # zero out inactive dimensions
+    return terms.sum(axis=-1)
+
+
+def fit_diagonal_gaussian(feature_matrix, min_var_frac=1e-3, abs_eps=1e-6):
+    """
+    Fit a diagonal Gaussian (per-dimension mean/variance) to a matrix of
+    feature vectors, and flag dimensions too close to constant to trust.
+
+    :param feature_matrix: (n_samples, d) array.
+    :param min_var_frac:   a dimension is flagged "inactive" if its variance
+                           is below `median(var) * min_var_frac` -- a floor
+                           *relative* to this feature space's own typical
+                           variance (an absolute constant would be the wrong
+                           scale for different layers/models; see module
+                           docstring).
+    :param abs_eps:        absolute floor under the relative one, in case
+                           every dimension happens to have tiny variance
+                           (e.g. a degenerate/tiny calibration set).
+    :return:               dict with 'mean', 'var', 'active_dims' (all lists,
+                           JSON-serialisable), and 'eps' (float) -- the eps
+                           to use for the active dimensions at scoring time.
+    """
+    feature_matrix = np.asarray(feature_matrix, dtype=np.float64)
+    mean = feature_matrix.mean(axis=0)
+    var = feature_matrix.var(axis=0)
+
+    median_var = float(np.median(var))
+    floor = max(median_var * min_var_frac, abs_eps)
+    active_dims = var >= floor
+    n_inactive = int((~active_dims).sum())
+    if n_inactive:
+        logger.info(f'fit_diagonal_gaussian: {n_inactive}/{len(var)} '
+                    f'dimensions flagged inactive (variance < {floor:.3g}), '
+                    f'excluded from distance calculation.')
+
+    return {
+        'mean': mean.tolist(),
+        'var': var.tolist(),
+        'active_dims': active_dims.tolist(),
+        'eps': floor,
+    }
+
+
+class FeatureNoveltyDetector:
+    """
+    DonkeyCar Part. Computes a live "novelty" score for each frame: how far
+    the frame sits from the training distribution, via diagonal-covariance
+    Mahalanobis distance in the feature space of a GENERIC image encoder (see
+    ``donkeycar.parts.ood``).
+
+    IMPORTANT -- this used to measure distance in the steering model's own
+    ``dense_2`` layer, but that feature space is task-collapsed: a model
+    trained only to predict steering discards texture/colour/semantics, so
+    grass, carpet and open track all mapped to nearly identical features and
+    the score barely moved (it only reacted to gross changes like a covered
+    camera). It now uses a separate ImageNet-pretrained encoder that keeps
+    that scene content, which actually separates different scenes -- see the
+    ``donkeycar.parts.ood`` module docstring for the measured before/after.
+
+    Unlike ``MCDropoutConfidence``, this is a pure auxiliary observer -- it
+    does NOT produce steering/throttle, and rides alongside whichever part
+    already drives the car. One encoder forward pass per frame (no dropout
+    stochasticity needed -- novelty is a distance-from-training measure). The
+    encoder is independent of the steering pilot; the ``pilot`` argument is
+    kept only for call-site compatibility and is not used.
+
+    On slow/power-constrained hardware, ``interval`` rate-limits the encoder
+    pass (mirroring ``MCDropoutConfidence``'s ``interval``). This part never
+    drives, so between updates it holds the last score and skips the encoder
+    pass entirely -- important, since the encoder is heavier than the old
+    single steering-model pass.
+
+    Run signature::
+
+        score, raw_distance, smoothed_distance = part.run(img_arr)
+
+    ``score`` is a 0-100 novelty % derived from the calibration file (see
+    ``donkeycar.parts.mc_calibrate``), or ``None`` if the model has no
+    calibration with a ``novelty_ood`` block, or the encoder could not be
+    loaded.
+
+    :param pilot:            kept for call-site compatibility; unused (novelty
+                             now uses its own encoder, not the pilot's model).
+    :param calibration_path: path to a ``<model>.calib.json`` with a
+                             ``novelty_ood`` block, produced by
+                             ``donkeycar.parts.mc_calibrate``. Optional.
+    :param alpha:            EMA smoothing factor in [0, 1] for the raw
+                             distance -- same role as MCDropoutConfidence's.
+    :param interval:         minimum seconds between encoder passes. 0 (the
+                             default) updates every frame. Between updates the
+                             last score/distance is held and NO pass runs.
+    """
+
+    def __init__(self, pilot=None, calibration_path=None, alpha=0.2,
+                 interval=0.0):
+        self.alpha = float(alpha)
+        self.smoothed_distance = None
+        self.raw_distance = 0.0
+
+        # Minimum seconds between updates. 0 = every frame. This part is a
+        # pure observer (doesn't drive), so a held frame costs nothing --
+        # no fallback pass needed, unlike MCDropoutConfidence.
+        self.interval = float(interval)
+        self.last_update_time = None
+
+        self.extractor = None      # OOD feature extractor (generic encoder)
+        self.calibration = None    # the 'novelty_ood' calib block
+
+        if calibration_path:
+            try:
+                from donkeycar.parts.mc_calibrate import load_calibration
+                calib = load_calibration(calibration_path)
+                block = calib.get('novelty_ood')
+                if block is None:
+                    logger.warning(
+                        f'FeatureNoveltyDetector: {calibration_path} has no '
+                        f'"novelty_ood" stats (older calibration, or built '
+                        f'before the encoder-based novelty fix); novelty will '
+                        f'be unavailable -- re-run mc_calibrate to add it.')
+                else:
+                    self._load_encoder(block, calibration_path)
+                    if self.extractor is not None:
+                        self.calibration = block
+                        logger.info(f'FeatureNoveltyDetector: loaded '
+                                    f'encoder-based novelty calibration from '
+                                    f'{calibration_path}')
+            except Exception as e:
+                logger.warning(f'FeatureNoveltyDetector: could not load '
+                               f'calibration {calibration_path} ({e}); '
+                               f'novelty score will be unavailable.')
+
+    def _load_encoder(self, block, calibration_path):
+        """Prefer the encoder sidecar saved next to the calibration (so a Pi
+        driving offline needs no weight download); fall back to rebuilding the
+        encoder from ImageNet weights (needs the cache/internet)."""
+        from donkeycar.parts.ood import CPUEncoderExtractor
+        ef = block.get('encoder_file')
+        if ef and calibration_path:
+            sidecar = os.path.join(
+                os.path.dirname(os.path.abspath(calibration_path)), ef)
+            if os.path.exists(sidecar):
+                try:
+                    m = tf.keras.models.load_model(sidecar, compile=False)
+                    self.extractor = CPUEncoderExtractor(
+                        block['encoder'], model=m)
+                    logger.info(f'FeatureNoveltyDetector: loaded OOD encoder '
+                                f'sidecar {sidecar}')
+                    return
+                except Exception as e:
+                    logger.warning(f'FeatureNoveltyDetector: encoder sidecar '
+                                   f'load failed ({e}); rebuilding from '
+                                   f'ImageNet weights.')
+        try:
+            self.extractor = CPUEncoderExtractor(
+                block['encoder'], block.get('input_size'),
+                block.get('alpha', 1.0))
+        except Exception as e:
+            logger.warning(f'FeatureNoveltyDetector: could not build OOD '
+                           f'encoder ({e}); novelty will be unavailable.')
+
+    def run(self, img_arr, now=None):
+        if img_arr is None:
+            return self._score(), 0.0, (self.smoothed_distance or 0.0)
+
+        # `now` lets a tub replay (mc_calibrate) drive the interval-throttle
+        # off recorded timestamps instead of wall-clock time -- see
+        # MCDropoutConfidence.run() for the full rationale.
+        now = now if now is not None else time.time()
+        if (self.interval > 0 and self.last_update_time is not None
+                and (now - self.last_update_time) < self.interval):
+            # Rate-limited: skip the encoder pass entirely and hold the last
+            # values -- no fallback pass needed since this part never drives.
+            return self._score(), self.raw_distance, \
+                (self.smoothed_distance or 0.0)
+        self.last_update_time = now
+
+        if self.calibration is not None and self.extractor is not None:
+            feat = self.extractor.extract(img_arr)
+            mean = np.array(self.calibration['mean'])
+            var = np.array(self.calibration['var'])
+            active = np.array(self.calibration['active_dims'])
+            eps = self.calibration['eps']
+            raw_distance = float(
+                mahalanobis_diag(feat, mean, var, active, eps))
+        else:
+            raw_distance = 0.0
+        self.raw_distance = raw_distance
+
+        if self.smoothed_distance is None:
+            self.smoothed_distance = raw_distance
+        else:
+            self.smoothed_distance = (
+                self.alpha * raw_distance
+                + (1.0 - self.alpha) * self.smoothed_distance)
+
+        return self._score(), raw_distance, self.smoothed_distance
+
+    def _score(self):
+        if self.calibration is None or self.smoothed_distance is None:
+            return None
+        from donkeycar.parts.mc_calibrate import novelty_distance_to_score
+        return novelty_distance_to_score(self.smoothed_distance,
+                                         self.calibration)
+
+    def shutdown(self):
+        pass

--- a/donkeycar/parts/ood.py
+++ b/donkeycar/parts/ood.py
@@ -1,0 +1,233 @@
+"""
+Generic-encoder feature extraction for out-of-distribution (novelty) detection.
+
+WHY THIS EXISTS (the diagnosis behind it): the original novelty detector
+measured distance-from-training in the *steering model's* penultimate layer
+(``dense_2``). But that model was trained only to predict a steering angle, so
+it learned to discard everything that doesn't affect steering -- texture,
+colour, scene semantics. Empirically, grass / carpet / open track all collapse
+to nearly identical ``dense_2`` features (all mean "drive straight"), so the
+novelty score barely moved for genuinely different scenes and only reacted to
+gross changes like covering the camera. Measured z-scores from the training
+distribution: grass +0.0, carpet -0.2, white-noise -0.3 (i.e. *less* novel
+than a real track frame), vs +5.5 only for a blacked-out camera.
+
+The fix is to measure novelty in the feature space of a *generic* image
+encoder (an ImageNet-pretrained backbone) that was never trained to ignore
+scene content, so it keeps the texture/semantics that distinguish grass from
+track. With the same diagonal-Mahalanobis math, the same scenes then separate
+by tens-to-hundreds of sigma (grass +116, carpet +92, noise +141).
+
+This module provides a pluggable extractor interface so the *source* of the
+features can change without touching the OOD math or calibration downstream:
+
+  * ``CPUEncoderExtractor`` -- runs a small ImageNet backbone (MobileNetV2 by
+    default) on the CPU. The portable default: works on any setup.
+  * (future) a Hailo-NPU-backed extractor implementing the same ``extract`` /
+    ``extract_batch`` interface, so the encoder forward pass moves off the Pi
+    CPU. Not yet implemented -- see the project notes.
+
+The extractor is deliberately independent of the steering pilot: novelty here
+is a property of the *input scene*, not of the driving model.
+"""
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Supported generic encoders: name -> (keras.applications ctor, preprocess,
+# default input size). Kept small/Pi-friendly; MobileNetV2 pooled = 1280-dim.
+_ENCODERS = {
+    'mobilenet_v2': ('MobileNetV2', 'mobilenet_v2', 128),
+    'mobilenet': ('MobileNet', 'mobilenet', 128),
+}
+
+
+def build_ood_encoder(name='mobilenet_v2', input_size=None, alpha=1.0):
+    """
+    Build a generic ImageNet feature-extractor model (no classification head,
+    global-average-pooled) and its matching preprocessing function.
+
+    :return: (keras.Model mapping (B,S,S,3) uint8-range floats -> (B, feat_dim),
+              preprocess_fn, input_size)
+    """
+    import tensorflow as tf
+    if name not in _ENCODERS:
+        raise ValueError(f'Unknown OOD encoder {name!r}; options: '
+                         f'{sorted(_ENCODERS)}')
+    ctor_name, prep_mod, default_size = _ENCODERS[name]
+    input_size = int(input_size or default_size)
+
+    ctor = getattr(tf.keras.applications, ctor_name)
+    kwargs = dict(weights='imagenet', include_top=False, pooling='avg',
+                  input_shape=(input_size, input_size, 3))
+    # alpha (width multiplier) is only accepted by the mobilenet family.
+    try:
+        model = ctor(alpha=alpha, **kwargs)
+    except TypeError:
+        model = ctor(**kwargs)
+
+    prep = getattr(tf.keras.applications, prep_mod).preprocess_input
+    logger.info(f'Built OOD encoder {name} (input={input_size}, '
+                f'feat_dim={model.output_shape[-1]})')
+    return model, prep, input_size
+
+
+class CPUEncoderExtractor:
+    """
+    Extract generic-encoder features from camera frames on the CPU.
+
+    ``extract(img)`` / ``extract_batch(imgs)`` take uint8 [0,255] (H,W,3)
+    frames (any size -- resized internally) and return L2-comparable float
+    feature vectors suitable for the downstream Mahalanobis / kNN scorer.
+
+    :param name:       encoder key (see ``_ENCODERS``).
+    :param input_size: square input the encoder is resized to. None -> the
+                       encoder's default.
+    :param model:      optional pre-built encoder Model (e.g. loaded from a
+                       sidecar so the Pi needs no weight download). If given,
+                       ``name``/``input_size`` must match how it was built.
+    """
+
+    def __init__(self, name='mobilenet_v2', input_size=None, alpha=1.0,
+                 model=None):
+        self.name = name
+        if model is not None:
+            import tensorflow as tf
+            self.model = model
+            self.input_size = int(model.input_shape[1])
+            _, prep_mod, _ = _ENCODERS[name]
+            self.preprocess = getattr(tf.keras.applications,
+                                      prep_mod).preprocess_input
+        else:
+            self.model, self.preprocess, self.input_size = build_ood_encoder(
+                name, input_size, alpha)
+        self.feat_dim = int(self.model.output_shape[-1])
+
+    def _prep_batch(self, imgs):
+        from PIL import Image
+        s = self.input_size
+        batch = np.stack([
+            np.asarray(Image.fromarray(im).resize((s, s)), dtype=np.float32)
+            for im in imgs])
+        return self.preprocess(batch)
+
+    def extract_batch(self, imgs):
+        """imgs: list/array of uint8 (H,W,3) -> (n, feat_dim) float32."""
+        batch = self._prep_batch(imgs)
+        return np.asarray(self.model(batch, training=False), dtype=np.float32)
+
+    def extract(self, img):
+        """img: uint8 (H,W,3) -> (feat_dim,) float32."""
+        return self.extract_batch([img])[0]
+
+
+def spatial_input_hw(frame_h, frame_w, short_side=224, stride=32):
+    """
+    Pick an encoder input (H, W) that preserves the camera frame's aspect
+    ratio, with both sides multiples of the encoder's total stride.
+
+    The pooled encoder used for the live novelty score squashes frames into a
+    square, which is harmless when every location is averaged together. The
+    SPATIAL map keeps per-location distances, so a squashed input would
+    stretch the resulting heat map unevenly when it is drawn back over the
+    frame. Sizing to the frame's own aspect avoids that.
+
+    :param short_side: target size of the shorter side; the longer side is
+                       scaled to match the frame's aspect ratio. Bigger =
+                       finer grid (grid ~= size/stride) and slower.
+    """
+    frame_h, frame_w = int(frame_h), int(frame_w)
+    aspect = frame_w / max(1, frame_h)
+
+    def snap(v):
+        return max(stride, int(round(v / stride)) * stride)
+
+    if frame_w >= frame_h:
+        h = snap(short_side)
+        w = snap(short_side * aspect)
+    else:
+        w = snap(short_side)
+        h = snap(short_side / aspect)
+    return h, w
+
+
+def build_ood_spatial_encoder(name='mobilenet_v2', input_hw=(224, 384),
+                              alpha=1.0):
+    """
+    Same generic ImageNet encoder as ``build_ood_encoder``, but WITHOUT the
+    global-average-pooling head, so the spatial feature grid is preserved.
+
+    Averaging this model's output over its spatial axes reproduces the pooled
+    model's output exactly, which is the point: the offline spatial novelty
+    map and the live novelty score then live in the same feature space
+    instead of two unrelated ones.
+
+    :return: (keras.Model mapping (B,H,W,3) -> (B, gh, gw, feat_dim),
+              preprocess_fn, (H, W))
+    """
+    import tensorflow as tf
+    if name not in _ENCODERS:
+        raise ValueError(f'Unknown OOD encoder {name!r}; options: '
+                         f'{sorted(_ENCODERS)}')
+    ctor_name, prep_mod, _ = _ENCODERS[name]
+    h, w = int(input_hw[0]), int(input_hw[1])
+
+    ctor = getattr(tf.keras.applications, ctor_name)
+    kwargs = dict(weights='imagenet', include_top=False, pooling=None,
+                  input_shape=(h, w, 3))
+    try:
+        model = ctor(alpha=alpha, **kwargs)
+    except TypeError:
+        model = ctor(**kwargs)
+
+    prep = getattr(tf.keras.applications, prep_mod).preprocess_input
+    logger.info(f'Built spatial OOD encoder {name} (input={h}x{w}, '
+                f'grid={model.output_shape[1:3]}, '
+                f'feat_dim={model.output_shape[-1]})')
+    return model, prep, (h, w)
+
+
+class SpatialEncoderExtractor:
+    """
+    Per-location generic-encoder features, for the offline novelty heat map.
+
+    Mirrors ``CPUEncoderExtractor`` but keeps the spatial grid instead of
+    averaging it away. Offline-only: nothing in the drive loop uses this, so
+    the larger input size costs no live latency.
+    """
+
+    def __init__(self, name='mobilenet_v2', input_hw=(224, 384), alpha=1.0,
+                 model=None):
+        self.name = name
+        if model is not None:
+            import tensorflow as tf
+            self.model = model
+            self.input_hw = (int(model.input_shape[1]),
+                             int(model.input_shape[2]))
+            _, prep_mod, _ = _ENCODERS[name]
+            self.preprocess = getattr(tf.keras.applications,
+                                      prep_mod).preprocess_input
+        else:
+            self.model, self.preprocess, self.input_hw = \
+                build_ood_spatial_encoder(name, input_hw, alpha)
+        self.feat_dim = int(self.model.output_shape[-1])
+        self.grid_hw = tuple(int(v) for v in self.model.output_shape[1:3])
+
+    def _prep_batch(self, imgs):
+        from PIL import Image
+        h, w = self.input_hw
+        batch = np.stack([
+            np.asarray(Image.fromarray(im).resize((w, h)), dtype=np.float32)
+            for im in imgs])
+        return self.preprocess(batch)
+
+    def extract_grid_batch(self, imgs):
+        """imgs: list of uint8 (H,W,3) -> (n, gh, gw, feat_dim) float32."""
+        batch = self._prep_batch(imgs)
+        return np.asarray(self.model(batch, training=False), dtype=np.float32)
+
+    def extract_grid(self, img):
+        """img: uint8 (H,W,3) -> (gh, gw, feat_dim) float32."""
+        return self.extract_grid_batch([img])[0]

--- a/donkeycar/parts/salient.py
+++ b/donkeycar/parts/salient.py
@@ -1,106 +1,270 @@
-#from https://github.com/ermolenkodev/keras-salient-object-visualisation
+"""
+Vanilla-gradient saliency: how much would each *pixel* of the input image
+change the model's steering(+throttle) output if perturbed, via the gradient
+of the summed output(s) w.r.t. the raw input image.
+
+This is a different technique from Grad-CAM
+(``donkeycar.parts.gradcam_uncertainty``), which operates on the last
+convolutional layer's coarse feature grid and is smoothed by channel-pooling
+into a small number of spatial cells. Vanilla-gradient saliency computes
+gradients directly against full-resolution input pixels instead, giving a
+finer but visibly noisier, more spatially-diffuse view of "what matters to
+the prediction" -- a complementary lens, not a replacement. In practice
+Grad-CAM tends to produce a small number of clean, localized hotspots, while
+vanilla-gradient saliency tends to highlight many pixels weakly across a
+wider area (see the "Caveats" note below).
+
+This module offers two pixel-level attribution methods:
+  * ``VanillaGradientSaliency`` -- a single raw input gradient. Cheap, but the
+    gradient saturates for deep nets, so the map is speckly/noisy.
+  * ``IntegratedGradients`` -- integrates the gradient along a straight path
+    from a baseline (black image) to the input. Much cleaner attributions
+    (satisfies the sensitivity + implementation-invariance axioms of
+    Sundararajan et al., 2017) at the cost of ``steps`` extra passes. Offline
+    only -- never put it on the live drive loop.
+
+Used by:
+  * ``donkeycar.management.makemovie`` -- the ``--salient`` flag on
+    ``donkey makemovie`` burns vanilla saliency into an exported video, frame
+    by frame.
+  * ``donkeycar.parts.gradcam_uncertainty`` -- offers both vanilla saliency
+    and integrated gradients as overlay layers alongside the Grad-CAM
+    attention/uncertainty maps and the feature-space novelty map, for the same
+    analysed frames.
+
+Caveats:
+  * Compared to Grad-CAM, pixel-level gradients are typically noisier and
+    less spatially decisive -- treat these as one more data point, not a more
+    "correct" answer than the other overlays.
+  * Model scope: like the rest of this toolkit, only architectures with
+    identifiable output layers (name containing "out", excluding dropout
+    layers) are supported -- this covers the default linear and categorical
+    architectures.
+"""
 import os
-from keras import backend as K
-import tensorflow as tf
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-from keras.layers import Input, Dense, merge
-from keras.models import Model
-from keras.layers import Convolution2D, MaxPooling2D, Reshape, BatchNormalization
-from keras.layers import Activation, Dropout, Flatten, Dense
-import cv2
+import tempfile
+
 import numpy as np
+import tensorflow as tf
+from tensorflow.keras import activations
+from tensorflow.keras.models import load_model
 
-class SalientVis():
-    '''
-    Note, this part is quite tuned ust for the image dimensions and layers
-    in our standard models. It will not reflect cropping or additional layers
-    that might be in your model.
-    '''
 
-    def __init__(self, kerasPart):
-        self.model = kerasPart.model
-        self.init_salient(self.model)
+def _apply_linear_output_activation(model):
+    """
+    Force the model's output layer(s) (name contains "out", excluding
+    dropout layers) to linear activation, and rebuild the graph via a
+    save/reload round-trip -- directly setting ``layer.activation`` does not
+    actually rebuild the compute graph. A no-op for architectures whose
+    outputs are already linear (e.g. the default linear model); needed for
+    architectures with a non-linear output activation (e.g. categorical's
+    softmax), so gradients are taken against raw scores, not squashed ones.
 
-    def run(self, image):
-        if image is None:
-            return
-        image = self.draw_salient(image)
-        image = image * 255
-        image = image.astype('uint8')
-        return image
+    :return: (model, found_any) -- `model` is unchanged if no matching
+             output layer was found, and `found_any` is False.
 
-    def init_salient(self, model):
-        img_in = Input(shape=(120, 160, 3), name='img_in')
-        x = img_in
-        x = Convolution2D(24, (5,5), strides=(2,2), activation='relu', name='conv1')(x)
-        x = Convolution2D(32, (5,5), strides=(2,2), activation='relu', name='conv2')(x)
-        x = Convolution2D(64, (5,5), strides=(2,2), activation='relu', name='conv3')(x)
-        x = Convolution2D(64, (3,3), strides=(2,2), activation='relu', name='conv4')(x)
-        conv_5 = Convolution2D(64, (3,3), strides=(1,1), activation='relu', name='conv5')(x)
-        self.convolution_part = Model(inputs=[img_in], outputs=[conv_5])
+    The caller's model is never mutated: in TF2 ``Dense.call`` reads
+    ``self.activation`` at call time, so assigning it in place would silently
+    change the predictions of the very pilot the caller is still using (e.g.
+    stripping the softmax off a categorical model that ``makemovie`` then
+    keeps calling for its predicted-steering overlay). The activation is set
+    on a reloaded copy instead, and the round-trip is skipped altogether when
+    every output is already linear -- the common case, since the default
+    linear architecture needs no change at all.
+    """
+    output_idx = [i for i, layer in enumerate(model.layers)
+                 if 'dropout' not in layer.name.lower()
+                 and 'out' in layer.name.lower()]
+    if not output_idx:
+        return model, False
 
-        for layer_num in ('1', '2', '3', '4', '5'):
-            self.convolution_part.get_layer('conv' + layer_num).set_weights(model.get_layer('conv2d_' + layer_num).get_weights())
-        
-        self.inp = self.convolution_part.input                                           # input placeholder
-        self.outputs = [layer.output for layer in self.convolution_part.layers[1:]]          # all layer outputs
-        self.functor = K.function([self.inp], self.outputs)
+    if all(getattr(model.layers[i], 'activation', None) is activations.linear
+           for i in output_idx):
+        # Already linear: nothing to rebuild, and no reason to pay a full .h5
+        # serialise + deserialise just to hand back an identical model.
+        return model, True
 
-        kernel_3x3 = tf.constant(np.array([
-        [[[1]], [[1]], [[1]]], 
-        [[[1]], [[1]], [[1]]], 
-        [[[1]], [[1]], [[1]]]
-        ]), tf.float32)
+    model_path = os.path.join(tempfile.gettempdir(),
+                              next(tempfile._get_candidate_names()) + '.h5')
+    try:
+        # Round-trip the ORIGINAL first, then retarget the copy, so the
+        # caller's own model object keeps its real activations.
+        model.save(model_path)
+        linear_model = load_model(model_path, compile=False)
+        for i in output_idx:
+            linear_model.layers[i].activation = activations.linear
+        linear_model.save(model_path)
+        return load_model(model_path, compile=False), True
+    finally:
+        os.remove(model_path)
 
-        kernel_5x5 = tf.constant(np.array([
-                [[[1]], [[1]], [[1]], [[1]], [[1]]], 
-                [[[1]], [[1]], [[1]], [[1]], [[1]]], 
-                [[[1]], [[1]], [[1]], [[1]], [[1]]],
-                [[[1]], [[1]], [[1]], [[1]], [[1]]],
-                [[[1]], [[1]], [[1]], [[1]], [[1]]]
-        ]), tf.float32)
 
-        self.layers_kernels = {5: kernel_3x3, 4: kernel_3x3, 3: kernel_5x5, 2: kernel_5x5, 1: kernel_5x5}
+class VanillaGradientSaliency:
+    """
+    Computes a full-resolution pixel-saliency map: the L2 norm, across
+    output channels, of the gradient of each output w.r.t. each input pixel.
 
-        self.layers_strides = {5: [1, 1, 1, 1], 4: [1, 2, 2, 1], 3: [1, 2, 2, 1], 2: [1, 2, 2, 1], 1: [1, 2, 2, 1]}
+    :param model:       a raw Keras model (e.g. ``pilot.interpreter.model``).
+    :param categorical: True for categorical/binned outputs (uses each
+                        output's argmax score), False (default) for
+                        continuous linear outputs (uses the raw score).
+    """
 
-        
-    def compute_visualisation_mask(self, img):
-        #from https://github.com/ermolenkodev/keras-salient-object-visualisation
-        
-        activations = self.functor([np.array([img])])
-        activations = [np.reshape(img, (1, img.shape[0], img.shape[1], img.shape[2]))] + activations
-        upscaled_activation = np.ones((3, 6))
-        for layer in [5, 4, 3, 2, 1]:
-            averaged_activation = np.mean(activations[layer], axis=3).squeeze(axis=0) * upscaled_activation
-            output_shape = (activations[layer - 1].shape[1], activations[layer - 1].shape[2])
-            x = tf.constant(
-                np.reshape(averaged_activation, (1,averaged_activation.shape[0],averaged_activation.shape[1],1)),
-                tf.float32
-            )
-            conv = tf.nn.conv2d_transpose(
-                x, self.layers_kernels[layer],
-                output_shape=(1,output_shape[0],output_shape[1], 1), 
-                strides=self.layers_strides[layer], 
-                padding='VALID'
-            )
-            with tf.Session() as session:
-                result = session.run(conv)
-            upscaled_activation = np.reshape(result, output_shape)
-        final_visualisation_mask = upscaled_activation
-        return (final_visualisation_mask - np.min(final_visualisation_mask))/(np.max(final_visualisation_mask) - np.min(final_visualisation_mask))
+    def __init__(self, model, categorical=False):
+        self.categorical = categorical
+        self.model, self.found_output_layers = \
+            _apply_linear_output_activation(model)
 
-    def draw_salient(self, img):
-        #from https://github.com/ermolenkodev/keras-salient-object-visualisation
-        alpha = 0.004
-        beta = 1.0 - alpha
+    def saliency_map(self, norm_img):
+        """
+        :param norm_img: float32 image, [0,1], shape (H, W, C)
+        :return: (H, W) float map normalised to [0,1]
+        """
+        img = tf.Variable(norm_img[np.newaxis, ...], dtype=tf.float32)
 
-        salient_mask = self.compute_visualisation_mask(img)
-        salient_mask_stacked = np.dstack((salient_mask,salient_mask))
-        salient_mask_stacked = np.dstack((salient_mask_stacked,salient_mask))
-        blend = cv2.addWeighted(img.astype('float32'), alpha, salient_mask_stacked, beta, 0.0)
-        return blend
+        with tf.GradientTape(persistent=True) as tape:
+            tape.watch(img)
+            preds = self.model(img, training=False)
+            preds = preds if isinstance(preds, (list, tuple)) else [preds]
+            if self.categorical:
+                pred_list = [p[0][tf.math.argmax(p[0])] for p in preds]
+            else:
+                pred_list = preds
+
+        grads_sq = 0
+        for p in pred_list:
+            grads_sq += tf.math.square(tape.gradient(p, img))
+        grads = tf.math.sqrt(grads_sq)
+        grads = tf.reduce_sum(grads, axis=-1)[0].numpy()   # (H, W)
+
+        gmin, gmax = float(grads.min()), float(grads.max())
+        if gmax > gmin:
+            grads = (grads - gmin) / (gmax - gmin)
+        else:
+            grads = np.zeros_like(grads)
+        return grads
 
     def shutdown(self):
         pass
-        
+
+
+class IntegratedGradients:
+    """
+    Integrated Gradients (Sundararajan, Taly & Yan, ICML 2017): a cleaner
+    pixel-attribution method than :class:`VanillaGradientSaliency`.
+
+    Rather than taking one gradient at the real image (which saturates and
+    looks speckly), IG walks a straight path from a *baseline* image (black by
+    default) to the real input in ``steps`` increments, takes the gradient at
+    each step, and averages them; the average is then multiplied elementwise by
+    ``(input - baseline)``::
+
+        IG(x) = (x - baseline) * mean_over_path( dF/dx )
+
+    Averaging along the path cancels much of the per-point gradient noise and
+    gives the method its two axioms: *sensitivity* (a pixel that changes the
+    output always gets non-zero attribution) and *implementation-invariance*
+    (functionally identical models give identical attributions) -- neither of
+    which vanilla gradients guarantee.
+
+    Attribution target is the model's first output (steering on the linear
+    model), matching Grad-CAM's choice, so this reads as "which pixels drove
+    the steering decision". Cost is ``steps`` forward+backward passes per
+    frame (all ``steps`` are batched into ONE pass), so this is offline-only --
+    never put it on the live drive loop.
+
+    :param model:       a raw Keras model (e.g. ``pilot.interpreter.model``).
+    :param categorical: True for categorical/binned outputs (attributes the
+                        top class along the path), False (default) for a
+                        continuous linear output.
+    :param steps:       number of Riemann-sum steps along the baseline->input
+                        path (typical 20-50). More steps = smoother, slower.
+    :param baseline:    optional (H, W, C) float32 [0,1] baseline image. None
+                        (default) uses a black (zeros) baseline.
+    """
+
+    def __init__(self, model, categorical=False, steps=32, baseline=None):
+        self.categorical = categorical
+        self.steps = int(steps)
+        self.baseline = baseline
+        self.model, self.found_output_layers = \
+            _apply_linear_output_activation(model)
+
+    def saliency_map(self, norm_img):
+        """
+        :param norm_img: float32 image, [0,1], shape (H, W, C)
+        :return: (H, W) float map normalised to [0,1]
+        """
+        x = tf.convert_to_tensor(norm_img[np.newaxis, ...], dtype=tf.float32)
+        if self.baseline is None:
+            baseline = tf.zeros_like(x)
+        else:
+            baseline = tf.convert_to_tensor(
+                self.baseline[np.newaxis, ...], dtype=tf.float32)
+
+        # Interpolated inputs along the straight path, batched: (steps, H, W, C).
+        alphas = tf.reshape(tf.linspace(0.0, 1.0, self.steps), (-1, 1, 1, 1))
+        path = baseline + alphas * (x - baseline)
+
+        with tf.GradientTape() as tape:
+            tape.watch(path)
+            preds = self.model(path, training=False)
+            preds = preds if isinstance(preds, (list, tuple)) else [preds]
+            target_out = preds[0]                        # steering head
+            if self.categorical:
+                per_row = tf.reduce_max(target_out, axis=-1)
+            else:
+                per_row = tf.reshape(target_out, (self.steps, -1))[:, 0]
+            # Rows of the path batch are independent, so the gradient of the
+            # summed score w.r.t. the path gives each step its own gradient.
+            score = tf.reduce_sum(per_row)
+        path_grads = tape.gradient(score, path)          # (steps, H, W, C)
+
+        avg_grads = tf.reduce_mean(path_grads, axis=0, keepdims=True)
+        ig = (x - baseline) * avg_grads                  # (1, H, W, C)
+        ig = tf.reduce_sum(tf.abs(ig), axis=-1)[0].numpy()   # (H, W)
+
+        gmin, gmax = float(ig.min()), float(ig.max())
+        if gmax > gmin:
+            ig = (ig - gmin) / (gmax - gmin)
+        else:
+            ig = np.zeros_like(ig)
+        return ig
+
+    def shutdown(self):
+        pass
+
+
+class SalientVis:
+    """
+    DonkeyCar Part: overlay a saliency map on a camera frame, image -> image.
+
+    Kept for ``scripts/salient_vis_listener.py``, which streams frames off a
+    running car and wants a drop-in part. The previous implementation
+    hand-rebuilt the conv stack with hardcoded 120x160 layer shapes and a
+    TF1 ``tf.Session``; this one wraps :class:`VanillaGradientSaliency`, so it
+    works for whatever architecture the pilot actually is.
+
+    :param kerasPart:   a loaded KerasPilot (e.g. from ``get_model_by_type``).
+    :param categorical: True for categorical/binned outputs.
+    """
+
+    def __init__(self, kerasPart, categorical=False):
+        model = getattr(getattr(kerasPart, 'interpreter', None), 'model', None)
+        if model is None:
+            model = kerasPart.model     # pilots predating the interpreter API
+        self.saliency = VanillaGradientSaliency(model, categorical=categorical)
+
+    def run(self, image):
+        if image is None:
+            return None
+        from donkeycar.utils import normalize_image
+        mask = self.saliency.saliency_map(
+            normalize_image(image).astype(np.float32))[..., np.newaxis]
+        # Blend the [0,1] mask over the frame: brightest where it matters.
+        base = image.astype(np.float32) / 255.0
+        blend = base * (1.0 - mask) + mask
+        return (np.clip(blend, 0.0, 1.0) * 255).astype(np.uint8)
+
+    def shutdown(self):
+        pass

--- a/donkeycar/parts/tta.py
+++ b/donkeycar/parts/tta.py
@@ -1,0 +1,243 @@
+"""
+Test-Time Augmentation (TTA) stability -- a third live uncertainty signal.
+
+MC-Dropout confidence (``donkeycar.parts.mc_dropout``) perturbs the model's
+*weights* (dropout masks) and asks "do my sub-networks agree?". Novelty
+(``donkeycar.parts.novelty``) perturbs nothing and asks "does this scene look
+like training data?". TTA perturbs the *input image* and asks a third,
+distinct question: "does my answer stay the same if the picture changes a
+little?" -- i.e. robustness of the prediction to input noise, which neither of
+the other two signals measures directly.
+
+Mechanism: run the DETERMINISTIC model (dropout OFF, same weights every time)
+on M lightly-augmented copies of the frame, and take the variance of the M
+steering predictions. Low variance = the prediction is stable under input
+perturbation = robust; high variance = fragile. The variance is EMA-smoothed
+and mapped through the model's calibration to a 0-100 "stability %" (high =
+robust), mirroring the confidence signal's machinery but with its own
+calibration block (``calib['tta']``).
+
+CRITICAL -- photometric augmentations ONLY. We perturb brightness, contrast,
+gamma, and add a little gaussian noise: changes that do NOT move the road in
+the image, so the *correct* steering answer is unchanged and any wobble in the
+prediction is genuinely the model being fragile. We deliberately do NOT use
+rotation / horizontal flip / large translation: those change the correct
+answer (a flipped road really does turn the other way), which would conflate
+"model is fragile" with "the scene genuinely changed". This keeps TTA a clean
+"robustness to camera/lighting noise" signal. (Geometric TTA would require
+applying the inverse transform to the output -- out of scope here.)
+
+Like ``FeatureNoveltyDetector``, this is a pure auxiliary observer: it does
+NOT produce steering/throttle and rides alongside whichever part drives the
+car. M forward passes are batched into ONE deterministic call (same trick as
+MC-Dropout), so it is cheap enough to run live -- but M passes every single
+frame, unconditionally, is still real load on top of whatever else is
+running (the driving pass, MC-Dropout's own N passes, novelty's single pass).
+``XAI_TTA_INTERVAL`` rate-limits how often that M-pass update actually runs;
+between updates the last score is held with ZERO forward passes (no fallback
+pass needed, since this part never drives) -- the single biggest lever if
+running multiple signals together is straining the hardware's power budget.
+
+Model scope: like the rest of this toolkit, the default linear architecture
+(``KerasLinear``) with a single image input and a callable Keras interpreter
+-- not TFLite/TensorRT.
+"""
+import logging
+import time
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.utils import normalize_image
+
+logger = logging.getLogger(__name__)
+
+
+def photometric_batch(norm_img, num_samples, strength, rng):
+    """
+    Build a batch of ``num_samples`` photometrically-augmented copies of a
+    normalised image. Geometry is untouched (no spatial transform), so the
+    correct steering answer is identical for every copy -- see the module
+    docstring for why that matters.
+
+    :param norm_img:    (H, W, C) float32 image in [0, 1].
+    :param num_samples: M, the number of augmented copies.
+    :param strength:    augmentation strength; brightness/contrast/gamma are
+                        each jittered within +/- this fraction, gaussian noise
+                        std is ``strength * 0.1``. 0 -> all copies identical.
+    :param rng:         a ``numpy.random.Generator``.
+    :return:            (M, H, W, C) float32 batch in [0, 1].
+    """
+    M = int(num_samples)
+    imgs = np.repeat(norm_img[np.newaxis, ...], M, axis=0).astype(np.float32)
+
+    # Per-sample photometric parameters, shaped to broadcast over (H, W, C).
+    bright = rng.uniform(-strength, strength, (M, 1, 1, 1)).astype(np.float32)
+    contrast = (1.0 + rng.uniform(-strength, strength,
+                                  (M, 1, 1, 1))).astype(np.float32)
+    gamma = (1.0 + rng.uniform(-strength, strength,
+                               (M, 1, 1, 1))).astype(np.float32)
+
+    # Contrast about each image's own mean, then a brightness shift.
+    mean = imgs.mean(axis=(1, 2, 3), keepdims=True)
+    imgs = (imgs - mean) * contrast + mean
+    imgs = imgs + bright
+    imgs = np.clip(imgs, 0.0, 1.0)
+    # Gamma (safe on [0, 1]; gamma stays positive for strength < 1).
+    imgs = np.power(imgs, gamma)
+    # A little gaussian sensor noise.
+    if strength > 0:
+        imgs = imgs + rng.normal(0.0, strength * 0.1, imgs.shape).astype(np.float32)
+    return np.clip(imgs, 0.0, 1.0)
+
+
+class TTAStabilityDetector:
+    """
+    DonkeyCar Part. Computes a live "stability" score per frame: the variance
+    of the deterministic model's steering prediction across M photometrically
+    -augmented copies of the frame, EMA-smoothed and mapped to a 0-100 % (high
+    = robust) via the model's ``calib['tta']`` block.
+
+    Pure auxiliary observer (like ``FeatureNoveltyDetector``): does NOT drive.
+    Each update costs M forward passes (batched into one call) -- more
+    expensive per-update than novelty's single pass, so rate-limiting via
+    ``interval`` matters more here on slow/power-constrained hardware. Between
+    updates the last score is held and NO forward pass runs at all (no
+    fallback pass needed, since this part never drives). Likewise, if the
+    model has no calibration at all (``calibration_path`` missing/invalid),
+    the M-pass batch is skipped entirely rather than computed and discarded --
+    nothing consumes the raw variance without a calibration mapping, so there
+    is no reason to pay for it.
+
+    Run signature::
+
+        stability, raw_variance, smoothed_variance = part.run(img_arr)
+
+    ``stability`` is a 0-100 % (high = robust), or ``None`` if the model has no
+    calibration, or a calibration made before TTA stats existed.
+
+    :param pilot:            a loaded KerasPilot (KerasLinear); its underlying
+                             Keras model is reused directly.
+    :param calibration_path: path to a ``<model>.calib.json``. Optional.
+    :param num_samples:      M, number of augmented copies per frame (~8).
+    :param alpha:            EMA smoothing factor in [0, 1] for the variance.
+    :param strength:         photometric augmentation strength (see
+                             ``photometric_batch``).
+    :param interval:         minimum seconds between updates (each an M-pass
+                             batch). 0 (the default) updates every frame.
+    :param seed:             optional RNG seed for reproducible augmentations.
+    :param always_measure:   when True, run the M-pass batch even without a
+                             calibration. Live driving leaves this False (an
+                             uncalibrated variance has nothing to be scored
+                             against, so paying M passes for it is waste);
+                             ``mc_calibrate`` sets it True, since measuring
+                             those variances is precisely how the calibration
+                             gets built in the first place.
+    """
+
+    def __init__(self, pilot, calibration_path=None, num_samples=8,
+                 alpha=0.2, strength=0.2, interval=0.0, seed=None,
+                 always_measure=False):
+        self.num_samples = int(num_samples)
+        self.alpha = float(alpha)
+        self.strength = float(strength)
+        self.rng = np.random.default_rng(seed)
+        self.smoothed_variance = None
+        self.raw_variance = 0.0
+        self.always_measure = bool(always_measure)
+
+        # Minimum seconds between M-pass updates. 0 = every frame. Held
+        # frames cost nothing (no forward pass at all) -- this part never
+        # drives, unlike MCDropoutConfidence's interval fallback.
+        self.interval = float(interval)
+        self.last_update_time = None
+
+        interpreter = getattr(pilot, 'interpreter', None)
+        self.model = getattr(interpreter, 'model', None)
+        if self.model is None or not callable(self.model):
+            raise ValueError(
+                'TTAStabilityDetector requires a Keras pilot with a callable '
+                'model (the default KerasInterpreter). TFLite/TensorRT '
+                'interpreters are not supported.')
+        self.input_keys = list(interpreter.input_keys)
+        if len(self.input_keys) > 1:
+            logger.warning(
+                'TTAStabilityDetector: model has multiple inputs %s; TTA '
+                'supports single-image-input (linear) models only. Using the '
+                'first input, others left unset may error.', self.input_keys)
+
+        self.calibration = None
+        if calibration_path:
+            try:
+                from donkeycar.parts.mc_calibrate import load_calibration
+                calib = load_calibration(calibration_path)
+                self.calibration = calib.get('tta')
+                if self.calibration is None:
+                    logger.warning(
+                        f'TTAStabilityDetector: {calibration_path} has no '
+                        f'"tta" stats (calibration made before TTA, or with '
+                        f'XAI_TTA_ENABLED off); stability will be unavailable '
+                        f'-- re-run mc_calibrate with XAI_TTA_ENABLED=True.')
+                else:
+                    logger.info(f'TTAStabilityDetector: loaded TTA calibration '
+                                f'from {calibration_path}')
+            except Exception as e:
+                logger.warning(f'TTAStabilityDetector: could not load '
+                               f'calibration {calibration_path} ({e}); '
+                               f'stability will be unavailable.')
+
+    def run(self, img_arr, now=None):
+        if img_arr is None:
+            return self._score(), 0.0, (self.smoothed_variance or 0.0)
+
+        # `now` lets a tub replay (mc_calibrate) drive the interval-throttle
+        # off recorded timestamps instead of wall-clock time -- see
+        # MCDropoutConfidence.run() for the full rationale.
+        now = now if now is not None else time.time()
+        if (self.interval > 0 and self.last_update_time is not None
+                and (now - self.last_update_time) < self.interval):
+            # Rate-limited: skip the M-pass batch entirely and hold the last
+            # values -- no fallback pass needed since this part never drives.
+            return self._score(), self.raw_variance, \
+                (self.smoothed_variance or 0.0)
+        self.last_update_time = now
+
+        if self.calibration is not None or self.always_measure:
+            norm = normalize_image(img_arr).astype(np.float32)
+            batch = photometric_batch(norm, self.num_samples, self.strength,
+                                      self.rng)
+            input_dict = {self.input_keys[0]: tf.convert_to_tensor(batch)}
+            outputs = self.model(input_dict, training=False)  # DETERMINISTIC
+            # Linear model returns [angle (M,1), throttle (M,1)].
+            angle_samples = np.asarray(outputs[0]).reshape(-1)
+            raw_variance = float(np.var(angle_samples))
+        else:
+            # No calibration to score against, and not explicitly asked to
+            # measure anyway -- skip the M-pass batch entirely (mirrors
+            # FeatureNoveltyDetector). Nothing consumes the raw variance
+            # without a calibration mapping, so there's no reason to pay for
+            # M forward passes just to produce a number nobody reads.
+            # NOTE: calibration itself MUST pass always_measure=True, or the
+            # variances it collects here would all be 0.0 and the resulting
+            # 'tta' block would be degenerate.
+            raw_variance = 0.0
+        self.raw_variance = raw_variance
+
+        if self.smoothed_variance is None:
+            self.smoothed_variance = raw_variance
+        else:
+            self.smoothed_variance = (
+                self.alpha * raw_variance
+                + (1.0 - self.alpha) * self.smoothed_variance)
+
+        return self._score(), raw_variance, self.smoothed_variance
+
+    def _score(self):
+        if self.calibration is None or self.smoothed_variance is None:
+            return None
+        from donkeycar.parts.mc_calibrate import tta_variance_to_stability
+        return tta_variance_to_stability(self.smoothed_variance,
+                                         self.calibration)
+
+    def shutdown(self):
+        pass

--- a/donkeycar/parts/uncertainty_viewer.html
+++ b/donkeycar/parts/uncertainty_viewer.html
@@ -1,0 +1,558 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>DonkeyCar Uncertainty Viewer</title>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: #f5f6f8; color: #24292f;
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  header {
+    background: #fff; border-bottom: 1px solid #d8dee4;
+    padding: 10px 18px; display: flex; align-items: baseline; gap: 14px;
+    flex-wrap: wrap;
+  }
+  header h1 { font-size: 16px; margin: 0; }
+  header .meta { font-size: 12px; color: #57606a; }
+  main { max-width: 1280px; margin: 14px auto; padding: 0 14px; }
+  .panel {
+    background: #fff; border: 1px solid #d8dee4; border-radius: 6px;
+    padding: 12px; margin-bottom: 14px;
+  }
+  /* The wrapper's aspect ratio is set from the first real frame that loads
+     (see seek()), so the stage matches the actual footage instead of a
+     hardcoded 4:3 that letterboxes 16:9 frames. 16/9 is only the starting
+     guess before anything has loaded. Keeping the ratio on the wrapper (not
+     the img) means the "unavailable" placeholder, which has its own size,
+     drops into the same box without shifting the layout. */
+  #img-wrap { position: relative; background: #0d1117; border-radius: 4px;
+              display: flex; align-items: center; justify-content: center;
+              overflow: hidden; aspect-ratio: 16 / 9; max-height: 78vh; }
+  #frame-img {
+    image-rendering: auto; display: block;
+    width: 100%; height: 100%; object-fit: contain;
+  }
+  #badge {
+    position: absolute; top: 8px; left: 8px; font-size: 11px;
+    background: rgba(0,0,0,.65); color: #fff; padding: 3px 8px;
+    border-radius: 10px;
+  }
+  #controls { display: flex; align-items: center; gap: 10px; margin-top: 10px;
+              flex-wrap: wrap; font-size: 13px; }
+  button, select {
+    font: inherit; padding: 4px 12px; border: 1px solid #d0d7de;
+    border-radius: 6px; background: #f6f8fa; cursor: pointer;
+  }
+  button:hover, select:hover { background: #eef1f4; }
+  #play { min-width: 84px; font-weight: 600; }
+  #scrub { width: 100%; margin-top: 10px; }
+  #readout { margin-top: 6px; font-size: 13px; color: #57606a;
+             font-variant-numeric: tabular-nums; min-height: 18px; }
+  #readout b { color: #24292f; }
+  #layer-explain { margin-top: 10px; padding: 10px 12px; background: #eef6ff;
+                   border: 1px solid #bcdcff; border-radius: 6px;
+                   font-size: 12.5px; line-height: 1.5; color: #1c3d5a; }
+  #layer-explain .term { font-weight: 700; color: #0969da; }
+  #layer-explain .tech { font-weight: 400; color: #57606a; font-size: 11.5px; }
+  .glossary-toggle { background: none; border: none; color: #0969da;
+                      font: inherit; font-size: 12px; cursor: pointer;
+                      padding: 2px 0; text-decoration: underline; }
+  .glossary-toggle:hover { color: #0550ae; }
+  #glossary { display: none; margin-top: 8px; padding: 10px 12px;
+              background: #f6f8fa; border: 1px solid #d8dee4;
+              border-radius: 6px; font-size: 12.5px; line-height: 1.6; }
+  #glossary dt { font-weight: 700; color: #24292f; margin-top: 6px; }
+  #glossary dt:first-child { margin-top: 0; }
+  #glossary dd { margin: 2px 0 0 0; color: #444d56; }
+  #graph { width: 100%; height: 170px; display: block; cursor: crosshair; }
+  .graph-title { font-size: 12px; color: #57606a; margin: 0 0 6px 2px; }
+  .legend { font-size: 11px; color: #57606a; margin-top: 4px; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 4px;
+         vertical-align: middle; margin: 0 3px 0 8px; }
+  .series-missing { flex-basis: 100%; font-size: 11.5px; color: #7d4e00;
+                    background: #fff8e5; border: 1px solid #f0d999;
+                    border-radius: 5px; padding: 5px 8px; margin-top: 4px; }
+  .series-legend { display: flex; flex-wrap: wrap; gap: 4px 16px;
+                    margin-top: 8px; font-size: 12.5px; }
+  .series-item { display: inline-flex; align-items: center; gap: 5px;
+                 cursor: pointer; user-select: none; color: #24292f; }
+  .series-item input[type="checkbox"] { margin: 0; cursor: pointer; }
+  .series-item input:disabled ~ .dot { opacity: .35; }
+  .series-item:has(input:disabled) { color: #8b949e; cursor: default; }
+  .hint { font-size: 11px; color: #8b949e; margin-top: 8px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>DonkeyCar Uncertainty Viewer</h1>
+  <span class="meta" id="meta">loading&hellip;</span>
+</header>
+
+<main>
+  <div class="panel">
+    <div id="img-wrap">
+      <img id="frame-img" alt="camera frame">
+      <span id="badge" hidden></span>
+    </div>
+    <div id="controls">
+      <button id="play">&#9654; Play</button>
+      <label>speed
+        <select id="fps">
+          <option value="2">2 fps</option>
+          <option value="5" selected>5 fps</option>
+          <option value="10">10 fps</option>
+        </select>
+      </label>
+      <label>layer
+        <select id="layer">
+          <option value="overlay" selected>Where the model was unsure (uncertainty)</option>
+          <option value="attention">Where the model looked (Grad-CAM)</option>
+          <option value="attention_pp">Where the model looked, sharper (Grad-CAM++)</option>
+          <option value="novelty">Have I seen this before? (novelty)</option>
+          <option value="saliency">Exact pixels that mattered (saliency)</option>
+          <option value="integrated_gradients">Exact pixels that mattered, cleaner (integrated gradients)</option>
+          <option value="orig">Just the camera</option>
+          <option value="model_input">What the model actually sees (transformed)</option>
+        </select>
+      </label>
+      <label><input type="checkbox" id="analyzed-only"> analysed frames only</label>
+      <label id="draw-on-mi-wrap" style="display:none"><input type="checkbox" id="draw-on-mi"> draw on model input</label>
+    </div>
+    <div id="layer-explain"></div>
+    <input type="range" id="scrub" min="0" max="0" value="0" step="1">
+    <div id="readout"></div>
+    <button class="glossary-toggle" id="glossary-btn" type="button">What do confidence / novelty / stability / variance mean? ▾</button>
+    <dl id="glossary">
+      <dt>variance</dt>
+      <dd>The raw, uncalibrated number underneath every % score below. On its
+        own it isn't meaningful (its scale depends on this specific model) --
+        the percentages are what you should actually read.</dd>
+      <dt>confidence %</dt>
+      <dd>Ask the model the same question 15 times, each time with a random
+        slice of its "brain" (dropout) switched off -- like asking 15 slightly
+        different clones. If the clones agree, confidence is high. This
+        measures whether the model agrees with <em>itself</em>, not whether
+        it's actually right.</dd>
+      <dt>novelty %</dt>
+      <dd>How far this scene's internal features are from anything the model
+        saw during training -- "does this remind me of anything I've driven
+        through before?" A model can be confident (its clones agree) about a
+        scene it has never truly seen, which novelty is built to catch.</dd>
+      <dt>TTA stability %</dt>
+      <dd>Show the model the same photo 8 times, each time with the
+        brightness/contrast/noise tweaked slightly -- like showing a photo at
+        noon, at dusk, through foggy glasses. If the answer barely changes,
+        stability is high. A low score means the model is fragile to
+        lighting/noise, a different failure mode from low confidence or high
+        novelty.</dd>
+    </dl>
+  </div>
+
+  <div class="panel">
+    <p class="graph-title" id="graph-title">Signals over drive</p>
+    <canvas id="graph"></canvas>
+    <div class="series-legend" id="series-legend"></div>
+    <div class="legend">
+      <span class="dot" style="background:#fb8c00"></span>analysed frame (has
+      overlay images)
+      <span class="dot" style="background:#24292f"></span>current position
+      &mdash; click the graph to jump
+    </div>
+    <p class="hint">Relative per-model signal, not a calibrated probability.
+      Independent of the layer dropdown above -- tick/untick to compare.
+      Space = play/pause, &larr;/&rarr; = step.</p>
+  </div>
+</main>
+
+<script>
+(function () {
+  'use strict';
+  const $ = id => document.getElementById(id);
+  const img = $('frame-img'), imgWrap = $('img-wrap'), badge = $('badge'),
+        scrub = $('scrub'),
+        playBtn = $('play'), fpsSel = $('fps'), layerSel = $('layer'),
+        analyzedOnly = $('analyzed-only'), readout = $('readout'),
+        canvas = $('graph'), layerExplain = $('layer-explain'),
+        glossaryBtn = $('glossary-btn'), glossary = $('glossary'),
+        drawOnMi = $('draw-on-mi'), drawOnMiWrap = $('draw-on-mi-wrap');
+
+  // Plain-language explanation for whichever layer is currently selected,
+  // technical name kept alongside rather than removed -- same information for
+  // every reader, just introduced before the jargon instead of instead of it.
+  const LAYER_INFO = {
+    overlay: {
+      term: 'Where the model was unsure', tech: 'uncertainty / Grad-CAM variance',
+      text: 'Runs Grad-CAM once per dropout sub-network, then highlights spots ' +
+            'where those sub-networks pointed at different things. Bright = ' +
+            'the sub-networks disagreed about where to look here.'
+    },
+    attention: {
+      term: 'Where the model looked', tech: 'Grad-CAM',
+      text: 'Shows which part of the image most influenced the steering ' +
+            'decision, averaged across the sub-networks. Bright = this region ' +
+            'mattered a lot to the prediction.'
+    },
+    attention_pp: {
+      term: 'Where the model looked, sharper', tech: 'Grad-CAM++',
+      text: 'A refined version of the map above: gives more credit to pixels ' +
+            'that individually pushed the prediction hardest, so it can show ' +
+            'several important regions clearly (e.g. both lane lines) instead ' +
+            'of blurring them into one blob.'
+    },
+    novelty: {
+      term: 'Have I seen this before?', tech: 'feature-space novelty / OOD',
+      text: 'Shows which parts of the image look unlike anything in the ' +
+            'training data -- about familiarity, not confidence. A model can ' +
+            'be confident (its sub-networks agree) about a scene it has never ' +
+            'truly seen; this layer is built to catch exactly that case.'
+    },
+    saliency: {
+      term: 'Exact pixels that mattered', tech: 'vanilla-gradient saliency',
+      text: 'Instead of coarse regions, this asks pixel-by-pixel: how much ' +
+            'would changing this exact pixel change the steering prediction? ' +
+            'Tends to look speckled/noisy -- that is a real property of this ' +
+            'technique, not a bug.'
+    },
+    integrated_gradients: {
+      term: 'Exact pixels that mattered, cleaner', tech: 'Integrated Gradients',
+      text: 'A more rigorous version of the pixel map above. Instead of one ' +
+            'noisy snapshot, it averages pixel-importance along a path from a ' +
+            'blank black image up to the real photo, cancelling out a lot of ' +
+            'the speckle.'
+    },
+    orig: {
+      term: 'Just the camera', tech: '',
+      text: 'No AI overlay -- the plain camera frame, for reference against ' +
+            'the layers above.'
+    },
+    model_input: {
+      term: 'What the model actually sees', tech: 'TRANSFORMATIONS applied',
+      text: 'The camera frame after the configured TRANSFORMATIONS / ' +
+            'POST_TRANSFORMATIONS (crop, edge detection, colour ' +
+            'conversion). This -- not the plain camera frame -- is the input ' +
+            'every heat map above is computed against, so if it looks wrong ' +
+            'here the model is genuinely being fed something wrong. Only ' +
+            'present when the pipeline actually changes the image.'
+    },
+  };
+
+  function updateLayerExplain() {
+    const info = LAYER_INFO[layerSel.value];
+    if (!info) { layerExplain.innerHTML = ''; return; }
+    layerExplain.innerHTML =
+      '<span class="term">' + info.term + '</span>' +
+      (info.tech ? ' <span class="tech">(' + info.tech + ')</span>' : '') +
+      ' &mdash; ' + info.text;
+  }
+
+  glossaryBtn.addEventListener('click', () => {
+    const open = glossary.style.display === 'block';
+    glossary.style.display = open ? 'none' : 'block';
+    glossaryBtn.textContent = (open ? 'What do confidence / novelty / '
+      + 'stability / variance mean? ▾' : 'Hide glossary ▴');
+  });
+
+  const PLACEHOLDER = 'data:image/svg+xml;utf8,' + encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="240">' +
+    '<rect width="100%" height="100%" fill="#161b22"/>' +
+    '<text x="50%" y="50%" fill="#8b949e" font-size="13" ' +
+    'font-family="sans-serif" text-anchor="middle">camera frame ' +
+    'unavailable</text></svg>');
+
+  let data = null, timeline = [], analyzedPos = [], pos = 0, timer = null;
+
+  // Graph series are the full-timeline scalar signals -- deliberately
+  // independent of the image-layer dropdown above, since most image layers
+  // (Grad-CAM++, saliency, integrated gradients) only have a value for the
+  // analysed top-K frames, not a per-frame number across the whole drive.
+  // Tick/untick any combination to compare signals directly.
+  const SERIES_DEFS = [
+    { key: 'confidence', label: 'Confidence', color: '#0969da' },
+    { key: 'novelty_score', label: 'Novelty', color: '#cf222e' },
+    { key: 'tta_stability', label: 'TTA stability', color: '#1a7f37' },
+  ];
+  let series = [];       // [{key,label,color,enabled}] -- what actually got drawn
+  let usingRawFallback = false, varMax = 1;
+
+  fetch('data.json').then(r => {
+    if (!r.ok) throw new Error('data.json not found (' + r.status + ')');
+    return r.json();
+  }).then(d => {
+    data = d;
+    timeline = d.timeline || [];
+    if (!timeline.length) throw new Error('empty timeline in data.json');
+
+    timeline.forEach((e, i) => {
+      if (d.frames && d.frames[String(e.index)]) analyzedPos.push(i);
+    });
+
+    // Only offer the model-input toggle when the transformation pipeline
+    // actually changed the pixels -- otherwise the two overlay variants
+    // would be identical and the checkbox would be a no-op.
+    if (drawOnMiWrap && d.model_input_available) {
+      drawOnMiWrap.style.display = '';
+    }
+
+    series = SERIES_DEFS
+      .filter(s => timeline.some(e => e[s.key] !== null && e[s.key] !== undefined))
+      .map(s => ({ ...s, enabled: true }));
+    usingRawFallback = series.length === 0;
+    if (usingRawFallback) {
+      // No calibrated % signal anywhere in this timeline (e.g. no calib.json
+      // when this analysis was run) -- fall back to the one thing every
+      // timeline always has: raw steering variance.
+      series = [{ key: 'variance', label: 'Steering variance (raw)',
+                 color: '#0969da', enabled: true, raw: true }];
+      varMax = Math.max(1e-9, ...timeline.map(e => e.variance || 0));
+    }
+    buildSeriesLegend();
+
+    $('meta').textContent =
+      d.model + ' · ' + (d.tub || '') + ' · N=' + d.num_passes +
+      ' · ' + d.n_analyzed + '/' + d.n_records +
+      ' frames analysed · ' + (d.created || '');
+    $('graph-title').textContent = usingRawFallback ?
+      'Steering variance over drive' : 'Signals over drive (%)';
+    scrub.max = timeline.length - 1;
+    seek(analyzedPos.length ? analyzedPos[0] : 0);
+    window.addEventListener('resize', drawGraph);
+  }).catch(err => {
+    $('meta').textContent = 'Error: ' + err.message;
+  });
+
+  function buildSeriesLegend() {
+    const el = $('series-legend');
+    el.innerHTML = '';
+    series.forEach(s => {
+      const label = document.createElement('label');
+      label.className = 'series-item';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = s.enabled;
+      cb.disabled = usingRawFallback;   // nothing to toggle with just one series
+      cb.addEventListener('change', () => { s.enabled = cb.checked; drawGraph(); });
+      const dot = document.createElement('span');
+      dot.className = 'dot';
+      dot.style.background = s.color;
+      label.appendChild(cb);
+      label.appendChild(dot);
+      label.appendChild(document.createTextNode(s.label));
+      el.appendChild(label);
+    });
+
+    // Say WHY a signal is absent rather than just leaving it out of the
+    // legend -- "not calibrated" and "calibrated but flat" look identical on
+    // a graph, and only one of them is something the user can act on.
+    const missing = (data && data.signals_unavailable) || [];
+    if (missing.length) {
+      const note = document.createElement('div');
+      note.className = 'series-missing';
+      note.textContent = 'Not shown: ' + missing
+        .map(m => m.label + ' (' + m.reason + ')').join('; ')
+        + '. Re-run calibration on this model to add them.';
+      el.appendChild(note);
+    }
+  }
+
+  function entryImage(entry) {
+    const f = data.frames && data.frames[String(entry.index)];
+    if (f) {
+      const layer = layerSel.value;
+      // When 'draw on model input' is ticked, prefer the '_mi' variant of
+      // whichever heat map is selected. Those are drawn straight onto the
+      // transformed image, so they need no crop mapping and are exact by
+      // construction; the default variants are projected back onto the raw
+      // frame instead. Novelty has no _mi variant on purpose -- it is
+      // measured on raw pixels, so it is already in raw coordinates.
+      if (drawOnMi && drawOnMi.checked && f[layer + '_mi']) {
+        return f[layer + '_mi'];
+      }
+      if (layer === 'attention') return f.attention;
+      if (layer === 'orig') return f.orig;
+      // absent when the pipeline is a no-op (nothing to show that the
+      // 'orig' layer doesn't already show) or on older analyses.
+      if (layer === 'model_input') return f.model_input || null;
+      // attention++ / IG maps may be absent on analyses produced before those
+      // layers existed -- fall through to unavailable rather than the overlay.
+      if (layer === 'attention_pp') return f.attention_pp || null;
+      if (layer === 'integrated_gradients') return f.integrated_gradients || null;
+      // novelty map may be absent even on an analysed frame if the model's
+      // calibration predates novelty stats -- fall through to unavailable.
+      if (layer === 'novelty') return f.novelty || null;
+      if (layer === 'saliency') return f.saliency || null;
+      return f.overlay;
+    }
+    if (entry.image) return entry.image;          // exported frames/
+    if (entry.tub_image) return 'tub/' + entry.tub_image;
+    return null;
+  }
+
+  function seek(p) {
+    pos = Math.max(0, Math.min(timeline.length - 1, p));
+    const entry = timeline[pos];
+    const f = data.frames && data.frames[String(entry.index)];
+
+    updateLayerExplain();
+    const src = entryImage(entry);
+    img.onerror = () => { img.onerror = null; img.src = PLACEHOLDER;
+                          showBadge('frame image unavailable'); };
+    // Size the stage to whatever this frame actually is. Camera frames and
+    // model-sized overlays don't always share a ratio, so read it per load
+    // rather than assuming one.
+    img.onload = () => {
+      if (img.src === PLACEHOLDER) return;   // keep the last real ratio
+      const w = img.naturalWidth, h = img.naturalHeight;
+      if (w > 0 && h > 0) imgWrap.style.aspectRatio = w + ' / ' + h;
+    };
+    if (src) { img.src = src; } else { img.src = PLACEHOLDER; }
+
+    if (f) {
+      if (layerSel.value === 'orig') showBadge('analysed · overlays hidden');
+      else if (layerSel.value === 'novelty' && !f.novelty)
+        showBadge('no novelty map for this frame (model has no novelty calibration)');
+      else if (layerSel.value === 'attention_pp' && !f.attention_pp)
+        showBadge('no attention++ map (analysis predates Grad-CAM++)');
+      else if (layerSel.value === 'integrated_gradients' && !f.integrated_gradients)
+        showBadge('no integrated-gradients map (analysis predates this layer)');
+      else badge.hidden = true;
+    } else {
+      showBadge('no uncertainty map for this frame');
+    }
+
+    scrub.value = pos;
+    const t0 = timeline[0].timestamp_ms || 0;
+    const dt = ((entry.timestamp_ms || t0) - t0) / 1000;
+    let txt = '<b>frame ' + entry.index + '</b> · t=+' + dt.toFixed(1) +
+              's · variance ' + (entry.variance === null ||
+                                 entry.variance === undefined
+                                 ? 'n/a' : entry.variance.toFixed(5));
+    if (entry.confidence !== null && entry.confidence !== undefined)
+      txt += ' · confidence <b>' + Math.round(entry.confidence) + '%</b>';
+    if (entry.novelty_score !== null && entry.novelty_score !== undefined)
+      txt += ' · novelty <b>' + Math.round(entry.novelty_score) + '%</b>';
+    if (entry.tta_stability !== null && entry.tta_stability !== undefined)
+      txt += ' · TTA stability <b>' + Math.round(entry.tta_stability) + '%</b>';
+    readout.innerHTML = txt;
+    drawGraph();
+  }
+
+  function showBadge(text) { badge.textContent = text; badge.hidden = false; }
+
+  // ---- playback ----------------------------------------------------------
+  function stepForward() {
+    if (analyzedOnly.checked && analyzedPos.length) {
+      const next = analyzedPos.find(p => p > pos);
+      if (next === undefined) { pause(); return; }
+      seek(next);
+    } else {
+      if (pos >= timeline.length - 1) { pause(); return; }
+      seek(pos + 1);
+    }
+  }
+  function stepBack() {
+    if (analyzedOnly.checked && analyzedPos.length) {
+      const prev = [...analyzedPos].reverse().find(p => p < pos);
+      if (prev !== undefined) seek(prev);
+    } else seek(pos - 1);
+  }
+  function play() {
+    if (pos >= timeline.length - 1) seek(0);       // replay from start
+    timer = setInterval(stepForward, 1000 / parseFloat(fpsSel.value));
+    playBtn.innerHTML = '&#10074;&#10074; Pause';
+  }
+  function pause() {
+    clearInterval(timer); timer = null;
+    playBtn.innerHTML = '&#9654; Play';
+  }
+  playBtn.addEventListener('click', () => timer ? pause() : play());
+  fpsSel.addEventListener('change', () => { if (timer) { pause(); play(); } });
+  layerSel.addEventListener('change', () => seek(pos));
+  if (drawOnMi) drawOnMi.addEventListener('change', () => seek(pos));
+  scrub.addEventListener('input', () => seek(parseInt(scrub.value, 10)));
+  document.addEventListener('keydown', e => {
+    if (e.target.tagName === 'SELECT' || e.target.tagName === 'INPUT') return;
+    if (e.code === 'Space') { e.preventDefault(); timer ? pause() : play(); }
+    if (e.code === 'ArrowRight') { pause(); stepForward(); }
+    if (e.code === 'ArrowLeft') { pause(); stepBack(); }
+  });
+
+  // ---- signals graph -------------------------------------------------------
+  function seriesValue(s, e) {
+    // Keep a missing variance as null (a gap in the line), not 0 -- 0 is the
+    // lowest possible variance and would read as "maximally certain here".
+    const v = s.raw ? e.variance : e[s.key];
+    return (v === null || v === undefined) ? null : v;
+  }
+  function drawGraph() {
+    if (!timeline.length) return;
+    const dpr = window.devicePixelRatio || 1;
+    const W = canvas.clientWidth * dpr, H = canvas.clientHeight * dpr;
+    canvas.width = W; canvas.height = H;
+    const ctx = canvas.getContext('2d');
+    const pad = { l: 40 * dpr, r: 8 * dpr, t: 8 * dpr, b: 20 * dpr };
+    const yMax = usingRawFallback ? varMax * 1.05 : 100;
+    const n = timeline.length;
+    const x = i => pad.l + (n === 1 ? 0 : i / (n - 1)) * (W - pad.l - pad.r);
+    const y = v => H - pad.b - (v / yMax) * (H - pad.t - pad.b);
+
+    // axes + gridlines
+    ctx.strokeStyle = '#d8dee4'; ctx.fillStyle = '#8b949e';
+    ctx.lineWidth = dpr; ctx.font = (10 * dpr) + 'px sans-serif';
+    ctx.textAlign = 'right'; ctx.textBaseline = 'middle';
+    const ticks = usingRawFallback ? [0, yMax / 2, yMax] : [0, 25, 50, 75, 100];
+    ticks.forEach(tv => {
+      ctx.beginPath(); ctx.moveTo(pad.l, y(tv)); ctx.lineTo(W - pad.r, y(tv));
+      ctx.stroke();
+      ctx.fillText(usingRawFallback ? tv.toExponential(0) : tv,
+                   pad.l - 5 * dpr, y(tv));
+    });
+
+    // one polyline per ticked series; a null/undefined value breaks the line
+    // into a gap instead of dropping to 0 (which would misread as "measured
+    // zero" rather than "no data this frame").
+    series.forEach(s => {
+      if (!s.enabled) return;
+      ctx.strokeStyle = s.color; ctx.lineWidth = 1.4 * dpr;
+      ctx.beginPath();
+      let drawing = false;
+      timeline.forEach((e, i) => {
+        const v = seriesValue(s, e);
+        if (v === null) { drawing = false; return; }
+        const px = x(i), py = y(v);
+        if (!drawing) { ctx.moveTo(px, py); drawing = true; }
+        else ctx.lineTo(px, py);
+      });
+      ctx.stroke();
+    });
+
+    // analysed-frame markers: a fixed row along the top edge, independent of
+    // which series are ticked (an analysed frame has overlay images
+    // regardless of which scalar signal you're currently comparing).
+    ctx.fillStyle = '#fb8c00';
+    analyzedPos.forEach(i => {
+      ctx.beginPath();
+      ctx.arc(x(i), pad.t + 3 * dpr, 2.2 * dpr, 0, 7);
+      ctx.fill();
+    });
+
+    // cursor
+    ctx.strokeStyle = '#24292f'; ctx.lineWidth = 1.6 * dpr;
+    ctx.beginPath(); ctx.moveTo(x(pos), pad.t);
+    ctx.lineTo(x(pos), H - pad.b); ctx.stroke();
+  }
+  canvas.addEventListener('click', e => {
+    const rect = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const padL = 40, padR = 8;
+    const frac = (e.clientX - rect.left - padL) /
+                 (rect.width - padL - padR);
+    pause();
+    seek(Math.round(frac * (timeline.length - 1)));
+  });
+})();
+</script>
+</body>
+</html>

--- a/donkeycar/parts/uncertainty_viewer.py
+++ b/donkeycar/parts/uncertainty_viewer.py
@@ -1,0 +1,560 @@
+"""
+Local web viewer for Grad-CAM uncertainty analyses (Feature 4 of the
+uncertainty toolkit) -- and, when no analysis is given yet, a small local
+GUI ("launcher") for running one, so you never have to type the full
+``python -m donkeycar.parts.gradcam_uncertainty --tub ... --model ...``
+command line by hand.
+
+Serves the output folder produced by ``donkeycar.parts.gradcam_uncertainty``
+together with a small self-contained web page (no internet required) that
+provides:
+
+  * the camera frame with the uncertainty-map overlay (or mean attention,
+    novelty, saliency, or the plain frame),
+  * a confidence-over-time graph for the whole drive with the current
+    position marked, click-to-jump,
+  * video-like playback (play/pause at a configurable 2-10 fps, scrub bar,
+    arrow-key stepping, optional "analysed frames only" mode).
+
+Frames without a precomputed uncertainty map simply show the camera frame
+(from the analysis dir if it was created with ``--export-frames``, else
+straight from the tub's images/ folder when the tub is available locally).
+
+**Launcher mode**: if ``--analysis`` is omitted (or points at a directory
+with no ``data.json`` yet), the server shows a form instead of the viewer:
+pick a tub and model (autodiscovered from ``data/`` and ``models/`` in the
+current directory, or typed by hand), choose which frames to analyse, and
+click Run. The analysis runs in this same process on a background thread
+(reusing ``gradcam_uncertainty.analyze_tub`` directly -- no subprocess), the
+page polls progress, and once done the server starts serving the viewer for
+the new output directory automatically -- no second command.
+
+Usage:
+    python -m donkeycar.parts.uncertainty_viewer [--analysis <dir>] \
+        [--tub <tub_dir>] [--config <config.py>] [--port 8890] [--host 127.0.0.1]
+
+Then open http://localhost:8890 in a browser.
+"""
+import argparse
+import copy
+import json
+import logging
+import os
+import threading
+import time
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs
+
+logger = logging.getLogger(__name__)
+
+HTML_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         'uncertainty_viewer.html')
+LAUNCHER_HTML_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                  'analysis_launcher.html')
+
+
+class LauncherState:
+    """
+    Owns the background analysis thread and its progress state. One instance
+    per server process, shared (read via a lock) across request-handling
+    threads.
+    """
+
+    def __init__(self, cfg, cwd):
+        self.cfg = cfg
+        self.cwd = cwd
+        self._lock = threading.Lock()
+        self._progress = {'running': False, 'done': False, 'error': None,
+                          'stage': None, 'current': 0, 'total': 0,
+                          'out_dir': None, 'calibration_warning': None}
+
+    def progress_snapshot(self):
+        with self._lock:
+            return dict(self._progress)
+
+    def _set(self, **kwargs):
+        with self._lock:
+            self._progress.update(kwargs)
+
+    def scan_defaults(self):
+        """Best-effort discovery of tub dirs (contain manifest.json) and
+        model .h5 files under the current directory, for the form's
+        suggestion lists. Returns {} entries if nothing found -- the form
+        fields are free text either way."""
+        tubs = []
+        data_dir = os.path.join(self.cwd, 'data')
+        if os.path.isfile(os.path.join(data_dir, 'manifest.json')):
+            tubs.append('data')
+        if os.path.isdir(data_dir):
+            for name in sorted(os.listdir(data_dir)):
+                p = os.path.join(data_dir, name)
+                if os.path.isdir(p) and os.path.isfile(
+                        os.path.join(p, 'manifest.json')):
+                    tubs.append(os.path.join('data', name))
+
+        models = []
+        models_dir = os.path.join(self.cwd, 'models')
+        if os.path.isdir(models_dir):
+            for name in sorted(os.listdir(models_dir)):
+                lower = name.lower()
+                # Skip the OOD-encoder sidecars this toolkit writes next to
+                # each model (<model>.novelty_encoder.h5). They're .h5 files
+                # but not pilots, and offering them here doubles the list with
+                # entries that can only ever fail if picked.
+                if lower.endswith('.novelty_encoder.h5'):
+                    continue
+                if lower.endswith('.h5'):
+                    models.append(os.path.join('models', name))
+
+        return {'tubs': tubs, 'models': models}
+
+    def tub_record_count(self, tub_path):
+        """
+        Best-effort total record count for a tub, read from its
+        ``manifest.json`` (a few small JSON-per-line records -- no need to
+        load the whole catalog dataset just to size the form's validation).
+        Returns None if it can't be determined (bad path, unexpected
+        manifest format).
+        """
+        manifest_path = os.path.join(
+            os.path.expanduser(tub_path), 'manifest.json')
+        if not os.path.isfile(manifest_path):
+            return None
+        try:
+            with open(manifest_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    d = json.loads(line)
+                    if isinstance(d, dict) and 'current_index' in d:
+                        n_deleted = len(d.get('deleted_indexes', []))
+                        return max(0, d['current_index'] - n_deleted)
+        except Exception as e:
+            logger.debug(f'tub_record_count({tub_path}) failed: {e}')
+        return None
+
+    def training_tubs_for_model(self, model_path):
+        """Best-effort lookup of the tub(s) `model_path` was actually trained
+        on (see ``mc_calibrate.find_training_tubs``), for pre-filling the
+        form's "Calibration tub" field. Returns None if unknown."""
+        try:
+            from donkeycar.parts.mc_calibrate import find_training_tubs
+            return find_training_tubs(self.cfg, os.path.expanduser(model_path))
+        except Exception as e:
+            logger.debug(f'training_tubs_for_model({model_path}) failed: {e}')
+            return None
+
+    def saved_pipeline_for_model(self, model_path):
+        """
+        Read `model_path`'s ``.preprocessing.json`` sidecar (written by
+        training, see ``image_transformations.save_preprocessing_metadata``)
+        and return its recorded pipeline, so the form can show what a model
+        actually expects before the user decides whether to accept this
+        launcher's config or type an override. Returns None if no sidecar
+        exists (e.g. a model trained before this tracking existed).
+        """
+        from donkeycar.parts.image_transformations import _sidecar_path_for
+        sidecar_path = _sidecar_path_for(os.path.expanduser(model_path))
+        if not os.path.isfile(sidecar_path):
+            return None
+        try:
+            with open(sidecar_path) as f:
+                saved = json.load(f)
+        except Exception as e:
+            logger.debug(f'saved_pipeline_for_model({model_path}) failed: {e}')
+            return None
+        return {
+            'pipeline_steps': saved.get('pipeline_steps'),
+        }
+
+    def has_calibration(self, model_path):
+        """Whether `model_path` already has a saved `<model>.calib.json`
+        (see ``mc_calibrate.default_calib_path``), for the form's
+        auto-calibrate checkbox default."""
+        from donkeycar.parts.mc_calibrate import default_calib_path
+        return os.path.isfile(
+            default_calib_path(os.path.expanduser(model_path)))
+
+    def start(self, form):
+        with self._lock:
+            if self._progress['running']:
+                raise RuntimeError('An analysis is already running.')
+            self._progress = {'running': True, 'done': False, 'error': None,
+                              'stage': 'starting', 'current': 0, 'total': 0,
+                              'out_dir': None, 'calibration_warning': None}
+        thread = threading.Thread(target=self._run, args=(form,), daemon=True)
+        thread.start()
+
+    def _run(self, form):
+        try:
+            tub = form['tub']
+            model = form['model']
+            if not tub or not model:
+                raise ValueError('Tub and model paths are required.')
+            mode = form.get('mode', 'top_k')
+            out_dir = form.get('out') or os.path.join(
+                os.path.expanduser(tub), 'gradcam_analysis')
+
+            def cb(stage, current, total):
+                self._set(stage=stage, current=current, total=total)
+
+            # This server's cfg is fixed at startup (from --config), so it
+            # was almost never trained alongside every model the form could
+            # point at -- it's the wrong pipeline for any model that used a
+            # different one. A comma-separated override in the form lets the
+            # user say "use THIS pipeline for this run" instead of restarting
+            # the whole launcher with a different --config per model.
+            # Applied to POST_TRANSFORMATIONS, matching how this project
+            # actually uses these settings (TRANSFORMATIONS stays empty,
+            # everything goes in POST_TRANSFORMATIONS). copy.copy() so the
+            # override never leaks
+            # into self.cfg and affect a later run that doesn't ask for it.
+            override_raw = (form.get('transformations_override') or '').strip()
+            if override_raw:
+                override_steps = [s.strip().upper() for s in
+                                  override_raw.split(',') if s.strip()]
+                run_cfg = copy.copy(self.cfg)
+                run_cfg.POST_TRANSFORMATIONS = override_steps
+                verify_preprocessing = False
+                logger.info(
+                    f'Transformations override from the form: '
+                    f'POST_TRANSFORMATIONS={override_steps} for this run '
+                    f'only. Skipping the saved-pipeline check since this is '
+                    f'an explicit override.')
+            else:
+                run_cfg = self.cfg
+                verify_preprocessing = True
+
+            from donkeycar.parts.mc_calibrate import (default_calib_path,
+                                                      calibrate_from_tub,
+                                                      find_training_tubs)
+            calib_path = default_calib_path(os.path.expanduser(model))
+            # Auto-calibrate models that have never been calibrated, so a
+            # first-time user gets confidence/novelty %% without having to
+            # know `mc_calibrate` exists as a separate command. Opt-out via
+            # the form checkbox; a calibration failure here degrades to the
+            # pre-existing behaviour (variance-only) rather than blocking the
+            # analysis the user actually asked for.
+            #
+            # IMPORTANT: calibration establishes "what does normal (training)
+            # data look like" -- it must run against the tub(s) the model was
+            # actually TRAINED on, not necessarily the tub being analysed here
+            # (which is very often a separate inference/test drive). Using the
+            # analysis tub as the calibration baseline would make novelty mean
+            # "unlike this other drive" instead of "unlike what the model
+            # learned" -- silently defeating the point of the signal. Priority
+            # order: (1) a tub the user explicitly typed into the "Calibration
+            # tub" field, (2) the real training tub(s) looked up from
+            # DonkeyCar's own training database, (3) the analysis tub as a
+            # last resort -- with a visible warning, not just a log line, for
+            # (3) since it's the one case that's likely wrong.
+            if (form.get('auto_calibrate', True)
+                    and not os.path.exists(calib_path)):
+                calib_tub_override = (form.get('calib_tub') or '').strip()
+                if calib_tub_override:
+                    calib_tubs = [t.strip() for t in
+                                 calib_tub_override.split(',') if t.strip()]
+                    logger.info(f'No calibration at {calib_path}; '
+                                f'auto-calibrating against the user-specified '
+                                f'tub(s): {calib_tubs}')
+                else:
+                    training_tubs = find_training_tubs(run_cfg, model)
+                    if training_tubs:
+                        calib_tubs = training_tubs
+                        logger.info(f'No calibration at {calib_path}; '
+                                    f'auto-calibrating against this model\'s '
+                                    f'recorded training tub(s): {calib_tubs}')
+                    else:
+                        calib_tubs = [tub]
+                        warning = (
+                            f'Could not find this model\'s recorded training '
+                            f'tub (no models/database.json entry, and no '
+                            f'"Calibration tub" was specified), so '
+                            f'calibration used the ANALYSIS tub ({tub}) '
+                            f'instead. If that is not the tub this model was '
+                            f'actually trained on, confidence/novelty %% here '
+                            f'are calibrated against the wrong baseline -- '
+                            f'specify the real training tub and recalibrate '
+                            f'for meaningful numbers.')
+                        logger.warning(warning)
+                        self._set(calibration_warning=warning)
+                try:
+                    # Calibration replays training-tub frames through
+                    # TRANSFORMATIONS/POST_TRANSFORMATIONS too (it needs to
+                    # see what the model actually sees), so it must use the
+                    # same run_cfg as the analysis below - otherwise the
+                    # baseline and the analysis would be built from two
+                    # different pipelines, corrupting the novelty stats.
+                    calibrate_from_tub(run_cfg, calib_tubs, model,
+                                       progress_callback=cb)
+                except Exception as e:
+                    # Surfaced to the UI (not just logged) -- a bad tub path
+                    # here was previously silently swallowed, leaving the user
+                    # with no calibration and no idea why.
+                    msg = (f'Auto-calibration against {calib_tubs} failed: '
+                          f'{e}. Continuing without it -- confidence/'
+                          f'novelty %% will be unavailable.')
+                    logger.warning(msg)
+                    self._set(calibration_warning=msg)
+
+            from donkeycar.parts.gradcam_uncertainty import analyze_tub
+            analyze_tub(
+                run_cfg, tub, model, out_dir,
+                num_passes=getattr(run_cfg, 'XAI_CONFIDENCE_PASSES', 15),
+                alpha=getattr(run_cfg, 'XAI_CONFIDENCE_ALPHA', 0.2),
+                ig_steps=getattr(run_cfg, 'XAI_IG_STEPS', 32),
+                verify_preprocessing=verify_preprocessing,
+                top_k=int(form['value']) if mode == 'top_k'
+                      and form.get('value') else 50,
+                percentile=float(form['value']) if mode == 'percentile'
+                          and form.get('value') else None,
+                analyze_all=(mode == 'all'),
+                limit=int(form['limit']) if form.get('limit') else None,
+                start=int(form['start']) if form.get('start') else None,
+                export_frames=bool(form.get('export_frames')),
+                progress_callback=cb)
+
+            # Point the viewer at the freshly-produced analysis.
+            ViewerHandler.active_dir = os.path.abspath(out_dir)
+            candidate = os.path.join(os.path.expanduser(tub), 'images')
+            ViewerHandler.tub_images_dir = \
+                os.path.abspath(candidate) if os.path.isdir(candidate) else None
+
+            self._set(running=False, done=True, out_dir=out_dir)
+        except Exception as e:
+            logger.exception('Analysis failed')
+            self._set(running=False, done=True, error=str(e))
+
+
+class ViewerHandler(SimpleHTTPRequestHandler):
+    """
+    Serves either the analysis viewer (if ``active_dir`` has a ready
+    ``data.json``) or the launcher form (otherwise), plus a small JSON API
+    for the launcher (``/api/scan``, ``/api/run``, ``/api/progress``) and raw
+    camera frames at ``/tub/<filename>`` when a tub is available.
+
+    ``active_dir``/``tub_images_dir``/``launcher_state`` are mutable class
+    attributes rather than constructor args, because ``http.server`` creates
+    a fresh handler instance per request -- setting them here lets the
+    *directory being served* change at runtime (e.g. once a launcher-mode
+    analysis finishes) without restarting the server.
+    """
+
+    tub_images_dir = None
+    active_dir = None
+    launcher_state = None
+
+    def __init__(self, *args, **kwargs):
+        # NEVER fall back to os.getcwd(): in launcher mode that would hand the
+        # whole car directory -- myconfig.py and its credentials, models, tubs
+        # -- to anyone who can reach this port, which with --host 0.0.0.0 is
+        # the entire network. Serve only a real analysis dir; static file
+        # requests are refused outright until one exists (see _serve_static).
+        directory = ViewerHandler.active_dir or os.path.dirname(
+            os.path.abspath(__file__))
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def _serve_static(self, method):
+        """Hand off to the base handler, but only once an analysis directory
+        is actually being served."""
+        if ViewerHandler.active_dir is None:
+            return self.send_error(404, 'No analysis is being served yet.')
+        return method()
+
+    def _analysis_ready(self):
+        return (ViewerHandler.active_dir is not None
+                and os.path.isfile(
+                    os.path.join(ViewerHandler.active_dir, 'data.json')))
+
+    def do_GET(self):
+        if self.path.startswith('/') and '?' in self.path:
+            path, query = self.path.split('?', 1)
+        else:
+            path, query = self.path, ''
+
+        if path in ('/', '/index.html'):
+            force_launcher = 'new=1' in query
+            if not force_launcher and self._analysis_ready():
+                return self._send_file(HTML_PATH, 'text/html; charset=utf-8')
+            if ViewerHandler.launcher_state is not None:
+                return self._send_file(LAUNCHER_HTML_PATH,
+                                       'text/html; charset=utf-8')
+            return self.send_error(
+                404, 'No analysis available and launcher mode is off '
+                     '(pass --analysis, or run without it to enable the '
+                     'launcher).')
+
+        if path == '/api/scan':
+            if ViewerHandler.launcher_state is None:
+                return self.send_error(404)
+            return self._send_json(ViewerHandler.launcher_state.scan_defaults())
+
+        if path == '/api/progress':
+            if ViewerHandler.launcher_state is None:
+                return self._send_json({})
+            return self._send_json(
+                ViewerHandler.launcher_state.progress_snapshot())
+
+        if path == '/api/tub_info':
+            if ViewerHandler.launcher_state is None:
+                return self.send_error(404)
+            tub = parse_qs(query).get('tub', [''])[0]
+            if not tub:
+                return self._send_json({'error': 'no tub given'}, status=400)
+            n = ViewerHandler.launcher_state.tub_record_count(tub)
+            if n is None:
+                return self._send_json(
+                    {'error': f'could not read manifest.json for {tub}'},
+                    status=404)
+            return self._send_json({'n_records': n})
+
+        if path == '/api/training_tubs':
+            if ViewerHandler.launcher_state is None:
+                return self.send_error(404)
+            model = parse_qs(query).get('model', [''])[0]
+            if not model:
+                return self._send_json({'error': 'no model given'}, status=400)
+            tubs = ViewerHandler.launcher_state.training_tubs_for_model(model)
+            return self._send_json({'tubs': tubs})
+
+        if path == '/api/model_info':
+            if ViewerHandler.launcher_state is None:
+                return self.send_error(404)
+            model = parse_qs(query).get('model', [''])[0]
+            if not model:
+                return self._send_json({'error': 'no model given'}, status=400)
+            info = ViewerHandler.launcher_state.saved_pipeline_for_model(model)
+            result = info or {'pipeline_steps': None}
+            result['has_calibration'] = \
+                ViewerHandler.launcher_state.has_calibration(model)
+            return self._send_json(result)
+
+        if path.startswith('/tub/'):
+            if not self.tub_images_dir:
+                return self.send_error(404, 'tub not available')
+            # basename() blocks any path traversal
+            name = os.path.basename(path[len('/tub/'):])
+            file_path = os.path.join(self.tub_images_dir, name)
+            if not os.path.isfile(file_path):
+                return self.send_error(404)
+            ctype = 'image/png' if name.lower().endswith('.png') \
+                else 'image/jpeg'
+            return self._send_file(file_path, ctype)
+
+        # everything else (data.json, images/, frames/) comes from
+        # active_dir via the base handler
+        return self._serve_static(super().do_GET)
+
+    def do_HEAD(self):
+        return self._serve_static(super().do_HEAD)
+
+    def do_POST(self):
+        if self.path == '/api/run':
+            if ViewerHandler.launcher_state is None:
+                return self.send_error(404)
+            length = int(self.headers.get('Content-Length', 0))
+            try:
+                form = json.loads(self.rfile.read(length)) if length else {}
+                ViewerHandler.launcher_state.start(form)
+                return self._send_json({'ok': True})
+            except Exception as e:
+                return self._send_json({'ok': False, 'error': str(e)},
+                                       status=400)
+        return self.send_error(404)
+
+    def _send_file(self, path, ctype):
+        try:
+            with open(path, 'rb') as f:
+                body = f.read()
+        except OSError:
+            return self.send_error(404)
+        self.send_response(200)
+        self.send_header('Content-Type', ctype)
+        self.send_header('Content-Length', str(len(body)))
+        self.send_header('Cache-Control', 'no-cache')
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_json(self, obj, status=200):
+        body = json.dumps(obj).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.send_header('Cache-Control', 'no-cache')
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):
+        logger.debug(fmt % args)
+
+
+def _load_config(config_path):
+    from donkeycar.parts.image_transformations import \
+        load_config_and_myconfig
+    return load_config_and_myconfig(config_path)
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        prog='uncertainty_viewer',
+        description='Web viewer (and analysis launcher) for Grad-CAM '
+                    'uncertainty analyses.')
+    parser.add_argument('--analysis', default=None,
+                        help='analysis dir produced by gradcam_uncertainty '
+                             '(must contain data.json). Omit to start in '
+                             'launcher mode and run a new analysis from the '
+                             'browser.')
+    parser.add_argument('--tub', default=None,
+                        help='tub dir for camera frames of non-analysed '
+                             'frames (default: the tub path recorded in '
+                             'data.json, if it exists on this machine)')
+    parser.add_argument('--config', default=None,
+                        help='path to config.py, used by launcher mode when '
+                             'starting a new analysis (defaults to '
+                             './config.py, falling back to bundled defaults)')
+    parser.add_argument('--port', type=int, default=8890)
+    parser.add_argument('--host', default='127.0.0.1',
+                        help='bind address (use 0.0.0.0 to allow access '
+                             'from other machines)')
+    parsed = parser.parse_args(args)
+
+    cwd = os.getcwd()
+    cfg = _load_config(parsed.config)
+    ViewerHandler.launcher_state = LauncherState(cfg, cwd)
+
+    if parsed.analysis:
+        analysis_dir = os.path.abspath(os.path.expanduser(parsed.analysis))
+        data_json = os.path.join(analysis_dir, 'data.json')
+        if os.path.isfile(data_json):
+            ViewerHandler.active_dir = analysis_dir
+            tub_dir = parsed.tub
+            if tub_dir is None:
+                with open(data_json) as f:
+                    tub_dir = json.load(f).get('tub')
+            if tub_dir:
+                candidate = os.path.join(os.path.expanduser(tub_dir), 'images')
+                if os.path.isdir(candidate):
+                    ViewerHandler.tub_images_dir = os.path.abspath(candidate)
+        else:
+            logger.warning(f'{analysis_dir} has no data.json yet; starting '
+                           f'in launcher mode instead.')
+
+    logger.info(f'Analysis dir : {ViewerHandler.active_dir or "(none yet -- launcher mode)"}')
+    if ViewerHandler.tub_images_dir:
+        logger.info(f'Tub images   : {ViewerHandler.tub_images_dir}')
+
+    server = ThreadingHTTPServer((parsed.host, parsed.port), ViewerHandler)
+    shown_host = 'localhost' if parsed.host in ('127.0.0.1', '0.0.0.0') \
+        else parsed.host
+    print(f'\nUncertainty viewer running at '
+          f'http://{shown_host}:{parsed.port}  (Ctrl+C to stop)\n')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print('\nStopped.')
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/donkeycar/parts/web_controller/templates/base.html
+++ b/donkeycar/parts/web_controller/templates/base.html
@@ -21,7 +21,7 @@
   <script src="/static/bootstrap/3.3.7/js/bootstrap.min.js" integrity="" crossorigin="anonymous"></script>
 
 
-  <script type="text/javascript" src="/static/main.js"></script>
+  <script type="text/javascript" src="/static/main.js?v=xai2"></script>
   <link href="/static/style.css" rel="stylesheet">
 
 </head>

--- a/donkeycar/parts/web_controller/templates/static/main.js
+++ b/donkeycar/parts/web_controller/templates/static/main.js
@@ -17,6 +17,9 @@ var driveHandler = new function() {
         'driveMode': "user",
         'pilot': 'None',
         'session': 'None',
+        'confidence': null,   // MC-Dropout confidence %, null when disabled
+        'novelty': null,      // feature-space novelty (OOD) %, null when disabled
+        'tta_stability': null, // TTA stability %, null when disabled
         'lag': 0,
         'controlMode': 'joystick',
         'maxThrottle' : 1,
@@ -94,7 +97,7 @@ var driveHandler = new function() {
                 // we are only updating existing fields.
                 //
                 if(state.hasOwnProperty(key) && state[key] !== data[key]) {
-                    if(typeof state[key] === 'object') {
+                    if(state[key] !== null && typeof state[key] === 'object') {
                         // recursively update the state's object field
                         changed = updateState(state[key], data[key]) && changed;
                     } else {
@@ -107,6 +110,18 @@ var driveHandler = new function() {
         return changed;
     }
 
+    // Renders the one-time "not calibrated" dashboard banner. `items` is a
+    // list of {signal, label, message} -- see LocalWebController.xai_uncalibrated
+    // (web.py) / complete.py, where this is built at vehicle start.
+    var showXaiUncalibratedBanner = function(items) {
+        var $list = $('#xai-banner-list');
+        $list.empty();
+        items.forEach(function(item) {
+            $list.append($('<li>').append($('<strong>').text(item.label + ': ')).append(document.createTextNode(item.message)));
+        });
+        $('#xai-uncalibrated-banner').show();
+    }
+
     var setBindings = function() {
       //
       // when server sends a message with state changes
@@ -116,6 +131,12 @@ var driveHandler = new function() {
       socket.onmessage = function (event) {
         console.log(event.data);
         const data = JSON.parse(event.data);
+        // One-time push on connect (not part of the per-frame telemetry
+        // updateState/updateUI loop below) -- handled separately since
+        // updateState only ever updates keys the state object already has.
+        if (data.xai_uncalibrated) {
+            showXaiUncalibratedBanner(data.xai_uncalibrated);
+        }
         if(updateState(state, data)) {
             updateUI();
         }
@@ -152,6 +173,21 @@ var driveHandler = new function() {
 
       $('#brake_button').click(function() {
         toggleBrake();
+      });
+
+      $('#xai-banner-dismiss').click(function() {
+        $('#xai-uncalibrated-banner').hide();
+      });
+
+      // Plain-language "what does this mean?" toggles on the confidence/
+      // novelty/TTA panels. Delegated so any future XAI panel with the same
+      // markup pattern (.xai-explain-toggle + data-target) works for free.
+      $(document).on('click', '.xai-explain-toggle', function () {
+        var $btn = $(this);
+        var $panel = $('#' + $btn.data('target'));
+        var opening = $panel.css('display') === 'none';
+        $panel.slideToggle(120);
+        $btn.html(opening ? 'Hide &#9652;' : 'What does this mean? &#9662;');
       });
 
       $('input[type=radio][name=controlMode]').change(function() {
@@ -231,6 +267,52 @@ var driveHandler = new function() {
 
       $('#throttle_label').html(throttleRounded);
       $('#steering_label').html(steeringRounded);
+
+      // MC-Dropout model confidence meter (only present when XAI_CONFIDENCE_ENABLED is on)
+      if (state.confidence !== null && state.confidence !== undefined) {
+        var conf = Math.max(0, Math.min(100, Math.round(state.confidence)));
+        // Tiers mirror the calibration anchors: normal / reduced / critical.
+        var confClass = conf >= 65 ? 'progress-bar-success'
+                      : conf >= 25 ? 'progress-bar-warning'
+                      : 'progress-bar-danger';
+        $('#confidence-panel').show();
+        $('#confidence-value').html(conf + '%');
+        $('#confidence-bar')
+          .css('width', conf + '%')
+          .removeClass('progress-bar-success progress-bar-warning progress-bar-danger')
+          .addClass(confClass);
+      }
+
+      // Feature-space novelty (OOD) meter (only present when
+      // XAI_NOVELTY_ENABLED is on). Tier colors are INVERTED from
+      // confidence: low novelty (familiar) = green, high (unfamiliar) = red.
+      if (state.novelty !== null && state.novelty !== undefined) {
+        var nov = Math.max(0, Math.min(100, Math.round(state.novelty)));
+        var novClass = nov <= 25 ? 'progress-bar-success'
+                     : nov <= 65 ? 'progress-bar-warning'
+                     : 'progress-bar-danger';
+        $('#novelty-panel').show();
+        $('#novelty-value').html(nov + '%');
+        $('#novelty-bar')
+          .css('width', nov + '%')
+          .removeClass('progress-bar-success progress-bar-warning progress-bar-danger')
+          .addClass(novClass);
+      }
+
+      // TTA stability meter (only present when XAI_TTA_ENABLED is on). Tier
+      // colors match confidence (high = good): stable = green, fragile = red.
+      if (state.tta_stability !== null && state.tta_stability !== undefined) {
+        var tta = Math.max(0, Math.min(100, Math.round(state.tta_stability)));
+        var ttaClass = tta >= 65 ? 'progress-bar-success'
+                     : tta >= 25 ? 'progress-bar-warning'
+                     : 'progress-bar-danger';
+        $('#tta-panel').show();
+        $('#tta-value').html(tta + '%');
+        $('#tta-bar')
+          .css('width', tta + '%')
+          .removeClass('progress-bar-success progress-bar-warning progress-bar-danger')
+          .addClass(ttaClass);
+      }
 
       if(state.tele.user.throttle < 0) {
         $('#throttle-bar-backward').css('width', throttlePercent).html(throttleRounded)

--- a/donkeycar/parts/web_controller/templates/static/style.css
+++ b/donkeycar/parts/web_controller/templates/static/style.css
@@ -141,3 +141,58 @@ body {
   height: 60px;
   background-color: #f5f5f5;
 }
+
+.xai-explain-toggle {
+  background: none;
+  border: none;
+  color: #337ab7;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 0 0 4px;
+  text-decoration: underline;
+}
+.xai-explain-toggle:hover {
+  color: #23527c;
+}
+.xai-explain {
+  margin-top: 6px;
+  padding: 8px 10px;
+  background: #eef6ff;
+  border: 1px solid #bcdcff;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #1c3d5a;
+}
+
+.xai-banner {
+  position: relative;
+  background: #fff8e6;
+  border-bottom: 2px solid #f0c14b;
+  color: #6b5300;
+  padding: 10px 36px 10px 16px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.xai-banner ul {
+  margin: 6px 0 0 0;
+  padding-left: 18px;
+}
+.xai-banner li {
+  margin-top: 2px;
+}
+.xai-banner-dismiss {
+  position: absolute;
+  top: 6px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: #6b5300;
+  padding: 2px 6px;
+}
+.xai-banner-dismiss:hover {
+  color: #4a3a00;
+}

--- a/donkeycar/parts/web_controller/templates/vehicle.html
+++ b/donkeycar/parts/web_controller/templates/vehicle.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% block content %}
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <!-- Shown once per dashboard connection when an enabled XAI signal (confidence/
+       novelty/TTA) has no calibration yet, so the person actually driving sees
+       why a panel never appears -- not just a line in a server log. -->
+  <div id="xai-uncalibrated-banner" class="xai-banner" style="display: none;">
+    <button type="button" id="xai-banner-dismiss" class="xai-banner-dismiss" aria-label="Dismiss">&times;</button>
+    <strong>Calibration warnings:</strong> these signals won't show a percentage, or may be reading against the wrong baseline.
+    <ul id="xai-banner-list"></ul>
+  </div>
   <div class="container">
     <div class="row">
 
@@ -57,6 +65,88 @@
             <div class="progress positive">
               <div id="throttle-bar-forward" class="progress-bar progress-bar-success" role="progressbar" style="width: 0%;">
               </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- model confidence (MC-Dropout), only shown when XAI_CONFIDENCE_ENABLED is on -->
+        <div id="confidence-panel" class="panel panel-default" style="display: none; clear: both; margin-top: 15px;">
+          <div class="panel-heading">
+            <strong>Do the model's "sub-networks" agree?</strong>
+            <small class="text-muted">(confidence)</small>
+            <span id="confidence-value" class="pull-right"></span>
+          </div>
+          <div class="panel-body">
+            <div class="progress" id="confidence-progress" style="margin-bottom: 8px;">
+              <div id="confidence-bar" class="progress-bar progress-bar-success"
+                   role="progressbar" style="width: 0%;"></div>
+            </div>
+            <small class="text-muted">
+              Relative to this model's own baseline, not a calibrated
+              probability.
+              <button type="button" class="xai-explain-toggle" data-target="confidence-explain">What does this mean? &#9662;</button>
+            </small>
+            <div id="confidence-explain" class="xai-explain" style="display: none;">
+              This works by asking the model the same question 15 times, each
+              time with a different random slice of its "brain" (dropout)
+              switched off &mdash; like asking 15 slightly different clones.
+              If the clones agree, confidence is high; if they scatter, it's
+              low. This measures whether the model agrees with
+              <em>itself</em> &mdash; not whether it's actually right.
+            </div>
+          </div>
+        </div>
+
+        <!-- feature-space novelty / OOD detection, only shown when XAI_NOVELTY_ENABLED is on -->
+        <div id="novelty-panel" class="panel panel-default" style="display: none; clear: both; margin-top: 15px;">
+          <div class="panel-heading">
+            <strong>Does this look familiar?</strong>
+            <small class="text-muted">(novelty)</small>
+            <span id="novelty-value" class="pull-right"></span>
+          </div>
+          <div class="panel-body">
+            <div class="progress" id="novelty-progress" style="margin-bottom: 8px;">
+              <div id="novelty-bar" class="progress-bar progress-bar-success"
+                   role="progressbar" style="width: 0%;"></div>
+            </div>
+            <small class="text-muted">
+              A different signal from model confidence above.
+              <button type="button" class="xai-explain-toggle" data-target="novelty-explain">What does this mean? &#9662;</button>
+            </small>
+            <div id="novelty-explain" class="xai-explain" style="display: none;">
+              This checks how far the current camera view is, in the model's
+              internal representation, from everything it saw during training
+              &mdash; like asking "does this remind me of anything I've
+              driven through before?" A totally new kind of scene can score
+              high here even while the model still feels "confident" above
+              &mdash; that's the point of having both signals.
+            </div>
+          </div>
+        </div>
+
+        <!-- test-time augmentation stability, only shown when XAI_TTA_ENABLED is on -->
+        <div id="tta-panel" class="panel panel-default" style="display: none; clear: both; margin-top: 15px;">
+          <div class="panel-heading">
+            <strong>Is the answer stable?</strong>
+            <small class="text-muted">(TTA stability)</small>
+            <span id="tta-value" class="pull-right"></span>
+          </div>
+          <div class="panel-body">
+            <div class="progress" id="tta-progress" style="margin-bottom: 8px;">
+              <div id="tta-bar" class="progress-bar progress-bar-success"
+                   role="progressbar" style="width: 0%;"></div>
+            </div>
+            <small class="text-muted">
+              A different signal from the two above.
+              <button type="button" class="xai-explain-toggle" data-target="tta-explain">What does this mean? &#9662;</button>
+            </small>
+            <div id="tta-explain" class="xai-explain" style="display: none;">
+              This shows the model the same photo 8 times, each time with the
+              brightness/contrast/noise tweaked slightly &mdash; like showing
+              a photo at noon, at dusk, through foggy glasses. If the answer
+              barely changes, stability is high. A low score means the model
+              is fragile to lighting/noise &mdash; a different failure mode
+              from low confidence or high novelty.
             </div>
           </div>
         </div>

--- a/donkeycar/parts/web_controller/web.py
+++ b/donkeycar/parts/web_controller/web.py
@@ -121,6 +121,20 @@ class LocalWebController(tornado.web.Application):
         self.port = port
 
         self.num_records = 0
+        self.confidence = None            # last MC-Dropout confidence % (or None)
+        self.last_confidence_pct = None   # last value pushed to clients
+        self.novelty = None                # last novelty (OOD) % (or None)
+        self.last_novelty_pct = None       # last value pushed to clients
+        self.tta_stability = None          # last TTA stability % (or None)
+        self.last_tta_pct = None           # last value pushed to clients
+        # XAI signals that are enabled but have no calibration -- set once by
+        # the drive template (complete.py) before the server starts, since it
+        # already knows this at vehicle-build time. Pushed to each new
+        # dashboard connection (see WebSocketDriveAPI.open below) so the
+        # person actually driving sees it, instead of only a server log line
+        # nobody watching the dashboard would ever see.
+        # [{'signal': 'confidence', 'label': 'Confidence', 'message': '...'}]
+        self.xai_uncalibrated = []
         self.wsclients = []
         self.loop = None
 
@@ -162,12 +176,20 @@ class LocalWebController(tornado.web.Application):
                                    exc_info=e)
                     pass
 
-    def run_threaded(self, img_arr=None, num_records=0, mode=None, recording=None):
+    def run_threaded(self, img_arr=None, num_records=0, mode=None,
+                     recording=None, confidence=None, novelty=None,
+                     tta_stability=None):
         """
         :param img_arr: current camera image or None
         :param num_records: current number of data records
         :param mode: default user/mode
         :param recording: default recording mode
+        :param confidence: MC-Dropout confidence % (0-100) or None if the
+                           feature is disabled / the model is uncalibrated
+        :param novelty: feature-space novelty (OOD) % (0-100) or None if the
+                        feature is disabled / the model is uncalibrated
+        :param tta_stability: test-time-augmentation stability % (0-100) or
+                        None if the feature is disabled / model uncalibrated
         """
         self.img_arr = img_arr
         self.num_records = num_records
@@ -196,6 +218,31 @@ class LocalWebController(tornado.web.Application):
             if self.num_records % 10 == 0:
                 changes['num_records'] = self.num_records
 
+        # Push MC-Dropout confidence, but only when the whole-number percent
+        # changes, so we don't flood the socket every drive-loop frame.
+        self.confidence = confidence
+        if confidence is not None:
+            conf_pct = int(round(confidence))
+            if conf_pct != self.last_confidence_pct:
+                self.last_confidence_pct = conf_pct
+                changes['confidence'] = conf_pct
+
+        # Push feature-space novelty (OOD) score the same throttled way.
+        self.novelty = novelty
+        if novelty is not None:
+            nov_pct = int(round(novelty))
+            if nov_pct != self.last_novelty_pct:
+                self.last_novelty_pct = nov_pct
+                changes['novelty'] = nov_pct
+
+        # Push TTA stability score the same throttled way.
+        self.tta_stability = tta_stability
+        if tta_stability is not None:
+            tta_pct = int(round(tta_stability))
+            if tta_pct != self.last_tta_pct:
+                self.last_tta_pct = tta_pct
+                changes['tta_stability'] = tta_pct
+
         #
         # get latched button presses then clear button presses
         # Next iteration will clear press in memory
@@ -213,8 +260,10 @@ class LocalWebController(tornado.web.Application):
 
         return self.angle, self.throttle, self.mode, self.recording, buttons
 
-    def run(self, img_arr=None, num_records=0, mode=None, recording=None):
-        return self.run_threaded(img_arr, num_records, mode, recording)
+    def run(self, img_arr=None, num_records=0, mode=None, recording=None,
+            confidence=None, novelty=None, tta_stability=None):
+        return self.run_threaded(img_arr, num_records, mode, recording,
+                                 confidence, novelty, tta_stability)
 
     def shutdown(self):
         pass
@@ -282,6 +331,24 @@ class WebSocketDriveAPI(tornado.websocket.WebSocketHandler):
     def open(self):
         logger.info("New client connected")
         self.application.wsclients.append(self)
+        # One-time push (not part of the per-frame telemetry loop) so a
+        # dashboard user sees, at a glance, which enabled XAI signals won't
+        # show a %% because this model has never been calibrated.
+        if self.application.xai_uncalibrated:
+            self.write_message(json.dumps(
+                {'xai_uncalibrated': self.application.xai_uncalibrated}))
+        # Seed this client with the CURRENT XAI values. run_threaded only
+        # emits a signal when its whole-number percent CHANGES, and the
+        # last-sent value is per-server, not per-client -- so without this a
+        # reconnecting or second client would see no panel at all until the
+        # number happened to move, which on a steady car can be indefinite.
+        current = {key: value for key, value in (
+                       ('confidence', self.application.last_confidence_pct),
+                       ('novelty', self.application.last_novelty_pct),
+                       ('tta_stability', self.application.last_tta_pct))
+                   if value is not None}
+        if current:
+            self.write_message(json.dumps(current))
 
     def on_message(self, message):
         data = json.loads(message)

--- a/donkeycar/pipeline/training.py
+++ b/donkeycar/pipeline/training.py
@@ -14,7 +14,8 @@ from donkeycar.pipeline.database import PilotDatabase
 from donkeycar.pipeline.sequence import TubRecord, TubSequence, TfmIterator
 from donkeycar.pipeline.types import TubDataset
 from donkeycar.pipeline.augmentations import ImageAugmentation
-from donkeycar.parts.image_transformations import ImageTransformations
+from donkeycar.parts.image_transformations import ImageTransformations, \
+    log_preprocessing_config, save_preprocessing_metadata
 from donkeycar.utils import get_model_by_type, normalize_image, train_test_split
 import tensorflow as tf
 import numpy as np
@@ -42,6 +43,9 @@ class BatchSequence(object):
         self.transformation = ImageTransformations(config, 'TRANSFORMATIONS')
         self.post_transformation = ImageTransformations(config,
                                                         'POST_TRANSFORMATIONS')
+        log_preprocessing_config(config,
+                                 'training' if is_train else 'validation',
+                                 include_augmentations=is_train)
         self.pipeline = self._create_pipeline()
 
     def __len__(self) -> int:
@@ -166,6 +170,10 @@ def train(cfg: Config, tub_paths: str, model: str = None,
                        patience=cfg.EARLY_STOP_PATIENCE,
                        show_plot=cfg.SHOW_PLOT)
 
+    # Record the exact preprocessing this model was trained with, so the
+    # vehicle can refuse to drive it if its own config doesn't match.
+    save_preprocessing_metadata(cfg, model_path)
+
     # We are doing the tflite/trt conversion here on a previously saved model
     # and not on the kl.interpreter.model object directly. The reason is that
     # we want to convert the best model which is not the model in its current
@@ -198,5 +206,31 @@ def train(cfg: Config, tub_paths: str, model: str = None,
     }
     database.add_entry(database_entry)
     database.write()
+
+    # Optionally build the MC-Dropout confidence calibration on the training
+    # tubs, so the trained model ships with a <model>.calib.json (saved next to
+    # the model) that the dashboard uses to show a confidence % when
+    # XAI_CONFIDENCE_ENABLED is enabled.
+    # Off by default because it adds a replay pass over the data; enable with
+    # XAI_CONFIDENCE_AUTO_CALIBRATE = True. Linear model only (MC-Dropout relies on
+    # the dropout layers in the default linear architecture).
+    if getattr(cfg, 'XAI_CONFIDENCE_AUTO_CALIBRATE', False):
+        if model_type == 'linear':
+            try:
+                from donkeycar.parts.mc_calibrate import calibrate_from_tub
+                calib_tubs = [os.path.expanduser(t)
+                              for t in tub_paths.split(',')]
+                limit = getattr(cfg, 'XAI_CONFIDENCE_CALIBRATE_LIMIT', None)
+                logger.info('Building MC-Dropout confidence calibration on '
+                            'the training tubs...')
+                _, calib_path = calibrate_from_tub(
+                    cfg, calib_tubs, model_path, limit=limit)
+                logger.info(f'Saved MC-Dropout calibration to {calib_path}')
+            except Exception as e:
+                logger.warning(f'MC-Dropout auto-calibration failed '
+                               f'(model still trained fine): {e}')
+        else:
+            logger.info(f'Skipping MC-Dropout calibration: only supported for '
+                        f'the linear model, not "{model_type}".')
 
     return history

--- a/donkeycar/templates/cfg_complete.py
+++ b/donkeycar/templates/cfg_complete.py
@@ -499,6 +499,159 @@ LEARNING_RATE_DECAY = 0.0
 # Store images as 'ARRAY' (faster), 'BINARY', or 'NOCACHE' (saves RAM).
 CACHE_POLICY = 'ARRAY'
 
+# ============================================================
+# EXPLAINABLE AI / UNCERTAINTY TOOLKIT
+# Two independent live signals, each its own on/off switch below. Either,
+# both, or neither can be enabled -- they don't depend on each other, and
+# neither needs any command-line flag. Both need a calibration file
+# (<model>.calib.json, produced by `python -m donkeycar.parts.mc_calibrate`
+# or automatically via XAI_CONFIDENCE_AUTO_CALIBRATE below) to show a % on
+# the dashboard; without one the raw numbers still get logged to the tub.
+# ============================================================
+
+# --- Signal 1: MC-Dropout confidence -------------------------------------
+# Runs the linear model N times per frame with dropout active and reports
+# the variance of the steering predictions as a relative uncertainty signal
+# ("do my dropout sub-networks agree?"). NOT a calibrated probability.
+# Costs N extra forward passes per frame -- the more expensive of the two
+# signals, hence its own explicit toggle.
+XAI_CONFIDENCE_ENABLED = False   # master on/off for the confidence signal
+XAI_CONFIDENCE_PASSES = 15       # number of stochastic forward passes per frame
+XAI_CONFIDENCE_ALPHA = 0.2       # EMA smoothing of the variance (0..1, higher=faster)
+# Minimum seconds between confidence updates. 0 = every frame; the default
+# below (0.3) updates confidence ~3x/sec instead. Between updates the car
+# still steers every frame via a cheap single-pass inference -- only the
+# confidence number is held, so this never costs driving responsiveness.
+# Reduces average compute load on slow hardware (Pi) by cutting how often
+# the expensive N-pass update runs.
+XAI_CONFIDENCE_INTERVAL = 0.3
+# When True, training automatically builds the confidence (and novelty)
+# calibration on the training tubs and saves <model>.calib.json next to the
+# model, so the model ships ready for the dashboard. Adds a replay pass
+# (~minutes), so it is off by default. Linear model only.
+XAI_CONFIDENCE_AUTO_CALIBRATE = False
+XAI_CONFIDENCE_CALIBRATE_LIMIT = None   # cap frames used for calibration (None=all)
+
+# --- Augmentation-aware novelty calibration ------------------------------
+# Training applies AUGMENTATIONS (see the augmentation section further down)
+# only to the training split, so a novelty baseline fit on raw tub frames
+# describes a NARROWER input distribution than the model was actually
+# trained for. The consequence: an ordinary brighter/dimmer or blurrier frame
+# scores as highly novel at runtime, and with XAI_THROTTLE_SCALING_ENABLED the
+# car slows down in exactly the conditions augmentation was added to survive.
+#
+# Unlike the confidence/TTA percentiles -- which are re-measured through the
+# retrained model on every calibration and so rescale themselves -- this
+# cannot self-correct: live novelty measures distance in a FROZEN ImageNet
+# encoder's feature space, which never sees a training epoch.
+#
+# When True (default) and AUGMENTATIONS is non-empty, calibration also pushes
+# a strided subset of frames through the same augmentation pipeline used in
+# training and pools those features into the novelty baseline. With no
+# AUGMENTATIONS configured this does nothing, so un-augmented models
+# calibrate exactly as before. Scoped to the novelty baselines only: the
+# MC-Dropout and TTA replays are untouched (their EMAs assume a contiguous
+# time-ordered frame stream).
+XAI_CALIBRATE_WITH_AUGMENTATIONS = True
+XAI_CALIBRATE_AUG_PASSES = 2        # randomised augmented passes per sampled frame
+XAI_CALIBRATE_AUG_MAX_SAMPLES = 1500  # cap on total augmented samples (bounds RAM/time)
+
+# --- Signal 2: feature-space novelty (out-of-distribution) detection -----
+# Measures how far the current scene is from the training distribution
+# (Mahalanobis distance) -- "have I seen anything like this?" A different
+# question from confidence above: a frame can be low-confidence yet
+# familiar-looking, or high-confidence yet genuinely novel (confidently
+# wrong). See donkeycar.parts.novelty module docstring for the full picture.
+#
+# Novelty is measured in the features of a GENERIC ImageNet encoder (below),
+# NOT the steering model's own layers -- the steering model is trained to
+# ignore scene content (grass vs track), so measuring novelty there barely
+# responded to different scenes. The encoder keeps that content. Its ImageNet
+# weights are fetched once at calibration time and saved next to the model as
+# <model>.novelty_encoder.h5, so a Pi driving offline needs no download.
+XAI_NOVELTY_ENABLED = False   # master on/off for the novelty signal
+XAI_NOVELTY_ALPHA = 0.2       # EMA smoothing of the raw Mahalanobis distance
+XAI_NOVELTY_ENCODER = 'mobilenet_v2'   # generic feature encoder ('mobilenet_v2'|'mobilenet')
+XAI_NOVELTY_ENCODER_INPUT = 128        # square input size fed to the encoder
+XAI_NOVELTY_ENCODER_ALPHA = 1.0        # encoder width multiplier (smaller=faster, e.g. 0.35 on a Pi)
+# Offline-only: the novelty HEAT MAP in the analysis viewer uses the same
+# encoder but keeps its spatial grid, at a larger, aspect-preserving input so
+# the map isn't a coarse 4x4. Costs nothing while driving. Grid resolution is
+# roughly (short side / 32), e.g. 224 -> a 7-row grid on a 16:9 frame.
+XAI_NOVELTY_SPATIAL_INPUT = 224
+# Frames sampled to fit that map's baseline. Every grid location of every
+# sampled frame is one training vector, so a few hundred frames is plenty.
+XAI_NOVELTY_SPATIAL_MAX_FRAMES = 400
+# Hard cap on those per-location vectors before fitting. Bounds calibration
+# memory (the fit materialises several n_vectors x 1280 float64 arrays);
+# a diagonal Gaussian fits each dimension independently, so a few thousand
+# samples is already ample.
+XAI_NOVELTY_SPATIAL_MAX_VECTORS = 4000
+# Minimum seconds between novelty updates. 0 = every frame; the default below
+# (0.3) updates novelty ~3x/sec instead. Unlike confidence's interval, a held
+# frame here costs NOTHING -- this signal never drives, so between updates it
+# just holds the last score with zero forward passes, instead of falling back
+# to a cheap pass. See the note by XAI_THROTTLE_STOP_DURATION below for how
+# this interacts with throttle scaling's reaction time.
+XAI_NOVELTY_INTERVAL = 0.3
+
+# --- Signal 3: test-time augmentation (TTA) stability --------------------
+# Runs the DETERMINISTIC model on M photometrically-augmented copies of the
+# frame and reports the variance of the steering predictions as a "stability"
+# signal ("does my answer stay the same if the lighting/noise changes a
+# little?"). A third, distinct question from the two above: confidence probes
+# the model's weights, novelty probes the scene, TTA probes robustness to
+# input perturbation. Photometric augmentation only (brightness/contrast/gamma
+# /noise) -- never geometric, which would change the correct steering answer.
+# M forward passes batched into one call, cheap enough for live use.
+# This flag only controls whether the signal runs while DRIVING. Calibration
+# always builds the "tta" block regardless, so you can switch this on later
+# without re-running calibration.
+XAI_TTA_ENABLED = False       # master on/off for the TTA stability signal (live only)
+XAI_TTA_SAMPLES = 8           # M, number of augmented copies per frame
+XAI_TTA_ALPHA = 0.2           # EMA smoothing of the steering variance
+# Minimum seconds between TTA updates. 0 = every frame, which means M forward
+# passes EVERY frame -- the most expensive of the three signals per update.
+# A held frame costs zero forward passes (this signal never drives). The
+# default below (0.5, i.e. ~2x/sec) is the most relaxed of the three since TTA
+# has the biggest single per-frame cost -- if confidence + novelty + TTA
+# together is straining the hardware (Pi power draw, brownouts), this is the
+# first knob to raise further. See the note by XAI_THROTTLE_STOP_DURATION
+# below for how this interacts with throttle scaling's reaction time.
+XAI_TTA_INTERVAL = 0.5
+XAI_TTA_STRENGTH = 0.2        # photometric jitter strength (0..1); 0 = no augmentation
+
+# --- Throttle scaling (Feature 2) -----------------------------------------
+# Scales autopilot throttle down as confidence drops and/or novelty rises;
+# steering is never affected, and manual driving is unchanged. Takes the
+# more conservative (lowest) scale across whichever of the two signals above
+# are currently enabled and calibrated -- enabling only one of them still
+# works, using that one signal alone. Disabled -> zero behaviour change.
+XAI_THROTTLE_SCALING_ENABLED = False
+XAI_CONFIDENCE_REDUCED_THRESHOLD = 65.0    # below this confidence %, start scaling
+XAI_CONFIDENCE_CRITICAL_THRESHOLD = 25.0   # below this confidence %, critical tier
+XAI_NOVELTY_REDUCED_THRESHOLD = 25.0       # above this novelty %, start scaling
+XAI_NOVELTY_CRITICAL_THRESHOLD = 65.0      # above this novelty %, critical tier
+XAI_TTA_REDUCED_THRESHOLD = 65.0           # below this stability %, start scaling
+XAI_TTA_CRITICAL_THRESHOLD = 25.0          # below this stability %, critical tier
+XAI_THROTTLE_MIN_SCALE = 0.4    # floor: never below 40% from any single signal
+# Secs sustained-critical (any signal) before full stop. If you also raised
+# XAI_NOVELTY_INTERVAL / XAI_TTA_INTERVAL to reduce compute load, know that
+# those signals can now be stale by up to that many seconds before a new
+# reading even arrives -- worst case, this adds to that delay before the car
+# reacts (e.g. NOVELTY_INTERVAL=0.3 + STOP_DURATION=1.0 -> up to ~1.3s before
+# a full stop). Fine for dashboard/monitoring use; worth tightening the
+# interval(s) back down if you're relying on this for real-time braking.
+XAI_THROTTLE_STOP_DURATION = 1.0   # secs sustained-critical (any signal) before full stop
+
+# --- Offline analysis (Grad-CAM tool) -------------------------------------
+# These only affect the offline post-drive analysis tool
+# (donkeycar.parts.gradcam_uncertainty / the run_gradcam_analysis.py GUI),
+# never the live drive loop. Each analysed frame gets several overlay layers:
+# Grad-CAM attention + uncertainty, Grad-CAM++ attention (sharper), novelty,
+# vanilla saliency, and Integrated Gradients.
+XAI_IG_STEPS = 32   # Integrated Gradients Riemann steps (20-50 typical; higher=cleaner+slower)
+
 # MODEL OPTIMIZATION
 # Automatically create TFLite model for faster inference on Pi.
 CREATE_TF_LITE = True

--- a/donkeycar/templates/complete.py
+++ b/donkeycar/templates/complete.py
@@ -301,10 +301,24 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
             print(e)
             print("ERR>> problems loading model json", json_fnm)
 
+    # Always defined (not just inside `if model_path:` below), so the
+    # throttle-scaling block further down -- which now runs AFTER AiLaunch,
+    # outside this conditional -- can safely check them even when driving
+    # without a model at all.
+    use_mc_dropout = use_novelty = use_tta = False
+
     #
     # load and configure model for inference
     #
     if model_path:
+        # Deterministic transforms (crop, trapezoidal mask, etc.) must be
+        # identical between training and driving, or the model looks at a
+        # different kind of input than it was trained on - stop startup
+        # rather than silently drive with mismatched preprocessing.
+        from donkeycar.parts.image_transformations import \
+            check_preprocessing_metadata
+        check_preprocessing_metadata(cfg, model_path)
+
         # If we have a model, create an appropriate Keras part
         kl = dk.utils.get_model_by_type(model_type, cfg)
 
@@ -402,17 +416,176 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
         # so they get applied at inference time in autopilot mode.
         #
         if hasattr(cfg, 'TRANSFORMATIONS') or hasattr(cfg, 'POST_TRANSFORMATIONS'):
-            from donkeycar.parts.image_transformations import ImageTransformations
+            from donkeycar.parts.image_transformations import \
+                ImageTransformations, log_preprocessing_config
             #
             # add the complete set of pre and post augmentation transformations
             #
             logger.info(f"Adding inference transformations")
+            log_preprocessing_config(cfg, 'vehicle')
             V.add(ImageTransformations(cfg, 'TRANSFORMATIONS',
                                        'POST_TRANSFORMATIONS'),
                   inputs=['cam/image_array'], outputs=['cam/image_array_trans'])
             inputs = ['cam/image_array_trans'] + inputs[1:]
 
-        V.add(kl, inputs=inputs, outputs=outputs, run_condition='run_pilot')
+        # Enabled-but-uncalibrated XAI signals, collected below and pushed to
+        # the dashboard once (see the end of this block) -- so someone
+        # actually driving sees why a panel never shows a %%, instead of that
+        # only ever appearing as a server log line nobody watching the
+        # dashboard would see.
+        xai_uncalibrated = []
+
+        from donkeycar.parts.mc_calibrate import (default_calib_path,
+                                                  missing_calibration_reason,
+                                                  transformation_drift)
+
+        def xai_calib_path(signal, label):
+            """Calibration path for one signal, or None when it has no usable
+            calibration -- in which case the reason is logged AND queued for
+            the dashboard banner. Checking the BLOCK (not just that the file
+            exists) matters: a calib.json written by an older version can be
+            present but lack this signal, which would otherwise show no panel
+            and no banner -- indistinguishable from the feature being off."""
+            path = default_calib_path(model_path)
+            reason = missing_calibration_reason(path, signal)
+            if not reason:
+                return path
+            logger.warning(f"{label} not calibrated: {reason}; run 'python -m "
+                           f"donkeycar.parts.mc_calibrate' to enable it. Raw "
+                           f"values are still logged to the tub.")
+            xai_uncalibrated.append({
+                'signal': signal, 'label': label,
+                'message': f"Enabled, but {reason}, so this won't show a "
+                           f"%. Run: python -m donkeycar.parts.mc_calibrate "
+                           f"--tub <training tub> --model {model_path}"})
+            return None
+
+        # MC-Dropout and TTA read the model's raw output tensors as scalar
+        # steering/throttle, which only holds for the default linear
+        # architecture. On a categorical/behavior/imu/localizer pilot those
+        # outputs are bin vectors (or the output list has a different arity),
+        # so the signals would be meaningless -- and MC-Dropout, which
+        # actually DRIVES, would feed the car a garbage command rather than
+        # fail. Gate both on the model type, matching the guard the training
+        # path already applies to auto-calibration.
+        xai_model_ok = (model_type == 'linear' and not cfg.TRAIN_LOCALIZER)
+        if not xai_model_ok and (getattr(cfg, 'XAI_CONFIDENCE_ENABLED', False)
+                                 or getattr(cfg, 'XAI_TTA_ENABLED', False)):
+            logger.warning(
+                f"XAI confidence/TTA are supported for the 'linear' model "
+                f"only (this vehicle uses '{model_type}'"
+                f"{' with TRAIN_LOCALIZER' if cfg.TRAIN_LOCALIZER else ''}); "
+                f"disabling them. Novelty detection is unaffected -- it uses "
+                f"its own encoder, not the pilot.")
+
+        #
+        # MC-Dropout confidence signal: runs the model N times per frame with
+        # dropout active and emits the variance of the steering predictions
+        # as an uncertainty signal. Linear model only; the averaged
+        # prediction is the driving command. Toggled independently of
+        # novelty detection below -- each is its own config flag, and each
+        # works with or without the other.
+        #
+        use_mc_dropout = getattr(cfg, 'XAI_CONFIDENCE_ENABLED', False) \
+            and xai_model_ok
+        if use_mc_dropout:
+            from donkeycar.parts.mc_dropout import MCDropoutConfidence
+            n_passes = getattr(cfg, 'XAI_CONFIDENCE_PASSES', 15)
+            alpha = getattr(cfg, 'XAI_CONFIDENCE_ALPHA', 0.2)
+            mc_interval = getattr(cfg, 'XAI_CONFIDENCE_INTERVAL', 0.0)
+            calib_path = xai_calib_path('confidence', 'Confidence')
+            logger.info(f"Enabling MC-Dropout confidence (N={n_passes}, "
+                        f"alpha={alpha})")
+            mc_pilot = MCDropoutConfidence(kl, num_passes=n_passes, alpha=alpha,
+                                           calibration_path=calib_path,
+                                           interval=mc_interval)
+            V.add(mc_pilot, inputs=inputs,
+                  outputs=outputs + ['pilot/confidence',
+                                     'pilot/raw_variance',
+                                     'pilot/smoothed_variance'],
+                  run_condition='run_pilot')
+        else:
+            V.add(kl, inputs=inputs, outputs=outputs,
+                  run_condition='run_pilot')
+
+        #
+        # Feature-space novelty (out-of-distribution) detection. Independent
+        # of XAI_CONFIDENCE_ENABLED: it's a single cheap deterministic
+        # pass, so it shouldn't force the N-pass MC-Dropout cost onto someone
+        # who only wants OOD detection. Rides alongside whichever part drives
+        # above (mc_pilot or kl) as a pure auxiliary observer -- it never
+        # produces steering/throttle.
+        #
+        use_novelty = getattr(cfg, 'XAI_NOVELTY_ENABLED', False)
+        if use_novelty:
+            from donkeycar.parts.novelty import FeatureNoveltyDetector
+            novelty_calib_path = xai_calib_path('novelty', 'Novelty')
+            logger.info("Enabling feature-space novelty detection")
+            novelty_part = FeatureNoveltyDetector(
+                kl, calibration_path=novelty_calib_path,
+                alpha=getattr(cfg, 'XAI_NOVELTY_ALPHA', 0.2),
+                interval=getattr(cfg, 'XAI_NOVELTY_INTERVAL', 0.0))
+            # Deliberately the RAW camera frame, not inputs[0] (which becomes
+            # 'cam/image_array_trans' when TRANSFORMATIONS are configured).
+            # Novelty asks "is this scene familiar?" -- a question about the
+            # world, not about the model -- and it answers it with a frozen
+            # ImageNet encoder whose features depend on the colour/texture
+            # content that a CROP or high-pass filter throws away. Confidence
+            # and TTA below/above stay on the transformed image, since those
+            # ARE questions about the model's own behaviour. Calibration
+            # mirrors this split (see mc_calibrate.calibrate_from_tub).
+            V.add(novelty_part, inputs=['cam/image_array'],
+                  outputs=['pilot/novelty', 'pilot/raw_novelty_distance',
+                           'pilot/smoothed_novelty_distance'],
+                  run_condition='run_pilot')
+
+        #
+        # Signal 3: test-time augmentation (TTA) stability. Independent of the
+        # two signals above (its own config toggle) -- a pure auxiliary
+        # observer (like novelty) that runs the deterministic model on M
+        # photometrically-augmented copies of the frame and reports the
+        # steering-prediction variance as a robustness signal. Rides alongside
+        # whichever part drives; never produces steering/throttle.
+        #
+        use_tta = getattr(cfg, 'XAI_TTA_ENABLED', False) and xai_model_ok
+        if use_tta:
+            from donkeycar.parts.tta import TTAStabilityDetector
+            tta_calib_path = xai_calib_path('tta', 'TTA stability')
+            logger.info("Enabling test-time augmentation (TTA) stability")
+            tta_part = TTAStabilityDetector(
+                kl, calibration_path=tta_calib_path,
+                num_samples=getattr(cfg, 'XAI_TTA_SAMPLES', 8),
+                alpha=getattr(cfg, 'XAI_TTA_ALPHA', 0.2),
+                strength=getattr(cfg, 'XAI_TTA_STRENGTH', 0.2),
+                interval=getattr(cfg, 'XAI_TTA_INTERVAL', 0.0))
+            V.add(tta_part, inputs=[inputs[0]],
+                  outputs=['pilot/tta_stability', 'pilot/raw_tta_variance',
+                           'pilot/smoothed_tta_variance'],
+                  run_condition='run_pilot')
+
+        # A calibration can be complete yet still stale: TRANSFORMATIONS
+        # apply at inference, so adding/removing one after calibrating means
+        # every threshold was measured on different pixels than the model now
+        # sees. Mask-style transforms (CROP/TRAPEZE) keep image dimensions, so
+        # nothing errors -- this check is the only thing that surfaces it.
+        if use_mc_dropout or use_novelty or use_tta:
+            drift = transformation_drift(default_calib_path(model_path), cfg)
+            if drift:
+                logger.warning(f'XAI calibration may be stale: {drift}.')
+                xai_uncalibrated.append({
+                    'signal': 'transformations', 'label': 'Calibration stale',
+                    'message': f"{drift} --tub <training tub> --model "
+                               f"{model_path}"})
+
+        # Push the calibration gaps found above to the dashboard (once per
+        # new connection -- see WebSocketDriveAPI.open in web.py). Read from
+        # V.web_ctr (set in add_user_controller), NOT a local `ctr` variable,
+        # since `ctr` gets reassigned to a joystick/RC controller when one is
+        # configured -- the web dashboard still runs in that case (just isn't
+        # the primary input), and should still get the banner.
+        web_ctr = getattr(V, 'web_ctr', None)
+        if xai_uncalibrated and web_ctr is not None:
+            web_ctr.xai_uncalibrated = xai_uncalibrated
 
     #
     # stop at a stop sign
@@ -442,6 +615,45 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     V.add(aiLauncher,
           inputs=['user/mode', 'pilot/throttle'],
           outputs=['pilot/throttle'])
+
+    #
+    # Feature 2: scale throttle down as confidence drops, novelty rises,
+    # and/or TTA stability drops. Only reduces throttle, never touches
+    # steering. Takes the more conservative (lowest) scale across whichever
+    # signal(s) are currently enabled and calibrated; a disabled or
+    # uncalibrated signal is ignored rather than blocking the others.
+    #
+    # Deliberately placed AFTER aiLauncher, not back where the signals
+    # themselves are added: AiLaunch REPLACES pilot/throttle outright with a
+    # fixed boost value for AI_LAUNCH_DURATION seconds rather than modulating
+    # it, so scaling applied before that point would simply be overwritten --
+    # meaning a critical signal (including the forced stop) would have no
+    # effect during exactly the window the car is least predictable. Running
+    # last means whichever value pilot/throttle currently holds -- boosted or
+    # not -- still gets scaled/stopped if a signal says so.
+    #
+    if model_path and getattr(cfg, 'XAI_THROTTLE_SCALING_ENABLED', False):
+        if not use_mc_dropout and not use_novelty and not use_tta:
+            logger.warning("XAI_THROTTLE_SCALING_ENABLED is set but none of "
+                           "XAI_CONFIDENCE_ENABLED / XAI_NOVELTY_ENABLED / "
+                           "XAI_TTA_ENABLED is enabled; throttle scaling "
+                           "has no signal to act on and will be inactive.")
+        from donkeycar.parts.mc_dropout import ThrottleScaler
+        logger.info("Enabling confidence/novelty/TTA-based throttle scaling")
+        throttle_scaler = ThrottleScaler(
+            confidence_reduced_threshold=getattr(cfg, 'XAI_CONFIDENCE_REDUCED_THRESHOLD', 65.0),
+            confidence_critical_threshold=getattr(cfg, 'XAI_CONFIDENCE_CRITICAL_THRESHOLD', 25.0),
+            novelty_reduced_threshold=getattr(cfg, 'XAI_NOVELTY_REDUCED_THRESHOLD', 25.0),
+            novelty_critical_threshold=getattr(cfg, 'XAI_NOVELTY_CRITICAL_THRESHOLD', 65.0),
+            tta_reduced_threshold=getattr(cfg, 'XAI_TTA_REDUCED_THRESHOLD', 65.0),
+            tta_critical_threshold=getattr(cfg, 'XAI_TTA_CRITICAL_THRESHOLD', 25.0),
+            min_scale=getattr(cfg, 'XAI_THROTTLE_MIN_SCALE', 0.4),
+            stop_duration=getattr(cfg, 'XAI_THROTTLE_STOP_DURATION', 1.0))
+        V.add(throttle_scaler,
+              inputs=['pilot/throttle', 'pilot/confidence', 'pilot/novelty',
+                      'pilot/tta_stability'],
+              outputs=['pilot/throttle'],
+              run_condition='run_pilot')
 
     #
     # Decide what inputs should change the car's steering and throttle
@@ -522,6 +734,28 @@ def drive(cfg, model_path=None, use_joystick=False, model_type=None,
     if cfg.RECORD_DURING_AI:
         inputs += ['pilot/angle', 'pilot/throttle']
         types += ['float', 'float']
+
+    # Log the MC-Dropout confidence signal with each frame; this is the
+    # input for the offline Grad-CAM analysis tool. Values are None (and thus
+    # skipped by the tub) whenever the pilot isn't running.
+    if getattr(cfg, 'XAI_CONFIDENCE_ENABLED', False):
+        inputs += ['pilot/confidence', 'pilot/raw_variance',
+                   'pilot/smoothed_variance']
+        types += ['float', 'float', 'float']
+
+    # Log the novelty (out-of-distribution) signal too, independent of
+    # XAI_CONFIDENCE_ENABLED -- input for the offline Grad-CAM analysis tool.
+    if getattr(cfg, 'XAI_NOVELTY_ENABLED', False):
+        inputs += ['pilot/novelty', 'pilot/raw_novelty_distance',
+                   'pilot/smoothed_novelty_distance']
+        types += ['float', 'float', 'float']
+
+    # Log the TTA stability signal too, independent of the others -- input for
+    # the offline analysis timeline.
+    if getattr(cfg, 'XAI_TTA_ENABLED', False):
+        inputs += ['pilot/tta_stability', 'pilot/raw_tta_variance',
+                   'pilot/smoothed_tta_variance']
+        types += ['float', 'float', 'float']
 
     if cfg.HAVE_PERFMON:
         from donkeycar.parts.perfmon import PerfMonitor
@@ -693,9 +927,17 @@ def add_user_controller(V, cfg, use_joystick, input_image='ui/image_array'):
     #
     ctr = LocalWebController(port=cfg.WEB_CONTROL_PORT, mode=cfg.WEB_INIT_MODE)
     V.add(ctr,
-          inputs=[input_image, 'tub/num_records', 'user/mode', 'recording'],
+          inputs=[input_image, 'tub/num_records', 'user/mode', 'recording',
+                  'pilot/confidence', 'pilot/novelty', 'pilot/tta_stability'],
           outputs=['user/steering', 'user/throttle', 'user/mode', 'recording', 'web/buttons'],
           threaded=True)
+    # Keep a reference to the web controller specifically, on the vehicle
+    # itself rather than this function's local `ctr` -- `ctr` gets
+    # REASSIGNED below to a joystick/RC controller when one is configured
+    # (a common setup: joystick to drive, web dashboard just to monitor), so
+    # code elsewhere that needs the actual web controller (e.g. to push the
+    # XAI "not calibrated" dashboard banner) must not rely on `ctr` itself.
+    V.web_ctr = ctr
 
     #
     # also add a physical controller if one is configured

--- a/donkeycar/templates/run_gradcam_analysis.py
+++ b/donkeycar/templates/run_gradcam_analysis.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+Run and view offline explainability analysis (Grad-CAM attention/uncertainty,
+feature-space novelty, and pixel-gradient saliency maps) for a recorded
+drive, entirely from the browser -- no need to remember the underlying
+`python -m donkeycar.parts.gradcam_uncertainty` command-line flags.
+
+Usage:
+    python run_gradcam_analysis.py [--port 8890] [--host 127.0.0.1]
+
+Then open the printed URL. Pick a tub and model (autodiscovered from data/
+and models/ in this directory, or type any path), choose which frames to
+analyse, and click Run -- the page shows live progress and switches to the
+viewer automatically when the analysis finishes.
+
+To view a previously-generated analysis directly (skipping the form), pass
+its directory:
+    python run_gradcam_analysis.py --analysis data/mytub/gradcam_analysis
+"""
+from donkeycar.parts.uncertainty_viewer import main
+
+if __name__ == '__main__':
+    main()

--- a/donkeycar/tests/test_gradcam_saliency.py
+++ b/donkeycar/tests/test_gradcam_saliency.py
@@ -1,0 +1,84 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.parts.gradcam_uncertainty import GradCamUncertainty
+from donkeycar.parts.salient import VanillaGradientSaliency, IntegratedGradients
+
+
+def _tiny_model():
+    """A minimal conv->flatten->linear-output model standing in for the
+    linear pilot: has a Conv2D (for Grad-CAM) and an output layer whose name
+    contains 'out' (for the saliency activation-linearisation helper)."""
+    tf.random.set_seed(0)
+    inp = tf.keras.Input((16, 16, 3))
+    x = tf.keras.layers.Conv2D(4, 3, activation='relu', name='conv')(inp)
+    x = tf.keras.layers.Flatten()(x)
+    out = tf.keras.layers.Dense(1, name='n_outputs0')(x)
+    return tf.keras.Model(inp, out)
+
+
+class TestGradCamPlusPlus(unittest.TestCase):
+
+    def setUp(self):
+        np.random.seed(0)
+        self.model = _tiny_model()
+        self.engine = GradCamUncertainty(self.model, num_passes=4)
+        self.img_u8 = (np.random.rand(16, 16, 3) * 255).astype(np.uint8)
+        self.norm = np.random.rand(16, 16, 3).astype(np.float32)
+
+    def test_attention_maps_pp_shape_and_range(self):
+        maps = self.engine.attention_maps_pp(self.norm)
+        self.assertEqual(maps.shape[0], 4)  # one per pass
+        self.assertTrue(np.all(np.isfinite(maps)))
+        self.assertGreaterEqual(maps.min(), 0.0)
+        self.assertLessEqual(maps.max(), 1.0 + 1e-6)
+
+    def test_attention_pp_map_upsampled_to_image_size(self):
+        m = self.engine.attention_pp_map(self.img_u8)
+        self.assertEqual(m.shape, self.img_u8.shape[:2])
+        self.assertTrue(np.all(np.isfinite(m)))
+        self.assertGreaterEqual(m.min(), 0.0)
+        self.assertLessEqual(m.max(), 1.0 + 1e-6)
+
+    def test_pp_is_not_identical_to_plain_gradcam(self):
+        # Grad-CAM++ must not degenerate into plain Grad-CAM (the regression
+        # gotcha the implementation guards against).
+        mean_map, _, _ = self.engine.uncertainty_map(self.img_u8)
+        pp_map = self.engine.attention_pp_map(self.img_u8)
+        self.assertGreater(np.abs(pp_map - mean_map).mean(), 1e-6)
+
+
+class TestIntegratedGradients(unittest.TestCase):
+
+    def setUp(self):
+        np.random.seed(1)
+        self.model = _tiny_model()
+        self.engine = IntegratedGradients(self.model, steps=16)
+        self.norm = np.random.rand(16, 16, 3).astype(np.float32)
+
+    def test_shape_and_range(self):
+        m = self.engine.saliency_map(self.norm)
+        self.assertEqual(m.shape, self.norm.shape[:2])
+        self.assertTrue(np.all(np.isfinite(m)))
+        self.assertGreaterEqual(m.min(), 0.0)
+        self.assertLessEqual(m.max(), 1.0 + 1e-6)
+
+    def test_zero_when_baseline_equals_input(self):
+        # IG axiom: with baseline == input, (input - baseline) == 0, so every
+        # attribution is exactly zero -- a deterministic sanity check.
+        engine = IntegratedGradients(self.model, steps=8, baseline=self.norm)
+        m = engine.saliency_map(self.norm)
+        self.assertTrue(np.allclose(m, 0.0))
+
+    def test_step_count_is_configurable(self):
+        few = IntegratedGradients(self.model, steps=4).saliency_map(self.norm)
+        many = IntegratedGradients(self.model, steps=48).saliency_map(self.norm)
+        self.assertEqual(few.shape, many.shape)
+        self.assertTrue(np.all(np.isfinite(few)))
+        self.assertTrue(np.all(np.isfinite(many)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/donkeycar/tests/test_image_transformations.py
+++ b/donkeycar/tests/test_image_transformations.py
@@ -1,0 +1,228 @@
+import json
+import os
+
+import pytest
+
+from donkeycar.config import Config
+from donkeycar.parts.image_transformations import (
+    ImageTransformations,
+    _pipeline_steps,
+    build_preprocessing_metadata,
+    check_preprocessing_metadata,
+    load_config_and_myconfig,
+    save_preprocessing_metadata,
+)
+
+
+class TestImageTransformationsDoesNotMutateConfig:
+    def test_config_transformations_list_is_left_alone(self):
+        # The two-arg form concatenates TRANSFORMATIONS + POST_TRANSFORMATIONS
+        # for its own use; doing that with `+=` would extend the config's own
+        # list in place, so every later reader (drive-time transformation
+        # drift checks, preprocessing metadata) would see a pipeline the user
+        # never configured.
+        cfg = Config()
+        cfg.TRANSFORMATIONS = []
+        cfg.POST_TRANSFORMATIONS = ['CROP']
+        cfg.ROI_CROP_TOP = 45
+        cfg.ROI_CROP_BOTTOM = 0
+        cfg.ROI_CROP_LEFT = 0
+        cfg.ROI_CROP_RIGHT = 0
+
+        part = ImageTransformations(cfg, 'TRANSFORMATIONS',
+                                    'POST_TRANSFORMATIONS')
+        assert len(part.transformations) == 1     # the CROP was picked up
+        assert cfg.TRANSFORMATIONS == []          # but the config is untouched
+        assert cfg.POST_TRANSFORMATIONS == ['CROP']
+
+
+class TestLoadConfigAndMyconfig:
+    def test_defaults_to_local_config_py(self, tmp_path, monkeypatch):
+        # The standard `donkey createcar` layout: running an analysis tool
+        # from the car directory with no --config must pick up ./config.py
+        # (it used to hit os.path.abspath(None) and crash instead).
+        (tmp_path / 'config.py').write_text('IMAGE_W = 111\nIMAGE_H = 222\n')
+        monkeypatch.chdir(tmp_path)
+
+        cfg = load_config_and_myconfig(None)
+        assert cfg.IMAGE_W == 111
+        assert cfg.IMAGE_H == 222
+
+    def test_local_myconfig_overrides_config(self, tmp_path, monkeypatch):
+        (tmp_path / 'config.py').write_text('IMAGE_W = 111\nIMAGE_H = 222\n')
+        (tmp_path / 'myconfig.py').write_text('IMAGE_W = 999\n')
+        monkeypatch.chdir(tmp_path)
+
+        cfg = load_config_and_myconfig(None)
+        assert cfg.IMAGE_W == 999     # override applied
+        assert cfg.IMAGE_H == 222     # base setting retained
+
+    def test_falls_back_to_bundled_template_outside_a_car_dir(
+            self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert not os.path.exists('config.py')
+
+        cfg = load_config_and_myconfig(None)
+        # cfg_complete.py defines these; the point is simply that we loaded
+        # a full base config rather than raising.
+        assert cfg.IMAGE_W is not None
+        assert cfg.DRIVE_LOOP_HZ is not None
+
+
+class TestPipelineOrder:
+    def test_augmentation_runs_before_crop_in_training(self):
+        cfg = Config()
+        cfg.TRANSFORMATIONS = []
+        cfg.POST_TRANSFORMATIONS = ['CROP']
+        cfg.AUGMENTATIONS = ['BRIGHTNESS', 'BLUR']
+
+        training_steps = _pipeline_steps(cfg, include_augmentations=True)
+        assert training_steps == ['BRIGHTNESS', 'BLUR', 'CROP']
+        assert training_steps.index('CROP') > training_steps.index('BLUR')
+
+    def test_validation_and_driving_never_see_augmentation(self):
+        cfg = Config()
+        cfg.TRANSFORMATIONS = []
+        cfg.POST_TRANSFORMATIONS = ['CROP']
+        cfg.AUGMENTATIONS = ['BRIGHTNESS', 'BLUR']
+
+        steps = _pipeline_steps(cfg, include_augmentations=False)
+        assert steps == ['CROP']
+        assert 'BRIGHTNESS' not in steps
+        assert 'BLUR' not in steps
+
+
+class TestPreprocessingMetadata:
+    def crop_cfg(self):
+        cfg = Config()
+        cfg.IMAGE_W = 160
+        cfg.IMAGE_H = 120
+        cfg.TRANSFORMATIONS = []
+        cfg.POST_TRANSFORMATIONS = ['CROP']
+        cfg.ROI_CROP_TOP = 45
+        cfg.ROI_CROP_BOTTOM = 0
+        cfg.ROI_CROP_LEFT = 0
+        cfg.ROI_CROP_RIGHT = 0
+        return cfg
+
+    def test_build_metadata_reflects_config(self):
+        meta = build_preprocessing_metadata(self.crop_cfg())
+        assert meta['image_width'] == 160
+        assert meta['image_height'] == 120
+        assert meta['roi_crop_top'] == 45
+        assert meta['pipeline_steps'] == ['CROP']
+
+    def test_save_then_check_matching_config_does_not_raise(self, tmp_path):
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'mypilot.h5')
+        with open(model_path, 'w') as f:
+            f.write('placeholder')
+        save_preprocessing_metadata(cfg, model_path)
+
+        sidecar = tmp_path / 'mypilot.preprocessing.json'
+        assert sidecar.exists()
+        with open(sidecar) as f:
+            saved = json.load(f)
+        assert saved['roi_crop_top'] == 45
+
+        # must not raise when config matches what was saved
+        check_preprocessing_metadata(cfg, model_path)
+
+    def test_check_detects_mismatch(self, tmp_path):
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'mypilot.h5')
+        with open(model_path, 'w') as f:
+            f.write('placeholder')
+        save_preprocessing_metadata(cfg, model_path)
+
+        drifted_cfg = self.crop_cfg()
+        drifted_cfg.ROI_CROP_TOP = 30  # simulates a stale/edited car config
+        with pytest.raises(RuntimeError, match='roi_crop_top'):
+            check_preprocessing_metadata(drifted_cfg, model_path)
+
+    def test_missing_sidecar_only_warns(self, tmp_path):
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'never_trained.h5')
+        # no sidecar file written at all
+        check_preprocessing_metadata(cfg, model_path)  # must not raise
+
+    def test_detects_added_transformation_step(self, tmp_path):
+        # The ROI_CROP_* fields are identical on both sides here; only the
+        # step list differs, which is exactly what pipeline_steps exists to
+        # catch (CANNY keeps the image dimensions, so nothing else would).
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'mypilot.h5')
+        with open(model_path, 'w') as f:
+            f.write('placeholder')
+        save_preprocessing_metadata(cfg, model_path)
+
+        drifted_cfg = self.crop_cfg()
+        drifted_cfg.POST_TRANSFORMATIONS = ['CROP', 'CANNY']
+        with pytest.raises(RuntimeError, match='pipeline_steps'):
+            check_preprocessing_metadata(drifted_cfg, model_path)
+
+    def test_legacy_sidecar_missing_new_fields_does_not_false_positive(
+            self, tmp_path):
+        # A sidecar saved before pipeline_steps existed (simulated here by
+        # stripping that key) must not be treated as a mismatch just because
+        # it lacks a field it predates - only fields it actually recorded
+        # should ever be compared.
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'mypilot.h5')
+        with open(model_path, 'w') as f:
+            f.write('placeholder')
+        save_preprocessing_metadata(cfg, model_path)
+
+        sidecar_path = str(tmp_path / 'mypilot.preprocessing.json')
+        with open(sidecar_path) as f:
+            saved = json.load(f)
+        del saved['pipeline_steps']
+        with open(sidecar_path, 'w') as f:
+            json.dump(saved, f)
+
+        check_preprocessing_metadata(cfg, model_path)  # must not raise
+
+    def test_skip_keys_excludes_fields_the_caller_reconciles_itself(
+            self, tmp_path):
+        # The offline analysis path calls check_model_image_size() first,
+        # which takes the model file as the authority on its input size and
+        # rewrites cfg to match (a documented convenience). Resolution is
+        # therefore excluded from this comparison explicitly -- but the crop
+        # geometry, which the model file cannot self-describe, must still be
+        # enforced.
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'mypilot.h5')
+        with open(model_path, 'w') as f:
+            f.write('placeholder')
+        save_preprocessing_metadata(cfg, model_path)
+
+        res_only = self.crop_cfg()
+        res_only.IMAGE_W = 192
+        res_only.IMAGE_H = 108
+        # must NOT raise: resolution is reconciled by check_model_image_size
+        check_preprocessing_metadata(
+            res_only, model_path, skip_keys=('image_width', 'image_height'))
+        # ... but it still raises without the exemption
+        with pytest.raises(RuntimeError, match='image_width'):
+            check_preprocessing_metadata(res_only, model_path)
+
+        # and a real crop mismatch is still caught even with the exemption
+        crop_drift = self.crop_cfg()
+        crop_drift.ROI_CROP_TOP = 30
+        with pytest.raises(RuntimeError, match='roi_crop_top'):
+            check_preprocessing_metadata(
+                crop_drift, model_path,
+                skip_keys=('image_width', 'image_height'))
+
+    def test_context_appears_in_mismatch_message(self, tmp_path):
+        cfg = self.crop_cfg()
+        model_path = str(tmp_path / 'mypilot.h5')
+        with open(model_path, 'w') as f:
+            f.write('placeholder')
+        save_preprocessing_metadata(cfg, model_path)
+
+        drifted_cfg = self.crop_cfg()
+        drifted_cfg.ROI_CROP_TOP = 30
+        with pytest.raises(RuntimeError, match="analysis's config"):
+            check_preprocessing_metadata(
+                drifted_cfg, model_path, context="this analysis's config")

--- a/donkeycar/tests/test_mc_calibrate.py
+++ b/donkeycar/tests/test_mc_calibrate.py
@@ -1,0 +1,392 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+from donkeycar.parts.mc_calibrate import (
+    build_calibration, variance_to_confidence, novelty_distance_to_score,
+    tta_variance_to_stability, _make_strictly_increasing,
+    missing_calibration_reason, _replay_ema, _record_timestamps_sec,
+)
+
+
+class TestConfidenceCalibration(unittest.TestCase):
+
+    def setUp(self):
+        rng = np.random.default_rng(42)
+        variances = rng.gamma(shape=2.0, scale=0.01, size=1000)  # always > 0
+        self.calib = build_calibration(variances, num_passes=15, alpha=0.2)
+
+    def test_confidence_is_monotonically_decreasing_with_variance(self):
+        xs = self.calib['confidence_anchors']['variance']
+        samples = np.linspace(xs[0], xs[-1], 50)
+        scores = [variance_to_confidence(v, self.calib) for v in samples]
+        for a, b in zip(scores, scores[1:]):
+            self.assertGreaterEqual(a, b - 1e-9)
+
+    def test_confidence_clamps_outside_anchor_range(self):
+        below_range = variance_to_confidence(-1.0, self.calib)
+        above_range = variance_to_confidence(1e6, self.calib)
+        self.assertAlmostEqual(below_range, 99.0, places=6)  # min-variance anchor
+        self.assertAlmostEqual(above_range, 5.0, places=6)   # max-variance anchor
+
+
+class TestNoveltyCalibration(unittest.TestCase):
+
+    def setUp(self):
+        rng = np.random.default_rng(7)
+        variances = rng.gamma(shape=2.0, scale=0.01, size=500)
+        feats = rng.normal(size=(500, 64))
+        self.calib = build_calibration(variances, num_passes=15, alpha=0.2,
+                                       ood_features=feats,
+                                       ood_encoder='mobilenet_v2',
+                                       ood_input_size=128)
+        self.block = self.calib['novelty_ood']
+
+    def test_novelty_block_is_built(self):
+        self.assertIn('novelty_ood', self.calib)
+
+    def test_novelty_is_monotonically_increasing_with_distance(self):
+        xs = self.block['score_anchors']['distance']
+        samples = np.linspace(xs[0], xs[-1], 50)
+        scores = [novelty_distance_to_score(d, self.block) for d in samples]
+        for a, b in zip(scores, scores[1:]):
+            self.assertLessEqual(a, b + 1e-9)
+
+    def test_novelty_clamps_outside_anchor_range(self):
+        below_range = novelty_distance_to_score(-1.0, self.block)
+        above_range = novelty_distance_to_score(1e6, self.block)
+        self.assertAlmostEqual(below_range, 2.0, places=6)   # min-distance anchor
+        self.assertAlmostEqual(above_range, 98.0, places=6)  # max-distance anchor
+
+    def test_no_features_means_no_novelty_blocks(self):
+        rng = np.random.default_rng(8)
+        variances = rng.gamma(shape=2.0, scale=0.01, size=100)
+        calib = build_calibration(variances, num_passes=15, alpha=0.2)
+        self.assertNotIn('novelty_ood', calib)
+        self.assertNotIn('novelty_ood_spatial', calib)
+
+    def test_spatial_block_records_its_encoder_geometry(self):
+        # The offline heat map has to rebuild an extractor with exactly the
+        # input size it was fitted at, or the per-location distances mean
+        # nothing -- so the geometry travels with the block.
+        rng = np.random.default_rng(9)
+        variances = rng.gamma(shape=2.0, scale=0.01, size=200)
+        calib = build_calibration(variances, num_passes=15, alpha=0.2,
+                                  ood_spatial_features=rng.normal(
+                                      size=(400, 32)),
+                                  ood_encoder='mobilenet_v2',
+                                  ood_spatial_input_hw=(224, 384))
+        block = calib['novelty_ood_spatial']
+        self.assertEqual(block['input_hw'], [224, 384])
+        self.assertEqual(block['encoder'], 'mobilenet_v2')
+        self.assertEqual(block['feat_dim'], 32)
+        # and it still scores like every other novelty block
+        xs = block['score_anchors']['distance']
+        scores = [novelty_distance_to_score(d, block)
+                  for d in np.linspace(xs[0], xs[-1], 20)]
+        for a, b in zip(scores, scores[1:]):
+            self.assertLessEqual(a, b + 1e-9)
+
+    def test_legacy_task_collapsed_blocks_are_no_longer_written(self):
+        # novelty_global (dense_2) was never read by anything once novelty
+        # moved to a generic encoder, and novelty_spatial (conv2d_5) has been
+        # replaced by the encoder-space map. Neither should reappear.
+        rng = np.random.default_rng(10)
+        calib = build_calibration(rng.gamma(2.0, 0.01, 100), num_passes=15,
+                                  alpha=0.2,
+                                  ood_features=rng.normal(size=(100, 16)),
+                                  ood_encoder='mobilenet_v2',
+                                  ood_input_size=128)
+        self.assertNotIn('novelty_global', calib)
+        self.assertNotIn('novelty_spatial', calib)
+
+
+class TestTTACalibration(unittest.TestCase):
+
+    def setUp(self):
+        rng = np.random.default_rng(11)
+        variances = rng.gamma(shape=2.0, scale=0.01, size=500)
+        tta_variances = rng.gamma(shape=2.0, scale=1e-4, size=500)
+        self.calib = build_calibration(variances, num_passes=15, alpha=0.2,
+                                       tta_variances=tta_variances,
+                                       tta_num_samples=8, tta_strength=0.2,
+                                       tta_alpha=0.2)
+        self.block = self.calib['tta']
+
+    def test_tta_block_is_built_with_metadata(self):
+        self.assertIn('tta', self.calib)
+        self.assertEqual(self.block['num_samples'], 8)
+        self.assertEqual(self.block['strength'], 0.2)
+
+    def test_stability_is_monotonically_decreasing_with_variance(self):
+        xs = self.block['stability_anchors']['variance']
+        samples = np.linspace(xs[0], xs[-1], 50)
+        scores = [tta_variance_to_stability(v, self.block) for v in samples]
+        for a, b in zip(scores, scores[1:]):
+            self.assertGreaterEqual(a, b - 1e-9)
+
+    def test_stability_clamps_outside_anchor_range(self):
+        below = tta_variance_to_stability(-1.0, self.block)
+        above = tta_variance_to_stability(1e6, self.block)
+        self.assertAlmostEqual(below, 99.0, places=6)  # min-variance anchor
+        self.assertAlmostEqual(above, 5.0, places=6)   # max-variance anchor
+
+    def test_no_tta_variances_means_no_tta_block(self):
+        rng = np.random.default_rng(12)
+        calib = build_calibration(rng.gamma(2.0, 0.01, 100), num_passes=15,
+                                  alpha=0.2)
+        self.assertNotIn('tta', calib)
+
+
+class TestAugmentationProvenance(unittest.TestCase):
+    """The 'augmentation' block records how the novelty baselines were fit
+    (clean-only vs widened with training-style augmented frames), so a
+    calibration can be told apart from an older one after the fact."""
+
+    def _variances(self, n=200, seed=21):
+        return np.random.default_rng(seed).gamma(shape=2.0, scale=0.01, size=n)
+
+    def test_absent_when_not_supplied_keeps_older_calibrations_valid(self):
+        calib = build_calibration(self._variances(), num_passes=15, alpha=0.2)
+        self.assertNotIn('augmentation', calib)
+
+    def test_recorded_verbatim_when_supplied(self):
+        info = {'applied': True, 'augmentations': ['SHADOW', 'GAMMA'],
+                'passes': 2, 'stride': 12, 'n_augmented_samples': 1500,
+                'n_clean_samples': 9221, 'scope': 'novelty baselines only'}
+        calib = build_calibration(self._variances(), num_passes=15, alpha=0.2,
+                                  augmentation_info=info)
+        self.assertEqual(calib['augmentation'], info)
+
+    def test_does_not_disturb_the_confidence_calibration(self):
+        """Provenance is metadata: adding it must not move any number the
+        confidence signal reads."""
+        v = self._variances()
+        plain = build_calibration(v, num_passes=15, alpha=0.2)
+        with_info = build_calibration(v, num_passes=15, alpha=0.2,
+                                      augmentation_info={'applied': False})
+        self.assertEqual(plain['percentiles'], with_info['percentiles'])
+        self.assertEqual(plain['confidence_anchors'],
+                         with_info['confidence_anchors'])
+        self.assertEqual(plain['n_frames'], with_info['n_frames'])
+        self.assertEqual(plain['tiers'], with_info['tiers'])
+
+    def test_n_frames_counts_clean_frames_only(self):
+        """Augmented samples are pooled into the novelty feature matrices but
+        never into the variance distribution, so the reported frame count
+        must still describe the replay, not the enlarged feature set."""
+        rng = np.random.default_rng(31)
+        variances = rng.gamma(shape=2.0, scale=0.01, size=300)
+        # 300 clean frames, but 900 novelty feature vectors (clean + augmented)
+        feats = rng.normal(size=(900, 64))
+        calib = build_calibration(variances, num_passes=15, alpha=0.2,
+                                  ood_features=feats,
+                                  ood_encoder='mobilenet_v2',
+                                  ood_input_size=128,
+                                  augmentation_info={'applied': True,
+                                                     'n_augmented_samples': 600})
+        self.assertEqual(calib['n_frames'], 300)
+        self.assertIn('novelty_ood', calib)
+
+
+class TestMissingCalibrationReason(unittest.TestCase):
+    """A calib.json can exist while lacking the block a given signal needs
+    (e.g. written before that signal shipped). Checking only for the file
+    would leave that signal silently blank on the dashboard -- no panel and
+    no 'not calibrated' banner, indistinguishable from the feature being off.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.path = os.path.join(self.tmp, 'model.calib.json')
+
+    def _write(self, calib):
+        with open(self.path, 'w') as f:
+            json.dump(calib, f)
+        return self.path
+
+    def test_absent_file_is_reported_for_every_signal(self):
+        missing = os.path.join(self.tmp, 'nope.calib.json')
+        for signal in ('confidence', 'novelty', 'tta'):
+            reason = missing_calibration_reason(missing, signal)
+            self.assertIsNotNone(reason)
+            self.assertIn("doesn't exist", reason)
+
+    def test_present_block_reports_no_reason(self):
+        self._write({'confidence_anchors': {}, 'novelty_ood': {}, 'tta': {}})
+        for signal in ('confidence', 'novelty', 'tta'):
+            self.assertIsNone(missing_calibration_reason(self.path, signal))
+
+    def test_file_present_but_block_missing_is_still_reported(self):
+        # The realistic case: an older calibration with confidence+novelty
+        # but no TTA block.
+        self._write({'confidence_anchors': {}, 'novelty_ood': {}})
+        self.assertIsNone(missing_calibration_reason(self.path, 'confidence'))
+        self.assertIsNone(missing_calibration_reason(self.path, 'novelty'))
+        tta_reason = missing_calibration_reason(self.path, 'tta')
+        self.assertIsNotNone(tta_reason)
+        self.assertIn('tta', tta_reason)
+
+    def test_unreadable_file_is_reported_rather_than_raising(self):
+        with open(self.path, 'w') as f:
+            f.write('{not valid json')
+        reason = missing_calibration_reason(self.path, 'confidence')
+        self.assertIsNotNone(reason)
+        self.assertIn('could not be read', reason)
+
+
+class TestMakeStrictlyIncreasing(unittest.TestCase):
+
+    def test_nudges_duplicate_values_strictly_increasing(self):
+        xs = _make_strictly_increasing([1.0, 1.0, 1.0, 2.0])
+        for a, b in zip(xs, xs[1:]):
+            self.assertLess(a, b)
+
+    def test_already_increasing_values_are_unchanged(self):
+        xs = _make_strictly_increasing([1.0, 2.0, 3.0])
+        self.assertEqual(xs, [1.0, 2.0, 3.0])
+
+
+class TestReplayEma(unittest.TestCase):
+    """_replay_ema reproduces, over an already-computed sequence, exactly the
+    hold-between-updates + EMA-fold logic MCDropoutConfidence/
+    FeatureNoveltyDetector/TTAStabilityDetector apply live in run()."""
+
+    def test_interval_zero_updates_every_entry_like_a_plain_ema(self):
+        values = [1.0, 2.0, 3.0, 4.0]
+        ts = [0.0, 1.0, 2.0, 3.0]
+        out = _replay_ema(values, ts, alpha=0.5, interval=0.0)
+        expected = [1.0, 1.5, 2.25, 3.125]   # standard EMA fold, alpha=0.5
+        np.testing.assert_allclose(out, expected)
+
+    def test_first_value_seeds_the_ema_unsmoothed(self):
+        out = _replay_ema([7.0, 7.0], [0.0, 0.1], alpha=0.2, interval=0.0)
+        self.assertEqual(out[0], 7.0)
+
+    def test_held_entries_repeat_the_last_smoothed_value(self):
+        # updates at t=0 and t=1 (>=1s apart); the entries at t=0.2 and t=0.5
+        # arrive too soon (interval=1.0) and must just repeat the t=0 value.
+        values = [10.0, 10.0, 10.0, 20.0]
+        ts = [0.0, 0.2, 0.5, 1.0]
+        out = _replay_ema(values, ts, alpha=0.5, interval=1.0)
+        self.assertEqual(out[0], out[1])
+        self.assertEqual(out[1], out[2])
+        # the update at t=1.0 folds 20.0 in (not just repeats 10.0)
+        self.assertAlmostEqual(out[3], 0.5 * 20.0 + 0.5 * 10.0)
+
+    def test_none_timestamps_updates_every_entry_regardless_of_interval(self):
+        # No _timestamp_ms on the tub -- caller is expected to pass interval=0
+        # in that case (mc_calibrate does), but the function itself is also
+        # safe if interval>0 is passed with timestamps=None: nothing can ever
+        # look "too soon" without a clock, so every entry updates.
+        values = [1.0, 5.0, 1.0, 5.0]
+        out = _replay_ema(values, None, alpha=0.5, interval=1.0)
+        # not constant -- proves entries after the first actually updated
+        self.assertNotEqual(out[1], out[0])
+        self.assertNotEqual(out[2], out[1])
+
+    def test_matches_feature_novelty_detector_semantics(self):
+        # Cross-check against FeatureNoveltyDetector's own EMA formula
+        # (self.smoothed = alpha*raw + (1-alpha)*smoothed, first = raw) over
+        # an unthrottled (interval=0) sequence.
+        rng = np.random.default_rng(3)
+        values = rng.gamma(2.0, 1.0, size=25)
+        alpha = 0.2
+        expected = []
+        sm = None
+        for v in values:
+            sm = v if sm is None else alpha * v + (1 - alpha) * sm
+            expected.append(sm)
+        out = _replay_ema(values, list(range(len(values))), alpha, 0.0)
+        np.testing.assert_allclose(out, expected)
+
+
+class TestRecordTimestampsSec(unittest.TestCase):
+
+    class _FakeRecord:
+        def __init__(self, ts_ms):
+            self.underlying = {'_timestamp_ms': ts_ms}
+
+    def test_converts_ms_to_seconds_in_order(self):
+        records = [self._FakeRecord(0), self._FakeRecord(500),
+                  self._FakeRecord(1500)]
+        self.assertEqual(_record_timestamps_sec(records), [0.0, 0.5, 1.5])
+
+    def test_any_missing_timestamp_returns_none(self):
+        records = [self._FakeRecord(0), self._FakeRecord(None)]
+        self.assertIsNone(_record_timestamps_sec(records))
+
+
+class TestNoveltyAnchorDistances(unittest.TestCase):
+    """The live 'novelty_ood' block must be percentile-anchored on whatever
+    distances it's given via ood_anchor_distances (the calibration replay's
+    own EMA-smoothed sequence) rather than the raw per-vector distances of
+    ood_features -- see _build_novelty_block's docstring for why scoring a
+    smoothed value against raw-fitted anchors silently mismatches."""
+
+    def test_anchors_reflect_the_passed_distances_not_the_raw_ones(self):
+        rng = np.random.default_rng(5)
+        feats = rng.normal(size=(300, 16))
+        # A synthetic "smoothed" sequence with an artificially narrow spread
+        # relative to the raw feature-implied distances, mirroring how a real
+        # EMA-smoothed sequence has less spread than the raw one it smooths.
+        narrow_distances = np.full(300, 3.0)  # every entry identical
+
+        calib_raw = build_calibration(
+            rng.gamma(2.0, 0.01, 100), num_passes=15, alpha=0.2,
+            ood_features=feats, ood_encoder='mobilenet_v2', ood_input_size=128)
+        calib_anchored = build_calibration(
+            rng.gamma(2.0, 0.01, 100), num_passes=15, alpha=0.2,
+            ood_features=feats, ood_encoder='mobilenet_v2', ood_input_size=128,
+            ood_anchor_distances=narrow_distances)
+
+        raw_anchors = calib_raw['novelty_ood']['score_anchors']['distance']
+        forced_anchors = calib_anchored['novelty_ood']['score_anchors']['distance']
+        # With every anchor_distance identical (3.0), min/p50/p80/p97/max
+        # collapse to the same nudged-apart value near 3.0 -- nothing like
+        # the spread of the real per-vector distances used for `calib_raw`.
+        self.assertNotEqual(raw_anchors, forced_anchors)
+        for x in forced_anchors:
+            self.assertAlmostEqual(x, 3.0, places=6)
+
+    def test_mean_var_active_dims_unaffected_by_anchor_distances(self):
+        # anchor_distances only changes what the PERCENTILES are fit on, not
+        # the Gaussian itself -- that still describes ood_features.
+        rng = np.random.default_rng(6)
+        feats = rng.normal(size=(200, 8))
+        calib_raw = build_calibration(
+            rng.gamma(2.0, 0.01, 50), num_passes=15, alpha=0.2,
+            ood_features=feats, ood_encoder='mobilenet_v2', ood_input_size=128)
+        calib_anchored = build_calibration(
+            rng.gamma(2.0, 0.01, 50), num_passes=15, alpha=0.2,
+            ood_features=feats, ood_encoder='mobilenet_v2', ood_input_size=128,
+            ood_anchor_distances=np.ones(200) * 7.0)
+        self.assertEqual(calib_raw['novelty_ood']['mean'],
+                         calib_anchored['novelty_ood']['mean'])
+        self.assertEqual(calib_raw['novelty_ood']['var'],
+                         calib_anchored['novelty_ood']['var'])
+
+    def test_spatial_block_is_never_affected_by_anchor_distances(self):
+        # novelty_ood_spatial has no smoothing/interval concept -- passing
+        # ood_anchor_distances must only touch the live pooled block.
+        rng = np.random.default_rng(7)
+        feats = rng.normal(size=(100, 8))
+        spatial_feats = rng.normal(size=(400, 8))
+        calib = build_calibration(
+            rng.gamma(2.0, 0.01, 50), num_passes=15, alpha=0.2,
+            ood_features=feats, ood_encoder='mobilenet_v2', ood_input_size=128,
+            ood_anchor_distances=np.ones(100) * 9.0,
+            ood_spatial_features=spatial_feats, ood_encoder_file=None,
+            ood_spatial_input_hw=(224, 384))
+        spatial_anchors = calib['novelty_ood_spatial']['score_anchors']['distance']
+        # not collapsed to ~9.0 like the pooled block would be
+        self.assertFalse(all(abs(x - 9.0) < 1e-6 for x in spatial_anchors))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/donkeycar/tests/test_mc_dropout.py
+++ b/donkeycar/tests/test_mc_dropout.py
@@ -1,0 +1,103 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.parts.mc_dropout import MCDropoutConfidence
+
+
+def _tiny_dropout_pilot():
+    """Minimal single-image-input, two-output (angle/throttle) model with a
+    real Dropout layer, wrapped in a stub pilot exposing .interpreter.model /
+    .interpreter.input_keys AND a .run() method -- the surface
+    MCDropoutConfidence reaches for (the latter is used on held/interval
+    frames, which fall back to a cheap single deterministic pass via
+    pilot.run() rather than the N-pass stochastic batch)."""
+    tf.random.set_seed(0)
+    inp = tf.keras.Input((16, 16, 3), name='img_in')
+    x = tf.keras.layers.Conv2D(4, 3, activation='relu')(inp)
+    x = tf.keras.layers.Flatten()(x)
+    x = tf.keras.layers.Dropout(0.2)(x)
+    angle = tf.keras.layers.Dense(1, name='angle')(x)
+    throttle = tf.keras.layers.Dense(1, name='throttle')(x)
+    model = tf.keras.Model(inp, [angle, throttle])
+
+    class _Interp:
+        def __init__(self, m):
+            self.model = m
+            self.input_keys = ['img_in']
+
+    class _Pilot:
+        def __init__(self, m):
+            self.interpreter = _Interp(m)
+
+        def run(self, img_arr, *other_arr):
+            from donkeycar.utils import normalize_image
+            norm = normalize_image(img_arr).astype(np.float32)
+            out = self.interpreter.model(
+                {'img_in': tf.convert_to_tensor(norm[np.newaxis, ...])},
+                training=False)
+            return float(np.asarray(out[0]).reshape(-1)[0]), \
+                float(np.asarray(out[1]).reshape(-1)[0])
+
+    return _Pilot(model)
+
+
+class TestMCDropoutConfidenceInterval(unittest.TestCase):
+    # Mirrors TestTTAStabilityDetectorInterval / TestFeatureNoveltyDetector
+    # Interval in test_tta.py / test_novelty.py -- MCDropoutConfidence is the
+    # third of the three signals mc_calibrate.calibrate_from_tub now replays
+    # at the tub's own recorded cadence via the same now= override.
+
+    def setUp(self):
+        self.pilot = _tiny_dropout_pilot()
+        self.img = (np.random.default_rng(0).random((16, 16, 3))
+                   * 255).astype(np.uint8)
+
+    def _counting_part(self, interval):
+        part = MCDropoutConfidence(self.pilot, num_passes=4,
+                                   interval=interval)
+        calls = {'n': 0}
+        real_model = part.model
+
+        def counting_call(*a, **kw):
+            calls['n'] += 1
+            return real_model(*a, **kw)
+
+        part.model = counting_call
+        return part, calls
+
+    def test_zero_interval_runs_stochastic_pass_every_frame(self):
+        part, calls = self._counting_part(interval=0.0)
+        part.run(self.img); part.run(self.img); part.run(self.img)
+        self.assertEqual(calls['n'], 3)
+
+    def test_now_override_drives_the_interval_gate_without_mocking_time(self):
+        part, calls = self._counting_part(interval=1.0)
+        part.run(self.img, now=100.0)
+        self.assertEqual(calls['n'], 1)
+        part.run(self.img, now=100.5)   # < 1.0s since the last update -> held
+        self.assertEqual(calls['n'], 1)
+        part.run(self.img, now=101.5)   # >= 1.0s since the last update
+        self.assertEqual(calls['n'], 2)
+
+    def test_held_smoothed_variance_matches_last_real_update(self):
+        part, _ = self._counting_part(interval=1.0)
+        _, _, _, _, smoothed1 = part.run(self.img, now=100.0)
+        _, _, _, _, smoothed2 = part.run(self.img, now=100.3)   # held
+        self.assertEqual(smoothed1, smoothed2)
+
+    def test_now_none_falls_back_to_wall_clock(self):
+        part, calls = self._counting_part(interval=1.0)
+        with mock.patch('donkeycar.parts.mc_dropout.time.time',
+                        return_value=200.0):
+            part.run(self.img)
+        with mock.patch('donkeycar.parts.mc_dropout.time.time',
+                        return_value=200.2):
+            part.run(self.img)
+        self.assertEqual(calls['n'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/donkeycar/tests/test_novelty.py
+++ b/donkeycar/tests/test_novelty.py
@@ -1,0 +1,169 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from donkeycar.parts.novelty import (mahalanobis_diag, fit_diagonal_gaussian,
+                                     FeatureNoveltyDetector)
+
+
+class TestMahalanobisDiag(unittest.TestCase):
+
+    def test_zero_at_mean(self):
+        mean = np.zeros(5)
+        var = np.ones(5)
+        self.assertAlmostEqual(mahalanobis_diag(mean, mean, var), 0.0, places=6)
+
+    def test_increases_with_distance(self):
+        mean = np.zeros(5)
+        var = np.ones(5)
+        near = mahalanobis_diag(np.full(5, 0.1), mean, var)
+        far = mahalanobis_diag(np.full(5, 5.0), mean, var)
+        self.assertGreater(far, near)
+
+    def test_active_dims_excludes_dimension(self):
+        mean = np.zeros(3)
+        var = np.ones(3)
+        vec = np.array([0.0, 0.0, 100.0])  # huge deviation, only in dim 2
+        active_all = np.array([True, True, True])
+        active_excl_dim2 = np.array([True, True, False])
+        dist_all = mahalanobis_diag(vec, mean, var, active_all)
+        dist_excl = mahalanobis_diag(vec, mean, var, active_excl_dim2)
+        self.assertAlmostEqual(dist_excl, 0.0, places=6)
+        self.assertGreater(dist_all, dist_excl)
+
+    def test_batched_input_returns_one_distance_per_row(self):
+        mean = np.zeros(4)
+        var = np.ones(4)
+        batch = np.stack([np.zeros(4), np.ones(4)])
+        distances = mahalanobis_diag(batch, mean, var)
+        self.assertEqual(distances.shape, (2,))
+        self.assertAlmostEqual(distances[0], 0.0, places=6)
+        self.assertGreater(distances[1], 0.0)
+
+
+class TestFitDiagonalGaussian(unittest.TestCase):
+
+    def test_mean_and_var_match_numpy(self):
+        rng = np.random.default_rng(0)
+        data = rng.normal(loc=3.0, scale=2.0, size=(500, 5))
+        stats = fit_diagonal_gaussian(data)
+        np.testing.assert_allclose(stats['mean'], data.mean(axis=0), rtol=1e-9)
+        np.testing.assert_allclose(stats['var'], data.var(axis=0), rtol=1e-9)
+
+    def test_flags_near_constant_dimension_inactive(self):
+        rng = np.random.default_rng(1)
+        data = rng.normal(loc=0.0, scale=1.0, size=(500, 4))
+        data[:, 2] = 5.0  # dead dimension: ~zero variance
+        stats = fit_diagonal_gaussian(data)
+        active = stats['active_dims']
+        self.assertFalse(active[2])
+        self.assertTrue(all(active[i] for i in (0, 1, 3)))
+
+
+class _StubExtractor:
+    """Stand-in for the generic-encoder feature extractor: returns a fixed
+    feature vector and counts how many times it actually ran, so we can test
+    the detector's rate-limiting without downloading a real ImageNet model."""
+    def __init__(self, feat):
+        self.feat = np.asarray(feat, dtype=np.float32)
+        self.calls = 0
+
+    def extract(self, img):
+        self.calls += 1
+        return self.feat
+
+
+def _novelty_part_with_stub(feat_dim=5, interval=0.0):
+    """A FeatureNoveltyDetector with a stub extractor + a minimal novelty_ood
+    calibration block injected, bypassing encoder construction/download."""
+    part = FeatureNoveltyDetector(None, interval=interval)
+    part.calibration = {
+        'mean': [0.0] * feat_dim,
+        'var': [1.0] * feat_dim,
+        'active_dims': [True] * feat_dim,
+        'eps': 1e-6,
+        'score_anchors': {'distance': [0.0, 10.0, 100.0],
+                          'score': [2.0, 50.0, 98.0]},
+    }
+    part.extractor = _StubExtractor(np.full(feat_dim, 2.0))
+    return part
+
+
+class TestFeatureNoveltyDetectorScoring(unittest.TestCase):
+
+    def test_run_computes_distance_and_score_from_encoder_features(self):
+        part = _novelty_part_with_stub(feat_dim=5)
+        # feat = 2.0 in each of 5 dims, mean 0 var 1 -> distance = 5 * 2^2 = 20
+        score, raw, smoothed = part.run(np.zeros((8, 8, 3), np.uint8))
+        self.assertAlmostEqual(raw, 20.0, places=4)
+        self.assertIsNotNone(score)
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 100.0)
+
+    def test_no_calibration_means_no_score(self):
+        part = FeatureNoveltyDetector(None)   # no calib, no extractor
+        score, raw, smoothed = part.run(np.zeros((8, 8, 3), np.uint8))
+        self.assertIsNone(score)
+        self.assertEqual(raw, 0.0)
+
+
+class TestFeatureNoveltyDetectorInterval(unittest.TestCase):
+    # Rate-limiting matters here: this part rides alongside the driving pilot
+    # on every frame, and the encoder pass is heavier than the old single
+    # steering-model pass -- so an unthrottled loop adds real load / power draw.
+
+    def setUp(self):
+        self.img = np.zeros((8, 8, 3), np.uint8)
+
+    def test_zero_interval_runs_encoder_every_frame(self):
+        part = _novelty_part_with_stub(interval=0.0)
+        part.run(self.img); part.run(self.img); part.run(self.img)
+        self.assertEqual(part.extractor.calls, 3)
+
+    def test_interval_skips_encoder_when_held(self):
+        part = _novelty_part_with_stub(interval=1.0)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=100.0):
+            part.run(self.img)
+        self.assertEqual(part.extractor.calls, 1)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=100.5):
+            part.run(self.img)   # within interval -> held, NO encoder pass
+        self.assertEqual(part.extractor.calls, 1)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=101.5):
+            part.run(self.img)   # past interval -> recompute
+        self.assertEqual(part.extractor.calls, 2)
+
+    def test_held_values_match_last_real_update(self):
+        part = _novelty_part_with_stub(interval=1.0)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=100.0):
+            _, raw1, smoothed1 = part.run(self.img)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=100.3):
+            _, raw2, smoothed2 = part.run(self.img)
+        self.assertEqual(raw1, raw2)
+        self.assertEqual(smoothed1, smoothed2)
+
+    def test_now_override_drives_the_interval_gate_without_mocking_time(self):
+        # Not actually used by mc_calibrate (calibration computes novelty
+        # features in one encoder batch, not via this Part's run() -- see
+        # mc_calibrate._replay_ema), but the same now= override exists here
+        # for symmetry with MCDropoutConfidence/TTAStabilityDetector and any
+        # future caller that DOES want to replay this part directly.
+        part = _novelty_part_with_stub(interval=1.0)
+        part.run(self.img, now=100.0)
+        self.assertEqual(part.extractor.calls, 1)
+        part.run(self.img, now=100.5)   # < 1.0s since the last update -> held
+        self.assertEqual(part.extractor.calls, 1)
+        part.run(self.img, now=101.5)   # >= 1.0s since the last update
+        self.assertEqual(part.extractor.calls, 2)
+
+    def test_now_none_falls_back_to_wall_clock(self):
+        part = _novelty_part_with_stub(interval=1.0)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=200.0):
+            part.run(self.img)
+        with mock.patch('donkeycar.parts.novelty.time.time', return_value=200.2):
+            part.run(self.img)
+        self.assertEqual(part.extractor.calls, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/donkeycar/tests/test_ood.py
+++ b/donkeycar/tests/test_ood.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.parts.ood import build_ood_encoder, CPUEncoderExtractor
+
+
+def _tiny_encoder(input_size=32, feat_dim=8):
+    """A stand-in for the ImageNet backbone so tests never download weights:
+    same interface (square image in, pooled vector out)."""
+    inp = tf.keras.Input((input_size, input_size, 3))
+    x = tf.keras.layers.Conv2D(feat_dim, 3, padding='same')(inp)
+    out = tf.keras.layers.GlobalAveragePooling2D()(x)
+    return tf.keras.Model(inp, out)
+
+
+class TestBuildOodEncoder(unittest.TestCase):
+
+    def test_unknown_encoder_raises(self):
+        with self.assertRaises(ValueError):
+            build_ood_encoder('not_a_real_encoder')
+
+
+class TestCPUEncoderExtractor(unittest.TestCase):
+
+    def setUp(self):
+        # Inject a tiny model (name is a real key so preprocess resolves).
+        self.ex = CPUEncoderExtractor('mobilenet_v2', model=_tiny_encoder(32, 8))
+
+    def test_feat_dim_and_input_size_from_injected_model(self):
+        self.assertEqual(self.ex.feat_dim, 8)
+        self.assertEqual(self.ex.input_size, 32)
+
+    def test_extract_single_shape(self):
+        img = (np.random.default_rng(0).random((120, 160, 3)) * 255).astype(np.uint8)
+        feat = self.ex.extract(img)
+        self.assertEqual(feat.shape, (8,))
+        self.assertTrue(np.all(np.isfinite(feat)))
+
+    def test_extract_batch_shape(self):
+        imgs = [(np.random.default_rng(i).random((120, 160, 3)) * 255).astype(np.uint8)
+                for i in range(4)]
+        feats = self.ex.extract_batch(imgs)
+        self.assertEqual(feats.shape, (4, 8))
+
+    def test_accepts_frames_of_any_size(self):
+        # Resizing happens internally, so odd input sizes must not error.
+        small = (np.random.default_rng(1).random((40, 60, 3)) * 255).astype(np.uint8)
+        big = (np.random.default_rng(2).random((480, 640, 3)) * 255).astype(np.uint8)
+        self.assertEqual(self.ex.extract(small).shape, (8,))
+        self.assertEqual(self.ex.extract(big).shape, (8,))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/donkeycar/tests/test_throttle_scaler.py
+++ b/donkeycar/tests/test_throttle_scaler.py
@@ -1,0 +1,122 @@
+import unittest
+from unittest import mock
+
+from donkeycar.parts.mc_dropout import ThrottleScaler
+
+
+class TestThrottleScalerPassthrough(unittest.TestCase):
+
+    def setUp(self):
+        self.scaler = ThrottleScaler()
+
+    def test_throttle_none_passes_through(self):
+        self.assertIsNone(self.scaler.run(None, 10.0, 90.0))
+
+    def test_both_signals_none_passes_through_unchanged(self):
+        self.assertEqual(self.scaler.run(0.5, None, None), 0.5)
+
+    def test_single_available_signal_still_scales(self):
+        # novelty disabled/uncalibrated (None); confidence alone drives it
+        result = self.scaler.run(1.0, 10.0, None)  # confidence critical
+        self.assertAlmostEqual(result, self.scaler.min_scale)
+
+
+class TestThrottleScalerTiers(unittest.TestCase):
+    # defaults: confidence reduced<65 critical<25, novelty reduced>25 critical>65
+
+    def setUp(self):
+        self.scaler = ThrottleScaler(min_scale=0.4, stop_duration=1.0)
+
+    def test_confidence_above_reduced_threshold_is_full_scale(self):
+        self.assertEqual(self.scaler.run(1.0, 80.0, None), 1.0)
+
+    def test_confidence_mid_reduced_tier_interpolates(self):
+        result = self.scaler.run(1.0, 45.0, None)  # midpoint of 25..65
+        self.assertAlmostEqual(result, 0.7, places=6)
+
+    def test_novelty_below_reduced_threshold_is_full_scale(self):
+        self.assertEqual(self.scaler.run(1.0, None, 10.0), 1.0)
+
+    def test_novelty_mid_reduced_tier_interpolates(self):
+        result = self.scaler.run(1.0, None, 45.0)  # midpoint of 25..65
+        self.assertAlmostEqual(result, 0.7, places=6)
+
+    def test_combined_signals_take_the_more_conservative_one(self):
+        # confidence mid-reduced (scale 0.7), novelty critical (scale 0.4) -> 0.4 wins
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            result = self.scaler.run(1.0, 45.0, 80.0)
+        self.assertAlmostEqual(result, 0.4, places=6)
+
+
+class TestThrottleScalerTTASignal(unittest.TestCase):
+    # TTA stability is "high is good" like confidence: reduced<65, critical<25
+
+    def setUp(self):
+        self.scaler = ThrottleScaler(min_scale=0.4, stop_duration=1.0)
+
+    def test_tta_none_does_not_block_other_signals(self):
+        # confidence full, novelty full, tta unavailable -> full throttle
+        self.assertEqual(self.scaler.run(1.0, 90.0, 5.0, None), 1.0)
+
+    def test_tta_alone_scales_when_fragile(self):
+        # only TTA available and mid-reduced tier (midpoint of 25..65 -> 0.7)
+        result = self.scaler.run(1.0, None, None, 45.0)
+        self.assertAlmostEqual(result, 0.7, places=6)
+
+    def test_tta_is_included_in_min_of_scales(self):
+        # confidence full (1.0), but TTA critical (0.4) -> 0.4 wins
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            result = self.scaler.run(1.0, 90.0, 5.0, 10.0)
+        self.assertAlmostEqual(result, 0.4, places=6)
+
+    def test_all_signals_none_passes_through(self):
+        self.assertEqual(self.scaler.run(0.5, None, None, None), 0.5)
+
+    def test_sustained_tta_critical_forces_stop(self):
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            self.scaler.run(1.0, None, None, 10.0)
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=101.5):
+            self.assertEqual(self.scaler.run(1.0, None, None, 10.0), 0.0)
+
+
+class TestThrottleScalerSustainedStop(unittest.TestCase):
+
+    def setUp(self):
+        self.scaler = ThrottleScaler(min_scale=0.4, stop_duration=1.0)
+
+    def test_critical_below_stop_duration_still_just_scales(self):
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            result = self.scaler.run(1.0, 10.0, None)
+        self.assertAlmostEqual(result, 0.4, places=6)
+
+    def test_critical_sustained_past_stop_duration_forces_zero(self):
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            self.scaler.run(1.0, 10.0, None)
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=101.5):
+            result = self.scaler.run(1.0, 10.0, None)
+        self.assertEqual(result, 0.0)
+
+    def test_recovery_resets_the_critical_timer(self):
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            self.scaler.run(1.0, 10.0, None)  # goes critical
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.5):
+            self.scaler.run(1.0, 80.0, None)  # recovers before stop_duration elapses
+        self.assertIsNone(self.scaler.critical_since)
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=101.0):
+            # critical again, but the timer restarted -- not yet sustained
+            result = self.scaler.run(1.0, 10.0, None)
+        self.assertAlmostEqual(result, 0.4, places=6)
+
+    def test_handoff_between_signals_counts_as_continuous_critical(self):
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.0):
+            self.scaler.run(1.0, 10.0, None)  # confidence critical starts the timer
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=100.6):
+            # confidence recovers but novelty goes critical -- timer must not reset
+            self.scaler.run(1.0, 80.0, 80.0)
+        with mock.patch('donkeycar.parts.mc_dropout.time.time', return_value=101.2):
+            result = self.scaler.run(1.0, 80.0, 80.0)
+        self.assertEqual(result, 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/donkeycar/tests/test_tta.py
+++ b/donkeycar/tests/test_tta.py
@@ -1,0 +1,234 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+import tensorflow as tf
+
+from donkeycar.parts.tta import photometric_batch, TTAStabilityDetector
+from donkeycar.parts.mc_calibrate import build_calibration
+
+
+def _tiny_pilot():
+    """Minimal single-image-input, two-output (angle/throttle) model wrapped in
+    a stub pilot exposing .interpreter.model / .interpreter.input_keys, the
+    surface TTAStabilityDetector reaches for."""
+    tf.random.set_seed(0)
+    inp = tf.keras.Input((16, 16, 3), name='img_in')
+    x = tf.keras.layers.Conv2D(4, 3, activation='relu')(inp)
+    x = tf.keras.layers.Flatten()(x)
+    angle = tf.keras.layers.Dense(1, name='angle')(x)
+    throttle = tf.keras.layers.Dense(1, name='throttle')(x)
+    model = tf.keras.Model(inp, [angle, throttle])
+
+    class _Interp:
+        def __init__(self, m):
+            self.model = m
+            self.input_keys = ['img_in']
+
+    class _Pilot:
+        def __init__(self, m):
+            self.interpreter = _Interp(m)
+
+    return _Pilot(model)
+
+
+class TestPhotometricBatch(unittest.TestCase):
+
+    def setUp(self):
+        self.rng = np.random.default_rng(0)
+        self.img = self.rng.random((16, 16, 3)).astype(np.float32)
+
+    def test_shape_and_range(self):
+        batch = photometric_batch(self.img, 8, 0.2, self.rng)
+        self.assertEqual(batch.shape, (8, 16, 16, 3))
+        self.assertGreaterEqual(batch.min(), 0.0)
+        self.assertLessEqual(batch.max(), 1.0)
+
+    def test_zero_strength_is_identity(self):
+        batch = photometric_batch(self.img, 5, 0.0, self.rng)
+        for m in range(5):
+            np.testing.assert_allclose(batch[m], self.img, atol=1e-6)
+
+    def test_higher_strength_gives_more_variance(self):
+        weak = photometric_batch(self.img, 16, 0.05, np.random.default_rng(1))
+        strong = photometric_batch(self.img, 16, 0.4, np.random.default_rng(1))
+        self.assertGreater(strong.var(axis=0).mean(), weak.var(axis=0).mean())
+
+    def test_geometry_is_preserved(self):
+        # A bright top half vs dark bottom half must stay that way for every
+        # augmented copy -- photometric augmentation never moves content.
+        img = np.zeros((16, 16, 3), dtype=np.float32)
+        img[:8] = 0.9
+        img[8:] = 0.1
+        batch = photometric_batch(img, 8, 0.2, np.random.default_rng(2))
+        for m in range(8):
+            self.assertGreater(batch[m, :8].mean(), batch[m, 8:].mean())
+
+
+class TestTTAStabilityDetector(unittest.TestCase):
+
+    def setUp(self):
+        self.pilot = _tiny_pilot()
+        self.img = (np.random.default_rng(3).random((16, 16, 3)) * 255).astype(np.uint8)
+
+    def test_run_returns_three_values_and_nonneg_variance(self):
+        part = TTAStabilityDetector(self.pilot, num_samples=8, strength=0.2,
+                                    seed=0)
+        stability, raw_var, smoothed_var = part.run(self.img)
+        self.assertIsNone(stability)          # no calibration loaded
+        self.assertGreaterEqual(raw_var, 0.0)
+        self.assertGreaterEqual(smoothed_var, 0.0)
+
+    def test_none_frame_passthrough(self):
+        part = TTAStabilityDetector(self.pilot, seed=0)
+        stability, raw_var, smoothed_var = part.run(None)
+        self.assertIsNone(stability)
+        self.assertEqual(raw_var, 0.0)
+
+    def test_uncalibrated_skips_the_forward_pass_entirely(self):
+        # Without a calibration block there's nothing to score against, so
+        # the M-pass batch should never actually run (mirrors
+        # FeatureNoveltyDetector) -- important on a Pi, where this would
+        # otherwise burn M forward passes every frame for a number nobody
+        # can read.
+        part = TTAStabilityDetector(self.pilot, num_samples=8, seed=0)
+        self.assertIsNone(part.calibration)
+        calls = {'n': 0}
+        real_model = part.model
+
+        def counting_call(*a, **kw):
+            calls['n'] += 1
+            return real_model(*a, **kw)
+
+        part.model = counting_call
+        stability, raw_var, smoothed_var = part.run(self.img)
+        self.assertEqual(calls['n'], 0)
+        self.assertIsNone(stability)
+        self.assertEqual(raw_var, 0.0)
+        self.assertEqual(smoothed_var, 0.0)
+
+    def test_always_measure_runs_the_pass_even_without_calibration(self):
+        # Calibration is the one caller that MUST measure while uncalibrated
+        # -- measuring those variances is how the 'tta' block gets built. If
+        # the skip above applied there too, every collected variance would be
+        # 0.0 and the resulting block would be degenerate.
+        part = TTAStabilityDetector(self.pilot, num_samples=8, seed=0,
+                                    always_measure=True)
+        self.assertIsNone(part.calibration)
+        calls = {'n': 0}
+        real_model = part.model
+
+        def counting_call(*a, **kw):
+            calls['n'] += 1
+            return real_model(*a, **kw)
+
+        part.model = counting_call
+        stability, raw_var, smoothed_var = part.run(self.img)
+        self.assertEqual(calls['n'], 1)       # the M-pass batch DID run
+        self.assertIsNone(stability)          # still no score without calib
+        self.assertGreater(raw_var, 0.0)      # and a real variance came back
+
+    def test_always_measure_defaults_off_so_live_driving_is_unchanged(self):
+        part = TTAStabilityDetector(self.pilot, num_samples=8, seed=0)
+        self.assertFalse(part.always_measure)
+
+    def test_stability_uses_calibration_block_when_present(self):
+        part = TTAStabilityDetector(self.pilot, num_samples=8, seed=0)
+        # Attach a real tta block built from a synthetic variance distribution.
+        rng = np.random.default_rng(4)
+        calib = build_calibration(
+            rng.gamma(2.0, 0.01, 200), num_passes=15, alpha=0.2,
+            tta_variances=rng.gamma(2.0, 1e-4, 200),
+            tta_num_samples=8, tta_strength=0.2, tta_alpha=0.2)
+        part.calibration = calib['tta']
+        part.run(self.img)
+        score = part._score()
+        self.assertIsNotNone(score)
+        self.assertGreaterEqual(score, 0.0)
+        self.assertLessEqual(score, 100.0)
+
+
+class TestTTAStabilityDetectorInterval(unittest.TestCase):
+    # TTA costs M forward passes per update -- the most expensive of the
+    # three signals per update -- so an unthrottled live loop adds real load
+    # (and, on power-constrained hardware like a Pi, real power draw) with no
+    # way to turn it down. This is the interval knob that closes that gap.
+
+    def setUp(self):
+        self.pilot = _tiny_pilot()
+        self.img = (np.random.default_rng(6).random((16, 16, 3)) * 255).astype(np.uint8)
+
+    def _counting_part(self, interval):
+        part = TTAStabilityDetector(self.pilot, num_samples=4,
+                                    interval=interval, seed=0)
+        # The interval-skip logic and the uncalibrated-skip logic are
+        # independent gates on the same forward pass -- attach a minimal
+        # calibration block so these tests exercise the interval gate alone.
+        part.calibration = {
+            'stability_anchors': {'variance': [0.0, 1.0], 'stability': [99.0, 5.0]},
+        }
+        calls = {'n': 0}
+        real_model = part.model
+
+        def counting_call(*a, **kw):
+            calls['n'] += 1
+            return real_model(*a, **kw)
+
+        part.model = counting_call
+        return part, calls
+
+    def test_zero_interval_runs_forward_pass_every_frame(self):
+        part, calls = self._counting_part(interval=0.0)
+        part.run(self.img)
+        part.run(self.img)
+        part.run(self.img)
+        self.assertEqual(calls['n'], 3)
+
+    def test_interval_skips_forward_pass_when_held(self):
+        part, calls = self._counting_part(interval=1.0)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=100.0):
+            part.run(self.img)
+        self.assertEqual(calls['n'], 1)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=100.5):
+            part.run(self.img)   # within interval -> held, NO forward pass
+        self.assertEqual(calls['n'], 1)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=101.5):
+            part.run(self.img)   # past interval -> recompute
+        self.assertEqual(calls['n'], 2)
+
+    def test_held_values_match_last_real_update(self):
+        part, _ = self._counting_part(interval=1.0)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=100.0):
+            _, raw1, smoothed1 = part.run(self.img)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=100.3):
+            _, raw2, smoothed2 = part.run(self.img)
+        self.assertEqual(raw1, raw2)
+        self.assertEqual(smoothed1, smoothed2)
+
+    def test_now_override_drives_the_interval_gate_without_mocking_time(self):
+        # mc_calibrate.calibrate_from_tub replays a tub through this part
+        # passing now= from each frame's own recorded timestamp, so the
+        # interval gate reflects the tub's real recorded pace rather than
+        # however fast the replay loop happens to run. No time.time mocking
+        # needed -- that's the point of the parameter.
+        part, calls = self._counting_part(interval=1.0)
+        part.run(self.img, now=100.0)
+        self.assertEqual(calls['n'], 1)
+        part.run(self.img, now=100.5)   # < 1.0s since the last update -> held
+        self.assertEqual(calls['n'], 1)
+        part.run(self.img, now=101.5)   # >= 1.0s since the last update
+        self.assertEqual(calls['n'], 2)
+
+    def test_now_none_falls_back_to_wall_clock(self):
+        # Every other caller (the live drive loop, gradcam_uncertainty.py's
+        # replay) doesn't pass now= at all -- must behave exactly as before.
+        part, calls = self._counting_part(interval=1.0)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=200.0):
+            part.run(self.img)
+        with mock.patch('donkeycar.parts.tta.time.time', return_value=200.2):
+            part.run(self.img)
+        self.assertEqual(calls['n'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/remote_cam_view.py
+++ b/scripts/remote_cam_view.py
@@ -16,7 +16,6 @@ import donkeycar as dk
 import cv2
 
 from donkeycar.parts.cv import CvImageView, ImgBGR2RGB, ImgRGB2BGR, ImageScale, ImgWriter, ArrowKeyboardControls
-from donkeycar.parts.salient import SalientVis
 from donkeycar.parts.network import MQTTValuePub, MQTTValueSub
 from donkeycar.parts.transform import Lambda
 from donkeycar.parts.image import JpgToImgArr

--- a/scripts/salient_vis_listener.py
+++ b/scripts/salient_vis_listener.py
@@ -37,7 +37,8 @@ model.load(model_path)
 V.add(TCPClientValue(name="camera", host=ip), outputs=["packet"])
 V.add(JpgToImgArr(), inputs=["packet"], outputs=["img"]) 
 V.add(ImgBGR2RGB(), inputs=["img"], outputs=["img"])
-V.add(SalientVis(model), inputs=["img"], outputs=["img"])
+V.add(SalientVis(model, categorical=(model_type == "categorical")),
+      inputs=["img"], outputs=["img"])
 V.add(ImageScale(4.0), inputs=["img"], outputs=["lg_img"])
 V.add(CvImageView(), inputs=["lg_img"])
 


### PR DESCRIPTION
# Explainable AI (XAI) Toolkit

## Overview

Stock Donkeycar's deep-learning autopilot gives you a steering/throttle number and nothing else — you can't tell *how sure* the model was, or *why* it steered the way it did, without guessing. This fork adds an explainability and uncertainty toolkit on top of the existing pilot, built from four independent pieces:

1. **Confidence** (MC-Dropout) — "do the model's internal sub-networks agree with each other?" A live 0-100% signal.
2. **Novelty / out-of-distribution (OOD) detection** — "does this camera frame look like anything the model was trained on?" Also live, 0-100%.
3. **TTA stability** — "if I nudge the lighting slightly, does the model's answer wobble?" Also live, 0-100%.
4. **Confidence-aware throttle scaling** — an optional part that slows the car down (and can bring it to a full stop) when any of the three signals above indicates trouble, so uncertainty isn't just a number nobody acts on.

Alongside the live signals, there's an **offline analysis viewer**: point it at a recorded drive and a model, and it produces a frame-by-frame, browser-based playback showing *where* the model was looking and *why* it was or wasn't confident, using four different visual attribution techniques (Grad-CAM, Grad-CAM++, Integrated Gradients, and pixel-gradient saliency).

All three live signals — and therefore the throttle scaling built on top of them — share one dependency: a **calibration file** (`<model>.calib.json`) that turns each raw internal number into a 0-100% score that's meaningful for *your* specific model and *your* specific training data. Without it there is no percentage to display or act on, so the dashboard panels stay hidden and throttle scaling passes throttle through untouched. The offline viewer is the exception: it runs without a calibration too, it just falls back to plotting raw variance instead of the 0-100% lines. If your model was trained with any `AUGMENTATIONS` turned on, calibration needs to know about that too, or the novelty signal will misfire — covered in detail in [§2.8](#28-how-augmentations-feed-into-calibration).

This document's Section 1 is a usage walkthrough: what to turn on, in what order, and what you'll see. Section 2 is a technical explanation of how each signal actually works.

---

## 1. Usage

### 1.1 The pipeline, at a glance

```
record data  →  train  →  calibrate  →  drive live (dashboard)
                                     ↘  analyse offline (viewer)
```

Calibration sits in the middle because every percentage downstream — the live dashboard panels, throttle scaling, and the offline viewer's confidence/novelty/stability graph — depends on it existing. (The offline viewer still runs without one; it just plots raw variance instead.)

### 1.2 Recording and training

No changes here — record a tub and train exactly as stock Donkeycar describes (`donkey train`). The XAI toolkit only reads the model file afterwards; it doesn't change how training itself works. One thing to know: MC-Dropout confidence (and, by extension, most of this toolkit) currently only supports the `linear` model type, since it relies on the `Dropout` layers already present in that architecture staying active at inference time — see [§2.2](#22-dropout-and-monte-carlo-dropout-confidence) for why.

**Recording an autopilot drive (for offline review, not for training).** By default Donkeycar only records frames while you're driving in `'user'` (manual) mode — switching into autopilot stops recording, even if the recording toggle is on. If you want to feed an actual autonomous run into this toolkit's offline viewer (§1.6), for example to see what the model was looking at right before a near-miss, set the stock Donkeycar option in `myconfig.py`:

```python
RECORD_DURING_AI = True
```

This is stock Donkeycar behaviour and this toolkit does not change it: autopilot frames go into **the same tub** as your manual frames, so the standard warning still applies — *don't train on a tub recorded this way* without filtering it first. The XAI columns (`pilot/confidence`, `pilot/novelty`, …) are written alongside every frame, but only autopilot frames actually carry values; manual frames leave them empty, because the signals run under Donkeycar's `run_pilot` condition. The offline tool handles that mix explicitly rather than guessing — see the note on unscored frames in §1.6.

### 1.3 Calibration

Calibration replays a tub of "known good" driving through the model once and records how the raw signals behave on data the model actually learned from — this becomes the yardstick every live percentage is measured against. **Nothing lights up on the dashboard until this has run once** for a given model.

**Option A — automatic, at the end of training.** In `myconfig.py`:

```python
XAI_CONFIDENCE_AUTO_CALIBRATE = True
```

This adds one extra replay pass over your training tubs right after `donkey train` finishes, and saves `<model>.calib.json` next to the model automatically. Off by default because it adds time to every training run.

**Option B — manual, from the command line** (needed if you trained before turning on auto-calibrate, or want to recalibrate later):

```bash
python -m donkeycar.parts.mc_calibrate --tub data/mytub --model models/mypilot.h5
```

```
usage: mc_calibrate [-h] --tub TUB [TUB ...] --model MODEL [--config CONFIG]
                     [--limit LIMIT] [--passes PASSES] [--alpha ALPHA]
                     [--out OUT] [--augment | --no-augment]

  --tub TUB [TUB ...]  one or more tub paths to replay
  --model MODEL        path to the .h5 model
  --config CONFIG      path to config.py (defaults to ./config.py, falling
                        back to the bundled complete template)
  --limit LIMIT        only use the first N frames
  --passes PASSES      override XAI_CONFIDENCE_PASSES
  --alpha ALPHA        override XAI_CONFIDENCE_ALPHA
  --out OUT            output calibration path (default <model>.calib.json)
  --augment            widen the novelty baselines with augmented frames
  --no-augment         fit the novelty baselines on clean frames only
```

Point `--tub` at the **same data the model was actually trained on** — calibration is meant to answer "what does normal look like to this model," and calibrating against a different drive (e.g. a test/inference tub) silently defeats the whole signal. The offline GUI launcher (§1.6) tries to auto-detect this for you from Donkeycar's own training record; the CLI here has no such lookup, so it's on you to point `--tub` correctly.

One calibration run covers **all three signals at once** — confidence, novelty and TTA stability are always all written into the file, whether or not you currently have them switched on for driving. So turning `XAI_TTA_ENABLED` (or any other signal) on later just works; you don't need to recalibrate to "add" it.

**When to recalibrate:**
- After retraining or swapping the model (new weights mean the old numbers no longer describe it).
- After changing `AUGMENTATIONS` in a meaningful way (see [§2.8](#28-how-augmentations-feed-into-calibration)).
- After changing an `XAI_*_INTERVAL` value. Calibration replays at whatever cadence the interval was set to *at calibration time* (see [§2.10](#210-known-limitations)); tightening or relaxing an interval afterward means the live update rhythm no longer matches what the anchors were fit against.

**On config loading:** all three entry points (`mc_calibrate`, `gradcam_uncertainty`, the GUI launcher) resolve `--config` the same way — your `./config.py` if you're in a car directory, otherwise the bundled template — and in every case they also apply the sibling `myconfig.py` on top. That last part matters: Donkeycar's own `load_config()` finds `myconfig.py` by string-replacing `"config.py"` in the path, which silently does nothing when the base file is named anything else (such as the bundled `cfg_complete.py`), so your real overrides would be dropped and the whole calibration built against template defaults.

**On image size:** calibration and offline analysis both read the input size directly from the model file, so a model trained at a different resolution than your current config still works — you'll just see a warning saying which size was used, and `IMAGE_W`/`IMAGE_H` are taken from the model. If that warning looks wrong, point `--config` at the `config.py` the model was actually trained with. Because the model file is treated as the authority there, resolution is deliberately left out of the preprocessing-sidecar comparison described in §2.9 — the crop geometry and transformation list, which a model file *cannot* self-describe, are still checked strictly.

### 1.4 Driving live with the signals on

Each signal is an independent switch in `myconfig.py` — turn on only what you want:

```python
XAI_CONFIDENCE_ENABLED = True   # MC-Dropout confidence
XAI_NOVELTY_ENABLED = True      # feature-space novelty / OOD
XAI_TTA_ENABLED = True          # test-time-augmentation stability
```

Once enabled and calibrated, driving with the web dashboard open shows a panel per signal:

| Panel heading (as shown) | Meaning | Green (safe) | Amber | Red |
|---|---|---|---|---|
| "Do the model's 'sub-networks' agree?" | Confidence | ≥ 65% | 25-65% | < 25% |
| "Does this look familiar?" | Novelty (OOD) | ≤ 25% | 25-65% | > 65% |
| "Is the answer stable?" | TTA stability | ≥ 65% | 25-65% | < 25% |

(Novelty's color scale is intentionally flipped from the other two — a *high* number there means "unfamiliar," which is bad, whereas a *high* number for confidence/stability is good.) Each panel has a "What does this mean? ▾" toggle with a plain-English explanation, and the confidence panel is explicit that it's *"[r]elative to this model's own baseline, not a calibrated probability"* — see [§2.3](#23-calibration-mechanics) for what that means concretely.

**If a signal is enabled but not yet calibrated**, its panel simply never appears — instead, on connecting to the dashboard you'll see a dismissible amber banner headed *"Calibration warnings: these signals won't show a percentage, or may be reading against the wrong baseline,"* listing exactly which signal(s) are affected and the exact `mc_calibrate` command to fix each. Go run calibration (§1.3) and reconnect.

Panels for calibrated signals appear as soon as the dashboard connects, including on a reload or a second browser: the server sends each new client the current value up front rather than waiting for the number to change.

**Pi / performance tuning:** each signal has its own `XAI_*_INTERVAL` (seconds; `0.0` = every frame, no rate-limiting at all). Out of the box these are already relaxed rather than `0.0` — confidence and novelty default to `0.3` (~3 updates/sec), TTA to `0.5` (~2 updates/sec) since it's the priciest signal (it runs `XAI_TTA_SAMPLES` extra forward passes per update). Confidence never costs steering responsiveness either way — the car still steers on a cheap single-pass inference every frame regardless of its interval, only the confidence *number* updates less often. Novelty and TTA are pure observers, so a held frame between updates costs zero forward passes. Raise any of these further if a Raspberry Pi is still struggling to keep up with `DRIVE_LOOP_HZ` — TTA is the first knob to turn. See [§1.5](#15-confidence-aware-throttle-scaling) for how a longer interval trades off against throttle-scaling reaction time.

### 1.5 Confidence-aware throttle scaling

An optional fourth switch that actually *acts* on the three signals above instead of just displaying them:

```python
XAI_THROTTLE_SCALING_ENABLED = True
```

With this on, whichever of confidence/novelty/stability is enabled gets combined: if any signal crosses its "reduced" threshold, throttle is scaled down (linearly, down to `XAI_THROTTLE_MIN_SCALE`, default `0.4` = never below 40% of the commanded throttle from a single signal); if any signal is past its "critical" threshold continuously for `XAI_THROTTLE_STOP_DURATION` seconds (default `1.0`), throttle is forced to zero. It only ever touches throttle — steering is never modified. Turning this on without enabling at least one of the three signals just logs a warning and does nothing (there's nothing to scale on).

**It runs after `AI_LAUNCH_*`, on purpose.** Donkeycar's stock AI-launch boost (`AI_LAUNCH_DURATION`, `AI_LAUNCH_THROTTLE`) **replaces** `pilot/throttle` with a fixed value rather than modulating it, so throttle scaling is wired in *after* the launch boost in the vehicle loop, not before — otherwise a critical signal (including the forced stop) would have no effect for the first `AI_LAUNCH_DURATION` seconds after switching into autopilot, exactly the window the car is least predictable in. With this ordering, whichever value `pilot/throttle` currently holds — launch-boosted or not — still gets scaled or stopped if a signal says so.

**Reaction-time tradeoff with the interval knobs (§1.4):** novelty and TTA are only ever as fresh as their `XAI_*_INTERVAL` — a sudden problem won't be seen until the next scheduled update, up to that many seconds later, and `XAI_THROTTLE_STOP_DURATION` then still needs to see it stay critical continuously before forcing a stop. At the defaults, that's roughly up to `0.3 + 1.0 = 1.3s` for novelty-triggered or `0.5 + 1.0 = 1.5s` for TTA-triggered stops, worst case. That's fine if you're using these signals for dashboard/monitoring, but if you're relying on `XAI_THROTTLE_SCALING_ENABLED` as a real-time safety net, consider lowering `XAI_NOVELTY_INTERVAL`/`XAI_TTA_INTERVAL` back toward `0.0` so the car reacts faster, at the cost of more compute per frame.

### 1.6 Offline analysis — the GUI launcher (recommended)

The easiest way to review a drive is the browser-based launcher, which wraps the CLI tool below so you never need to remember its flags. From your car's directory (`donkey createcar` installs this script for you):

```bash
python run_gradcam_analysis.py
```

This starts a local web server and prints a URL to open. You'll see a **"Run Explainability Analysis"** form:

| Field | What to put |
|---|---|
| Tub path | e.g. `data/mytub` (autocompletes from tubs found under `data/`) |
| Model path | e.g. `models/mypilot.h5` (autocompletes from `models/`) — once selected, a hint below the field shows what pipeline this model was actually trained with (e.g. `Trained with: CROP, CANNY`), read straight from the model's own `.preprocessing.json` sidecar (§2.9) |
| Transformations override (optional) | leave blank to use this launcher's own config. By default, the run is **refused** if this launcher's `TRANSFORMATIONS`/`POST_TRANSFORMATIONS` don't match what the selected model was actually trained with — since a mismatch would silently compute every heat map on pixels the model never saw. Only fill this in to deliberately analyse a model under a *different* pipeline than it trained with (an intentional what-if); doing so replaces `POST_TRANSFORMATIONS` for this run only and skips that check, since you're now doing it on purpose |
| Frames to analyse | **top-K most uncertain** (default, analyse a fixed number of the hardest frames), **percentile ≥** (analyse the worst N% of the drive), or **all frames** (only for short drives) |
| Limit / range of frames considered | optional — restrict to e.g. `500` or `1000-2000` instead of the whole tub |
| Auto-calibrate this model first if it has no calibration yet | auto-checked once you pick a model that has no saved calibration yet, unchecked if it already does — saves a manual `mc_calibrate` step. Override it by hand any time; your choice is never clobbered afterward |
| Calibration tub (training data) | only shown while auto-calibrate is checked. Auto-fills from Donkeycar's own training record for that model if it can find one; type over it if you want to force a specific tub |
| Export every camera frame | check this if you want the output folder to be self-contained (e.g. to copy off a remote GPU box) — otherwise only the analysed frames' images are saved |

Click **Run Analysis** and a progress readout tracks the current stage (variance → novelty → Grad-CAM). If auto-calibration had to fall back to using the analysis tub itself (because no training-tub record could be found), you'll see an amber warning and the page will **not** auto-continue — you have to click **Continue to viewer** explicitly, so a possibly-wrong calibration baseline can't slip by unnoticed. Otherwise it jumps to the viewer automatically when done.

**Unscored frames.** A tub recorded with `RECORD_DURING_AI` (§1.2) contains manual frames that carry no XAI values, because the signals only run while the autopilot does. Where a tub already has logged values the tool reuses them rather than recomputing, and frames without one are treated as *unknown*, not as zero — they stay in the timeline (drawn as a gap in the graph, shown as `variance n/a`), but they're excluded from "top-K most uncertain" and "percentile ≥" selection, and a log line reports how many were skipped. Zero would mean *lowest possible variance*, i.e. maximum confidence, which would rank exactly the frames nobody measured as the most certain in the drive. If you want those frames analysed anyway, use **all frames**, which ignores the ranking entirely.

**The viewer**, once open, shows the current frame plus a chosen overlay layer:

- *Where the model was unsure (uncertainty)* — the default view
- *Where the model looked (Grad-CAM)*
- *Where the model looked, sharper (Grad-CAM++)*
- *Have I seen this before? (novelty)*
- *Exact pixels that mattered (saliency)*
- *Exact pixels that mattered, cleaner (integrated gradients)*
- *Just the camera*
- *What the model actually sees (transformed)* — the frame **after** `TRANSFORMATIONS`/`POST_TRANSFORMATIONS` (crop, edge detection, colour conversion). This is the actual input every heat map above was computed against; only shown when the pipeline changes something (a no-op pipeline would make this identical to "Just the camera")

A short plain-language explanation for whichever layer is selected is always shown underneath the dropdown — no separate "advanced mode" to find it in. When a transformation changes the frame's geometry (see §2.9 — this is now the normal case for `CROP`), a **"draw on model input"** checkbox appears next to the layer dropdown: unticked (default) draws every heat map projected back onto the raw camera frame, so the scene stays recognisable; ticked draws them directly on the transformed frame instead, with no projection needed since that's the exact input the maps were computed from. Playback controls: Space/arrow keys or the play button at 2/5/10 fps, a scrub bar, and click-to-jump on the confidence graph below the image. The graph plots confidence/novelty/TTA-stability as separate, independently toggleable lines (checkboxes above the graph — whichever signals you actually calibrated/enabled), with the frames that got a full image analysis marked along the top edge. A **"What do confidence / novelty / stability / variance mean?"** link expands a glossary covering all of these terms in plain language, always available with one click.

### 1.7 Offline analysis — CLI (advanced / scripted use)

Equivalent to the launcher's form, useful for automation or a headless box:

```bash
python -m donkeycar.parts.gradcam_uncertainty --tub data/mytub --model models/mypilot.h5 --top-k 50
```

```
usage: gradcam_uncertainty [-h] --tub TUB --model MODEL [--config CONFIG]
                            [--out OUT] [--passes PASSES] [--top-k TOP_K]
                            [--percentile PERCENTILE] [--ig-steps IG_STEPS]
                            [--all] [--limit LIMIT] [--start START]
                            [--export-frames]

  --out OUT             output dir (default <tub>/gradcam_analysis)
  --passes PASSES       MC-Dropout passes (default cfg or 15)
  --top-k TOP_K         analyse the K most uncertain frames (default)
  --percentile PERCENTILE
                        instead analyse frames >= this variance percentile
  --ig-steps IG_STEPS   Integrated Gradients Riemann steps (default cfg
                        XAI_IG_STEPS or 32)
  --all                 analyse every frame (short drives only)
  --limit LIMIT         only consider N records
  --start START         skip this many records before considering any frames
  --export-frames       copy every camera frame into the output dir too
```

Then view the result (with or without the launcher's form):

```bash
python -m donkeycar.parts.uncertainty_viewer --analysis data/mytub/gradcam_analysis
```

The CLI enforces the same preprocessing-match check as the launcher (§2.9) — it refuses to run if `--config`'s `TRANSFORMATIONS`/`POST_TRANSFORMATIONS` don't match the model's saved training pipeline — but has no equivalent of the launcher's override field, so point `--config` at the actual config the model was trained with rather than trying to work around a mismatch here.

### 1.8 Config reference

<details>
<summary>Confidence (MC-Dropout)</summary>

```python
XAI_CONFIDENCE_ENABLED = False           # master on/off
XAI_CONFIDENCE_PASSES = 15               # stochastic forward passes per frame
XAI_CONFIDENCE_ALPHA = 0.2               # EMA smoothing of the variance
XAI_CONFIDENCE_INTERVAL = 0.3            # seconds between updates (0 = every frame, no rate-limiting)
XAI_CONFIDENCE_AUTO_CALIBRATE = False    # calibrate automatically after donkey train
XAI_CONFIDENCE_CALIBRATE_LIMIT = None    # cap frames used for auto-calibration
```

</details>

<details>
<summary>Novelty / OOD detection</summary>

```python
XAI_NOVELTY_ENABLED = False
XAI_NOVELTY_ALPHA = 0.2
XAI_NOVELTY_ENCODER = 'mobilenet_v2'     # 'mobilenet_v2' | 'mobilenet'
XAI_NOVELTY_ENCODER_INPUT = 128          # square input size fed to the encoder
XAI_NOVELTY_ENCODER_ALPHA = 1.0          # encoder width multiplier (e.g. 0.35 on a Pi)
XAI_NOVELTY_INTERVAL = 0.3                # seconds between updates (0 = every frame, no rate-limiting)
# Offline heat map only -- no effect while driving:
XAI_NOVELTY_SPATIAL_INPUT = 224           # short side; grid ≈ size/32
XAI_NOVELTY_SPATIAL_MAX_FRAMES = 400      # frames sampled to fit the map's baseline
XAI_NOVELTY_SPATIAL_MAX_VECTORS = 4000    # cap on per-location vectors (bounds memory)
```

</details>

<details>
<summary>TTA stability</summary>

```python
XAI_TTA_ENABLED = False
XAI_TTA_SAMPLES = 8       # M, augmented copies per frame
XAI_TTA_ALPHA = 0.2
XAI_TTA_INTERVAL = 0.5    # seconds between updates (0 = every frame, no rate-limiting)
XAI_TTA_STRENGTH = 0.2    # photometric jitter strength (0 = no augmentation)
```

</details>

<details>
<summary>Throttle scaling</summary>

```python
XAI_THROTTLE_SCALING_ENABLED = False
XAI_CONFIDENCE_REDUCED_THRESHOLD = 65.0
XAI_CONFIDENCE_CRITICAL_THRESHOLD = 25.0
XAI_NOVELTY_REDUCED_THRESHOLD = 25.0
XAI_NOVELTY_CRITICAL_THRESHOLD = 65.0
XAI_TTA_REDUCED_THRESHOLD = 65.0
XAI_TTA_CRITICAL_THRESHOLD = 25.0
XAI_THROTTLE_MIN_SCALE = 0.4
XAI_THROTTLE_STOP_DURATION = 1.0   # see the reaction-time note in §1.5
```

</details>

<details>
<summary>Offline analysis / calibration extras</summary>

```python
XAI_IG_STEPS = 32                        # Integrated Gradients Riemann steps
XAI_CALIBRATE_WITH_AUGMENTATIONS = True  # see §2.8
XAI_CALIBRATE_AUG_PASSES = 2
XAI_CALIBRATE_AUG_MAX_SAMPLES = 1500
```

</details>

### 1.9 Things to watch out for

- **MC-Dropout needs the Keras `.h5` model, not a `.tflite` export** — TFLite conversion bakes dropout out, so there's nothing left to disagree.
- **`linear` model type only** — this is enforced, not just advised. Confidence and TTA read the model's output tensors as plain steering/throttle numbers, which is only true of the `linear` architecture; on a `categorical`, `behavior`, `imu` or `inferred` pilot (or with `TRAIN_LOCALIZER = True`) those outputs are bin vectors or a differently-shaped list. If either signal is switched on for such a model the vehicle logs a warning and runs without them, rather than feeding the car a meaningless average of a softmax. Novelty is unaffected and still works on any model type — it never touches your pilot, only its own encoder.
- **A calibrated confidence % is not a probability.** It's a percentile rank relative to your own training data's variance distribution — see [§2.3](#23-calibration-mechanics) before treating it as "the model is X% likely to be right."
- **Novelty saturates at the extremes.** Wildly out-of-distribution input (camera covered, solid color, pointed at a wall) reads as ~98%, same as any other very-unfamiliar scene — it tells you *that* something is unfamiliar, not *how* unfamiliar in fine detail.
- Recalibration triggers are listed in §1.3 — it's easy to forget after retraining or changing augmentations, and the dashboard's "uncalibrated" banner is there specifically to catch that. The banner checks each signal's *data*, not just that a calibration file exists, so a calibration written by an older version will still correctly report which signal is missing.
- **`RECORD_DURING_AI`** (§1.2) is stock behaviour, unchanged by this toolkit: autopilot frames land in the *same* tub as manual ones, so the usual "don't train on this" caveat still applies. Such a tub is a mix of scored (autopilot) and unscored (manual) frames; §1.6 covers how the offline tool treats the unscored ones.
- **A mismatched `TRANSFORMATIONS`/`POST_TRANSFORMATIONS` config now stops things, rather than silently misbehaving.** Training writes a `<model>.preprocessing.json` sidecar recording the exact pipeline it used; both live driving and offline analysis (§1.6/§1.7) read it back and refuse to proceed if the current config doesn't match. Two gaps worth knowing: the plain `mc_calibrate` CLI (§1.3) does *not* run this check itself — it's enforced at drive-time and analysis-time, not at calibration-time — so it's still on you to point `--tub`/`--config` at the right pair when calibrating by hand; and the sidecar carries no schema version, so a sidecar written by an older build is compared only on the fields both versions happen to share (you'll get a "predates tracking …" warning naming what couldn't be verified).

---

## 2. Technical deep dive

### 2.1 Why explainability and uncertainty matter here

A CNN driving policy is a black box mapping camera pixels to a steering angle; by default it gives you the same confident-looking single number whether the road ahead is a textbook straightaway or something the model has never seen. For a small robot that can hit a wall or a person, being able to ask *"how sure are you"* and *"why did you decide that"* is the difference between a system you can trust incrementally and one you can only evaluate by watching it crash. Everything in this toolkit is one of two things: a way of estimating **uncertainty** (confidence, novelty, TTA stability — "should we trust this frame's answer?"), or a way of producing **visual attribution** (Grad-CAM, Grad-CAM++, Integrated Gradients, saliency — "what part of the image caused this answer?").

### 2.2 Dropout and Monte Carlo Dropout (confidence)

**Dropout**, as used during normal training, randomly zeroes out a fraction of a layer's neurons on every training step (Donkeycar's default `linear` architecture has `Dropout(0.2)` after several convolutional and dense layers — see [`donkeycar/parts/keras.py`](../donkeycar/parts/keras.py)). This forces the network to not rely too heavily on any single neuron (since it might be zeroed out next step), which is a well-known technique for reducing overfitting. Normally, once training finishes, dropout is **switched off** for inference — every neuron participates, and you get one deterministic prediction.

**Monte Carlo Dropout** (Gal & Ghahramani, 2016) is the trick of *leaving dropout switched on at inference time* and running the same input through the network multiple times. Since a different random set of neurons is zeroed out on each pass, each pass is effectively asking a slightly different, randomly-thinned "sub-network" for its opinion. If the input is something the model is confident about, most sub-networks should agree on roughly the same steering angle regardless of which neurons got dropped — the underlying feature is redundantly represented. If the input is ambiguous or unfamiliar, different sub-networks latch onto different (possibly spurious) cues and disagree more. **Confidence in this toolkit is literally the inverse of that disagreement**: run N stochastic passes, measure the variance of the resulting steering angle across them, and treat high variance as low confidence.

Implementation detail worth knowing: running N passes *sequentially* is too slow for a 20 Hz drive loop (roughly 165 ms for 15 passes on a desktop in early testing). Instead, the same image is **replicated N times into one batch** and passed through the model in a single batched call — the network still applies an independent random dropout mask to each element of the batch, so this is mathematically the same N independent stochastic passes, just computed in parallel (roughly 29 ms for the same 15 passes). See [`donkeycar/parts/mc_dropout.py`](../donkeycar/parts/mc_dropout.py).

The raw variance is smoothed frame-to-frame with an exponential moving average (`XAI_CONFIDENCE_ALPHA`) so the displayed number doesn't flicker, then converted into the 0-100% shown on the dashboard via calibration (§2.3).

### 2.3 Calibration mechanics

A raw MC-Dropout variance number (or a raw Mahalanobis distance, for novelty) is meaningless on its own — its scale depends on this specific model's weights, this specific dataset, even the random dropout masks drawn. Calibration ([`mc_calibrate.py`](../donkeycar/parts/mc_calibrate.py)) solves this by replaying a known tub through the model once, collecting the raw variance for every frame, and computing percentiles (e.g. the 50th/80th/97th) of that distribution. A **monotonic piecewise-linear map** is then built from "raw variance value" to "0-100% score," anchored at those percentiles, and saved to `<model>.calib.json`. At drive time, a new raw variance is looked up against this same map to produce the displayed percentage.

The important consequence: **a confidence score is a statement about where this frame's variance falls relative to your own training data's variance distribution — not a calibrated probability of correctness.** This is also why the dashboard explicitly disclaims it as "relative to this model's own baseline." It also means the percentile anchors are inherently **relative**, not absolute: by construction, roughly 20% of any tub replayed against an 80th-percentile-derived threshold — even the original training data itself — will read above that threshold. A "low confidence" reading doesn't necessarily mean something is objectively rare; it means it's rarer than most of what this model saw during calibration.

Novelty and TTA stability are calibrated the same way, with their own percentile anchors, just walking in the opposite direction (ascending for novelty — higher raw distance is *worse* — vs. descending for confidence and TTA stability, where higher is *better*).

### 2.4 Feature-space novelty / out-of-distribution detection

The goal here is different from confidence: instead of "do sub-networks of *this* model agree," it's "does this frame look anything like what the model was trained on at all" — catching genuine out-of-distribution (OOD) input like the car leaving the track entirely.

The underlying statistic is **Mahalanobis distance**: instead of plain Euclidean distance from a "typical" feature vector, it's a distance that accounts for how much each dimension is *expected* to vary — a value 3 standard deviations away from the mean on a dimension that's normally almost constant is treated as far more surprising than the same absolute distance on a dimension that's normally noisy. Concretely: fit a Gaussian to a set of feature vectors extracted from calibration frames (mean + per-dimension variance — a **diagonal covariance** approximation, i.e. we don't model correlations between dimensions, which is far cheaper to compute and invert than a full covariance matrix), then for a new frame's feature vector, compute how many (variance-normalized) standard deviations away it falls.

**The interesting part of this feature is *which* features that distance is measured in — and getting it wrong the first time was a genuine, real finding.** The first implementation measured distance in the driving model's own penultimate layer (`dense_2`, 50-dimensional). This didn't work: a model trained *only* to predict steering angle has every incentive to discard anything not needed for that task — texture, color, semantic content — so grass, carpet and open track all collapse to nearly the same `dense_2` vector, because they all mean "drive straight." Measuring against real training data, grass scored as *more familiar* than a legitimate on-track frame in some cases (a "grass is 90%+ confident" result that was genuinely reproduced, not a hypothetical). The fix: extract features from a **generic, frozen ImageNet-pretrained encoder** (MobileNetV2 by default, `XAI_NOVELTY_ENCODER`) instead of the task-specific steering model. A network trained on ImageNet's thousand object categories has to keep general visual information (texture, color, shape) around, so grass and track genuinely land in different regions of *that* feature space — the same math, applied to a feature space that hasn't collapsed away the information needed to tell them apart, correctly separated grass/carpet (scoring as clearly unfamiliar) from track frames.

The live detector ([`donkeycar/parts/novelty.py`](../donkeycar/parts/novelty.py)) runs one extra deterministic forward pass through this encoder per update, computes the Mahalanobis distance against the calibrated Gaussian, smooths it with an EMA, and maps it to 0-100% the same way as confidence (just ascending instead of descending). The offline viewer's per-location novelty overlay uses the very same encoder weights, just without the final averaging step, so the heat map and the percentage beside it live in the same feature space and answer the same question — a large improvement on the earlier version, where the map came from the steering model's `conv2d_5` and the percentage from the encoder, i.e. two unrelated spaces.

They are not, however, the *same measurement*, and it's worth being precise about that: the live pooled encoder squashes the frame to a 128×128 square (fine, since every location is averaged together anyway), while the offline map runs at a larger aspect-preserving input (`XAI_NOVELTY_SPATIAL_INPUT`, default 224 → roughly a 7×12 grid on a 16:9 frame) so the heat map isn't stretched when drawn back over the frame. Different input geometry means different feature vectors, which is why calibration fits and stores them as two separate blocks (`novelty_ood` and `novelty_ood_spatial`) with their own Gaussians and anchors. Expect the map and the percentage to agree in character — the same regions look unfamiliar — not to agree numerically.

### 2.5 Test-Time Augmentation (TTA) stability

A third, independent question: *if the same real-world scene were lit very slightly differently, would the model give a different answer?* TTA stability answers this directly rather than by proxy: it takes the current frame, generates `XAI_TTA_SAMPLES` copies with small random **photometric-only** jitter (brightness/contrast/gamma/noise — deliberately *not* geometric changes like crop or rotation, since those would actually change what the correct steering angle is), batches them through the model in one deterministic forward pass (dropout off, unlike MC-Dropout), and measures the variance of the resulting steering angle across that batch. High variance means the model's answer is fragile to lighting noise that shouldn't matter; low variance means it's robust to it.

This is a genuinely different signal from MC-Dropout confidence, not a duplicate of it — MC-Dropout asks "do many random internal sub-networks of this one exact image agree," while TTA asks "does the same sub-network agree with itself across slightly different lightings of the same scene." Measuring both against the same real footage showed a correlation of only about 0.19 between their raw variances — confirming they pick up on different kinds of trouble.

### 2.6 Confidence-aware throttle scaling

[`ThrottleScaler`](../donkeycar/parts/mc_dropout.py) takes whichever of the three 0-100% signals are enabled and, for each one independently, computes a *scale factor* between the configured min-scale and `1.0`: full throttle above the signal's "reduced" threshold, linearly interpolated down to `XAI_THROTTLE_MIN_SCALE` between "reduced" and "critical," and held at the minimum below "critical." Confidence and TTA stability are *descending* (high value = good, so the scale shrinks as the value drops); novelty is *ascending* (high value = bad, so the scale shrinks as the value rises) — both use the same underlying interpolation, just mirrored.

The **final throttle scale is the minimum across every enabled signal's scale** — i.e. whichever signal currently looks worst wins, a direct implementation of "slow down if *any* signal indicates trouble," rather than averaging signals together (which could let one bad signal be diluted by two fine ones). If any signal has been continuously in its critical range for `XAI_THROTTLE_STOP_DURATION` seconds, throttle is forced to exactly zero; the timer is shared across signals, so a car that goes from "novelty-critical" straight into "confidence-critical" without recovering in between still counts as one continuous critical episode, not two resets. Steering is never touched by this part.

### 2.7 Visual attribution: four ways to ask "why"

The offline viewer computes four different attribution maps per analysed frame, because they answer subtly different questions and none of them is uniquely "correct":

**Grad-CAM** — computes the gradient of the (summed) steering output with respect to the activations of a late convolutional layer (`conv2d_5`), uses those gradients to weight each channel of that layer's feature map, sums the weighted channels, and applies a ReLU (keeping only the parts that positively influenced the output). Because it operates on a late-stage conv layer, the result is naturally coarse — a small grid (e.g. 8×13) upsampled back to image size — showing *roughly where* in the image mattered, not exact pixels. In this toolkit, Grad-CAM is combined with MC-Dropout: it's computed once per dropout sub-network in the same batch, and the *mean* map across sub-networks becomes the "attention" overlay while the *pixel-wise variance* across those same maps becomes the "uncertainty" overlay — literally, "where did the model look" and "where did different sub-networks disagree about where to look."

**Grad-CAM++** — a refinement of Grad-CAM's channel weighting that accounts for a feature appearing in multiple locations at once (plain Grad-CAM's simple gradient-averaging weight can under-represent that case). The textbook derivation assumes a softmax classification output; since this is a regression output (a single steering value), this toolkit uses a practical approximation of the pixel-wise weighting derived from first- and second-order gradient terms (`alpha = g² / (2g² + (ΣA)g³)`) rather than the classification-specific formula. In practice it tends to produce sharper, more spatially precise blobs than plain Grad-CAM.

**Integrated Gradients (IG)** — instead of looking at gradients at the actual input alone (which can saturate — a very confidently-classified pixel can have a near-zero local gradient even though it clearly mattered), IG integrates the gradient along a straight-line path from a neutral **baseline** (a black image) to the real input, in `XAI_IG_STEPS` discrete steps (a Riemann-sum approximation of the integral), and multiplies the averaged path gradient by `(input - baseline)`. This satisfies a *completeness* property that plain gradients don't: the attributions sum up to exactly the difference between the model's output on the real image and on the baseline. Because it operates directly on input pixels rather than a coarse conv layer, its maps are full resolution.

**Vanilla gradient saliency** — the simplest and cheapest: one backward pass, the gradient of the output directly with respect to every input pixel. (One implementation wrinkle: a saturating output activation would clip gradients right where they matter most, so the output layers are linearized first. For the `linear` architecture they already are, so this is detected and skipped entirely; where it *is* needed — a `categorical` model's softmax, via `donkey makemovie --salient` — it's applied to a reloaded copy, leaving the pilot you're still driving with untouched.) Like IG, it's full-resolution, but with no baseline/integration step, so it's noisier and more speckled.

**Why look at all four:** the two conv-layer-based methods (Grad-CAM, Grad-CAM++) give smooth, coarse, easy-to-read localization; the two pixel-gradient methods (saliency, IG) give precise-but-noisier, exact per-pixel attribution. On a real test frame containing a pedestrian, Grad-CAM/++ showed two smooth blobs on the ground near the pedestrian, while saliency showed many small, scattered points across the pedestrian, nearby pillars, *and* background architecture — a genuinely different, complementary answer, not a redundant one. Relying on only one technique risks mistaking "coarse but clean" for "the whole picture," or "precise but noisy" for "definitely irrelevant."

### 2.8 How augmentations feed into calibration

Calibration's job is to define "what does normal training data look like" — which becomes the novelty detector's baseline. If a model is trained with, say, `AUGMENTATIONS = ['BRIGHTNESS', 'BLUR']` (so it has learned to drive correctly through varying exposure and softer focus), but calibration is only ever shown **clean, un-augmented** frames, the novelty baseline never learns that those conditions are "normal" — so the very conditions the model was made robust to would get flagged as unfamiliar and throttle down live, exactly backwards from the intent.

This was measured directly, not just reasoned about: fitting the novelty baseline on clean frames only, then scoring augmented-but-otherwise-normal frames against it, **79% crossed the "reduced" novelty threshold (vs. 38% for clean frames) and 50% crossed "critical" (vs. 10%)**. A model trained to handle varying lighting would have been throttled down by its own safety feature the moment it encountered it.

**The fix**, in [`mc_calibrate.py`](../donkeycar/parts/mc_calibrate.py): when `AUGMENTATIONS` is non-empty and `XAI_CALIBRATE_WITH_AUGMENTATIONS` is on (the default), calibration pushes a strided subset of frames (capped by `XAI_CALIBRATE_AUG_MAX_SAMPLES`) through the *same* `ImageAugmentation` pipeline used in training, `XAI_CALIBRATE_AUG_PASSES` times each (re-randomized every pass), and pools those augmented features into the novelty baseline alongside the clean ones. The resulting `calib.json` carries a small `"augmentation"` provenance block recording whether this happened and with what settings, so it's inspectable after the fact.

**This is scoped to novelty only** — not confidence or TTA. Both of those carry an exponential moving average over a *time-ordered* sequence of frames; splicing randomly-augmented frames into that sequence would corrupt the smoothing (a sudden synthetic brightness jump between two real consecutive frames isn't something either signal is designed to interpret). Novelty's calibration, by contrast, is a plain unordered percentile fit over a feature distribution, so mixing in augmented samples is safe and (per the measurement above) necessary.

### 2.9 How transformations affect the signals

`TRANSFORMATIONS` (crop, trapezoidal mask, colour-space conversion, high-pass filters) are different from augmentations in one way that matters enormously here: they apply at **both training and inference**. The model is only ever shown transformed pixels, so anything measuring the model's behaviour must be measured on transformed pixels too, or it's describing a situation that never actually occurs while driving.

That creates a split, and the toolkit handles the two halves differently:

- **Confidence, TTA stability, Grad-CAM, Grad-CAM++, saliency and Integrated Gradients** all get the **transformed** frame. Every one of them is a question about *your model* — how much its sub-networks disagree, how stable it is, which pixels drove its output — so they have to see the model's real input. Calibration replays tub frames through the same `TRANSFORMATIONS` pipeline training uses, in the same order (transform → augment → post-transform).
- **Novelty gets the raw frame.** It's the odd one out because it doesn't use your steering model at all — it measures scene familiarity in a frozen ImageNet encoder (§2.4). A crop or a high-pass filter strips exactly the colour and texture content that encoder relies on, so transforming the input degrades the very thing that makes OOD detection work. "Is this scene familiar?" is a question about the world, not about the model.

The magnitude here is not subtle. Measured on real frames with a modest crop (30 of 108 rows), feeding novelty the transformed frame instead of the raw one moved its score from **4.9% to 97.8%** — normal driving reading as maximally unfamiliar. Whichever input you choose, calibration and live driving must use the *same* one; the toolkit keeps them in step.

**Both `CROP` and `TRAPEZE` are masking transforms:** they blank out pixels outside the region of interest but leave the image at its original dimensions. That makes a mismatch the dangerous case — same dimensions, no shape error, just silently wrong thresholds — so it is caught directly instead: training saves a `<model>.preprocessing.json` sidecar recording the exact `TRANSFORMATIONS`/`POST_TRANSFORMATIONS`/`ROI_CROP_*` pipeline it was trained with, and both live driving and offline analysis refuse to run if the current config doesn't match it (§1.9). A calibration also records which transformations built it and the dashboard raises a "Calibration stale" warning if that's drifted, independent of this check.

In the offline viewer, what you *see* by default is the raw camera frame with heat maps drawn on it — since every available transform preserves the frame's geometry, that mapping is direct. You can also switch to the *"What the model actually sees (transformed)"* layer to see the transformed frame directly, and tick **"draw on model input"** to see the heat maps drawn on it instead (§1.6).


### 2.10 Known limitations

- **MC-Dropout's calibration percentiles are unseeded.** Calibrating the same model against the same tub twice will produce slightly different p50/p80/p97 anchors each time (a real, measured difference, not a bug) — this is expected statistical noise from the random dropout masks, so don't expect bit-identical thresholds across reruns.
- **(Fixed) Novelty's anchors used to be fitted on un-smoothed distances but scored on smoothed ones.** `_build_novelty_block` took its p50/p80/p97 from the raw per-frame Mahalanobis distances of the calibration frames, while every consumer — the live detector and the offline timeline alike — feeds the EMA-**smoothed** distance through those anchors. Smoothing shrinks the spread (measured on a real logged drive: raw σ≈987 vs smoothed σ≈452, raw p97≈5239 vs smoothed p97≈2919), so the top of the scale was much harder to reach than the percentile design implied — replaying a drive through anchors fitted the old way, 4% of frames crossed the 65% "critical" mark scored against raw distances, 0% did scored the way the code actually scores them. `calibrate_from_tub` now folds the calibration replay's own clean, time-ordered distances through the same EMA the live detector uses (`_replay_ema`, matching `FeatureNoveltyDetector.run()`'s formula exactly) and fits `novelty_ood`'s anchors on *that* sequence instead, via a new `ood_anchor_distances` parameter (`_build_novelty_block`, `mc_calibrate.py`). `novelty_ood_spatial` (the offline heat map) is untouched — it has no smoothing or interval concept, so raw per-location distances were already the right thing to fit on.
- **(Fixed) Calibration used to always replay at `interval = 0`, while driving defaults to `0.3`/`0.5`.** The EMA constant is per *update*, not per second, so a rate-limited live signal used to be smoothed over a ~6× longer real-time window than the calibration that defined its thresholds (median frame spacing ≈0.05s at 20 Hz vs an effective ≈0.3-0.5s live update spacing — confirmed on a real drive: only 15% of frames actually trigger a fresh EMA fold at the default `XAI_CONFIDENCE_INTERVAL=0.3`). `MCDropoutConfidence`/`FeatureNoveltyDetector`/`TTAStabilityDetector.run()` all now accept an optional `now=` override; `calibrate_from_tub` reads each frame's own recorded `_timestamp_ms` and passes it through, so confidence and TTA replay through their live Part objects at the tub's *actual* recorded pace rather than however fast the replay loop happens to run, and novelty's distance sequence is folded through the tub's own timestamps via `_replay_ema` the same way. Every other caller — the live drive loop, `gradcam_uncertainty.py`'s replay — doesn't pass `now=` and is unaffected. Tubs recorded before timestamp logging existed fall back to the old behaviour (measure every frame) with a warning, since replaying at the process's own speed has no relationship to how fast the frames were actually driven.
- **A generic ImageNet encoder for novelty runs on CPU today.** A Hailo-NPU-accelerated backend is a planned follow-up (to match the rest of the pipeline running on-device on hardware that has one), but isn't implemented in this toolkit yet — `CPUEncoderExtractor` ([`donkeycar/parts/ood.py`](../donkeycar/parts/ood.py)) is currently the only backend.
- **Novelty scores saturate rather than scale gracefully at the extreme end** (§1.9) — useful for a binary "is this track or not" read, less useful for graded ranking between different kinds of out-of-distribution input.